### PR TITLE
docs: enhance README with badges and benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # rapid-fuzzy
 
+[![CI](https://github.com/derodero24/rapid-fuzzy/actions/workflows/ci.yml/badge.svg)](https://github.com/derodero24/rapid-fuzzy/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/rapid-fuzzy)](https://www.npmjs.com/package/rapid-fuzzy)
+[![npm downloads](https://img.shields.io/npm/dm/rapid-fuzzy)](https://www.npmjs.com/package/rapid-fuzzy)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](https://nodejs.org/)
+
 Rust-powered fuzzy search and string distance for JavaScript/TypeScript.
 
 > **Status**: Work in progress. Not yet published to npm.
 
 ## Features
 
-- **Fast**: 10-50x faster than fuse.js/leven for large datasets (Rust + SIMD)
+- **Fast**: Up to 40x faster than fuse.js for large datasets (Rust + napi-rs)
 - **Universal**: Works in Node.js (native), browsers (WASM), Deno, and Bun
 - **Zero JS dependencies**: Pure Rust core with napi-rs bindings
 - **Type-safe**: Full TypeScript support with auto-generated type definitions
@@ -19,6 +25,11 @@ npm install rapid-fuzzy
 # or
 pnpm add rapid-fuzzy
 ```
+
+### Runtime-specific notes
+
+- **Node.js** (>=20): Uses native bindings via napi-rs for best performance.
+- **Browser / Deno / Bun**: Falls back to a WASM build automatically.
 
 ## Usage
 
@@ -53,7 +64,60 @@ closest('tsc', ['TypeScript', 'JavaScript', 'Python']);
 
 ## Benchmarks
 
-Coming soon.
+Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.dev/guide/features.html#benchmarking). Each benchmark processes 6 realistic string pairs of varying length and similarity.
+
+### Distance Functions
+
+| Function | rapid-fuzzy | fastest-levenshtein | leven | string-similarity |
+|---|---:|---:|---:|---:|
+| Levenshtein | 67,346 ops/s | **243,026 ops/s** | 51,789 ops/s | — |
+| Normalized Levenshtein | **64,592 ops/s** | — | — | — |
+| Sorensen-Dice | **61,050 ops/s** | — | — | 40,241 ops/s |
+| Jaro-Winkler | **198,140 ops/s** | — | — | — |
+| Damerau-Levenshtein | **58,888 ops/s** | — | — | — |
+
+> **Note**: For single-pair Levenshtein distance, fastest-levenshtein is faster due to its highly optimized pure-JS implementation that avoids FFI overhead. rapid-fuzzy provides broader algorithm coverage and excels in batch / search scenarios.
+
+### Search Performance
+
+| Dataset size | rapid-fuzzy | fuse.js | fuzzysort |
+|---|---:|---:|---:|
+| 20 items | 171,967 ops/s | 121,978 ops/s | **2,537,323 ops/s** |
+| 1,000 items | 4,941 ops/s | 376 ops/s | **55,388 ops/s** |
+| 10,000 items | 588 ops/s | 14 ops/s | **15,005 ops/s** |
+
+### Closest Match (Levenshtein-based)
+
+| Dataset size | rapid-fuzzy | fastest-levenshtein |
+|---|---:|---:|
+| 1,000 items | **5,912 ops/s** | 3,974 ops/s |
+| 10,000 items | **387 ops/s** | 126 ops/s |
+
+> rapid-fuzzy is up to **3x faster** than fastest-levenshtein for closest-match lookups on large datasets.
+
+### Why these numbers matter
+
+- **vs fuse.js**: rapid-fuzzy is **13x faster** on medium datasets and **41x faster** on large datasets for fuzzy search.
+- **vs fastest-levenshtein**: rapid-fuzzy wins on closest-match (1.5–3x faster) where batch FFI overhead is amortized.
+- **fuzzysort** uses a different (substring-based) matching algorithm that is extremely fast but produces different ranking results. Choose based on your matching needs.
+
+Run benchmarks yourself:
+
+```bash
+pnpm run bench        # JavaScript benchmarks
+cargo bench           # Rust internal benchmarks
+```
+
+## Why rapid-fuzzy?
+
+| | rapid-fuzzy | fuse.js | fastest-levenshtein | fuzzysort |
+|---|---|---|---|---|
+| **Algorithms** | Levenshtein, Jaro-Winkler, Sorensen-Dice, Damerau-Levenshtein, fuzzy search | Bitap-based fuzzy | Levenshtein only | Substring fuzzy |
+| **Runtime** | Rust (native + WASM) | Pure JS | Pure JS | Pure JS |
+| **Batch API** | Yes | No | No | No |
+| **Node.js native** | Yes (napi-rs) | No | No | No |
+| **Browser support** | Yes (WASM) | Yes | Yes | Yes |
+| **TypeScript** | Full (auto-generated) | Full | Yes | Yes |
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add shields.io badges: CI status, npm version, npm downloads, license, Node.js version
- Replace "Coming soon" benchmarks placeholder with actual benchmark results tables (distance functions, fuzzy search, closest match)
- Add "Why rapid-fuzzy?" feature comparison table
- Add runtime-specific installation notes (Node.js, browser, Deno, Bun)
- Update speed claim from "10-50x" to "up to 40x" based on measured results

Closes #35