### PR TITLE
chore: update biome.json schema URL to v2.4.7

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary

Update `biome.json` `$schema` URL from `2.4.6` to `2.4.7` to match the installed biome version after PR #24 merged the 2.4.7 update.

This removes the `info` diagnostic shown on every `biome ci` run:
```
ℹ The configuration schema version does not match the CLI version 2.4.7
```

Closes #52