### PR TITLE
docs: add SECURITY.md with vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.x     | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+**Please do not create public issues for security vulnerabilities.**
+
+To report a vulnerability, use [GitHub Security Advisories](https://github.com/derodero24/rapid-fuzzy/security/advisories/new). This allows us to discuss and resolve the issue privately before any public disclosure.
+
+When reporting, please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact
+- Suggested fix (if any)
+
+## Response Timeline
+
+- **Acknowledgment**: Within 48 hours of the report
+- **Initial assessment**: Within 5 business days
+- **Fix for critical vulnerabilities**: Within 7 days of confirmation
+- **Fix for non-critical vulnerabilities**: Included in the next scheduled release
+
+## Disclosure Policy
+
+We follow a coordinated disclosure process:
+
+1. The vulnerability is reported privately via GitHub Security Advisories.
+2. We confirm the issue and work on a fix.
+3. A patched version is released.
+4. The vulnerability is publicly disclosed after the fix is available.
+
+We kindly ask reporters to allow us reasonable time to address the issue before any public disclosure.


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with supported versions, vulnerability reporting instructions, response timeline, and coordinated disclosure policy
- Direct vulnerability reports to GitHub Security Advisories to avoid public exposure

Closes #69

## Test plan

- [ ] Verify `SECURITY.md` renders correctly on GitHub
- [ ] Confirm the Security Advisories link points to the correct URL