### PR TITLE
fix(ci): fix Renovate workflow and enable branch auto-cleanup

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: renovatebot/github-action@v41
+      - uses: renovatebot/github-action@v46.1.4
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix Renovate GitHub Actions workflow: `renovatebot/github-action@v41` does not exist, update to `@v46.1.4`
- Enable "delete branch on merge" in repository settings
- Clean up stale merged remote branches

## Related issue

Closes #18

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] TypeScript type-check passes (`pnpm run typecheck`)
- [x] JS tests pass (`pnpm test`)
- [x] Rust tests pass (`cargo test`)
- [x] Clippy passes (`cargo clippy`)
- [x] Build succeeds (`pnpm run build`)
- [ ] Changeset included (if `src/` or `crates/` changed) — N/A
- [ ] Benchmarks run for performance-sensitive changes — N/A