### PR TITLE
chore(config): add strict Biome linter rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,16 +25,33 @@
       "recommended": true,
       "correctness": {
         "noUnusedImports": "error",
-        "noUnusedVariables": "error"
+        "noUnusedVariables": "error",
+        "noUndeclaredDependencies": "error"
+      },
+      "suspicious": {
+        "noConsole": "error",
+        "useAwait": "error"
+      },
+      "complexity": {
+        "noForEach": "error",
+        "noExcessiveCognitiveComplexity": {
+          "level": "warn",
+          "options": { "maxAllowedComplexity": 15 }
+        }
       },
       "performance": {
-        "noAccumulatingSpread": "error"
+        "noAccumulatingSpread": "error",
+        "noBarrelFile": "error",
+        "noReExportAll": "error",
+        "noDelete": "warn"
       },
       "style": {
         "noDefaultExport": "error",
         "useConst": "error",
         "useExportType": "error",
-        "useImportType": "error"
+        "useImportType": "error",
+        "useForOf": "error",
+        "noNamespace": "error"
       }
     }
   },
@@ -45,6 +62,26 @@
         "rules": {
           "style": {
             "noDefaultExport": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["__test__/**/*.bench.ts", "__test__/esm-import.mjs"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["index.d.mts"],
+      "linter": {
+        "rules": {
+          "performance": {
+            "noReExportAll": "off"
           }
         }
       }


### PR DESCRIPTION
## Summary

- Add strict Biome linter rules for library safety: `noUndeclaredDependencies`, `noConsole`, `useAwait`, `noForEach`, `noExcessiveCognitiveComplexity`, `noBarrelFile`, `noReExportAll`, `noDelete`, `useForOf`, `noNamespace`
- Add overrides for benchmark files and ESM smoke test to allow `console` usage
- Add override for napi-rs generated `index.d.mts` to allow `export *` re-export

Closes #65

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (39 tests)
- [x] `cargo test` passes (33 tests)
- [x] `cargo clippy` passes
- [x] `pnpm run build` passes
- [x] All pre-push hooks pass (clippy, lint, cargo-test, cargo-deny, test, typecheck)