### PR TITLE
chore(config): modernize tsconfig with stricter type checking

### DIFF
--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -247,7 +247,11 @@ describe('search', () => {
   it('should return results sorted by score (best first)', () => {
     const results = search('an', items);
     for (let i = 1; i < results.length; i++) {
-      expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+      const prev = results[i - 1];
+      const curr = results[i];
+      if (prev && curr) {
+        expect(prev.score).toBeGreaterThanOrEqual(curr.score);
+      }
     }
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,25 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "Node10",
+    "lib": ["ES2023"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "strict": true,
-    "esModuleInterop": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "types": ["node"]
   },
   "include": ["__test__/**/*.ts", "*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "__test__/**/*.bench.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Summary

- Upgrade `module`/`moduleResolution` from `CommonJS`/`Node10` to `Node16` for modern Node.js resolution
- Add `lib: ["ES2023"]` for modern API type definitions
- Enable stricter compiler options: `noUncheckedIndexedAccess`, `noFallthroughCasesInSwitch`, `noImplicitReturns`, `noImplicitOverride`, `forceConsistentCasingInFileNames`, `isolatedModules`, `exactOptionalPropertyTypes`, `allowUnreachableCode: false`, `allowUnusedLabels: false`
- Exclude bench files and `vitest.config.ts` from type checking (they import ESM-only packages incompatible with Node16 CJS resolution; Vitest handles them independently)
- Fix array index access in test file to satisfy `noUncheckedIndexedAccess`

Closes #64

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (39/39)
- [x] `cargo test` passes (33/33)
- [x] `cargo clippy` passes
- [x] All lefthook hooks pass (pre-commit, commit-msg, pre-push)