### PR TITLE
ci: disable automatic release trigger until publish is ready

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches: [develop]
+  workflow_dispatch: # Manual trigger only — see #48 for full release CI setup
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Change `release.yml` trigger from `push: branches: [develop]` to `workflow_dispatch` (manual only)
- Adds a comment referencing #48 for future full release CI setup

## Background

The release CI fails on every push to `develop` because:
1. `NPM_TOKEN` secret is not configured
2. Native binary build steps are missing (required by napi-rs)
3. The project is not yet ready for npm publish

The project is currently in Phase 1 with pending tasks: ESM support (#33), batch API (#31), npm package structure (#36). The proper release CI redesign is tracked in #48.

## Checklist

- [x] `release.yml` trigger changed to `workflow_dispatch`
- [x] Comment links to #48 for future reference

## Related Issues

Closes #47
See #48 for full release CI setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースワークフローのトリガー方式を手動実行に変更しました。これにより、リリースのタイミングをより柔軟に管理できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->