### PR TITLE
ci(bench): add continuous benchmarking with regression detection

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -168,6 +168,18 @@ jobs:
           console.log('Total benchmarks: ' + merged.length);
           "
 
+      - name: Ensure gh-pages branch exists
+        run: |
+          if ! git ls-remote --heads origin gh-pages | grep -q gh-pages; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git checkout --orphan gh-pages
+            git reset --hard
+            git commit --allow-empty -m "Initial benchmark data branch"
+            git push origin gh-pages
+            git checkout "$GITHUB_SHA"
+          fi
+
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:


### PR DESCRIPTION
## Summary

- Add `.github/workflows/benchmark.yml` workflow using [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark)
- Run Rust (Criterion) and JS (Vitest bench) benchmarks on PRs and pushes to `develop`
- Parse results into unified `customBiggerIsBetter` format (ops/s) for both Rust and JS benchmarks
- Store historical results in `gh-pages` branch for trend analysis
- Comment benchmark comparison on PRs, alert on >10% regression
- Only track rapid-fuzzy's own benchmarks (not competitor baselines) for regression detection

## How it works

1. **Rust Benchmark** job runs `cargo bench` with Criterion, parses timing output to ops/s
2. **JS Benchmark** job builds native module, runs `pnpm run bench`, parses Vitest console output
3. **Report** job merges results and feeds to `github-action-benchmark` which:
   - On `develop` push: updates baseline in `gh-pages`
   - On PRs: compares against baseline and posts a comment

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストには、エンドユーザーに対する可視的な変更はありません。

* **Chores**
  * 開発ブランチでのベンチマーク測定を自動化するための内部インフラストラクチャを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->