### PR TITLE
ci(release): add multi-platform build matrix and npm publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,141 @@
 name: Release
 
 on:
-  workflow_dispatch: # Manual trigger only — see #48 for full release CI setup
+  push:
+    branches: [develop]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
-  release:
-    name: Release
+  # On push to develop: create or update Version Packages PR via changesets
+  version:
+    name: Version
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Create Release Pull Request
+        uses: changesets/action@v1
+        with:
+          version: pnpm changeset version
+          commit: 'chore(release): version packages'
+          title: 'chore(release): version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # On workflow_dispatch: build native binaries for all platforms
+  build:
+    name: Build - ${{ matrix.settings.target }}
+    if: github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: macos-13
+            target: x86_64-apple-darwin
+          - host: macos-latest
+            target: aarch64-apple-darwin
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            use-cross: true
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use-cross: true
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+          - host: windows-latest
+            target: aarch64-pc-windows-msvc
+          - host: ubuntu-latest
+            target: wasm32-wasip1-threads
+    runs-on: ${{ matrix.settings.host }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+        if: ${{ !matrix.settings.docker }}
+      - uses: actions/setup-node@v6
+        if: ${{ !matrix.settings.docker }}
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - uses: dtolnay/rust-toolchain@stable
+        if: ${{ !matrix.settings.docker }}
+        with:
+          targets: ${{ matrix.settings.target }}
+      - uses: Swatinem/rust-cache@v2
+        if: ${{ !matrix.settings.docker }}
+        with:
+          shared-key: release-${{ matrix.settings.target }}
+
+      - run: pnpm install --frozen-lockfile
+        if: ${{ !matrix.settings.docker }}
+
+      - name: Build
+        if: ${{ !matrix.settings.docker }}
+        run: >-
+          pnpm build
+          --target ${{ matrix.settings.target }}
+          ${{ matrix.settings.use-cross && '--use-napi-cross' || '' }}
+
+      - name: Build in Docker
+        if: ${{ matrix.settings.docker }}
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ matrix.settings.docker }}
+          options: >-
+            --user 0:0
+            -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db
+            -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache
+            -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index
+            -v ${{ github.workspace }}:/build
+            -w /build
+          run: |
+            set -e
+            corepack enable
+            corepack install
+            rustup target add ${{ matrix.settings.target }}
+            pnpm install --frozen-lockfile
+            pnpm build --target ${{ matrix.settings.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: bindings-${{ matrix.settings.target }}
+          path: |
+            rapid-fuzzy.*.node
+            rapid-fuzzy.*.wasm
+            rapid-fuzzy.wasi*.cjs
+            rapid-fuzzy.wasi*.js
+            wasi-worker*.mjs
+          if-no-files-found: error
+
+  # Publish to npm after all builds succeed
+  publish:
+    name: Publish
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
@@ -25,19 +146,33 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: pnpm install --frozen-lockfile
 
-      - name: Create Release Pull Request or Publish
-        id: changesets
-        uses: changesets/action@v1
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
         with:
-          version: pnpm changeset version
-          publish: pnpm changeset publish
+          path: artifacts
+
+      - name: Move artifacts to platform packages
+        run: pnpm napi artifacts --dir artifacts
+
+      - name: List packages
+        run: |
+          echo "=== Platform packages ==="
+          for dir in npm/*/; do
+            echo "$dir"
+            ls -la "$dir" 2>/dev/null
+            echo ""
+          done
+
+      - name: Publish to npm
+        run: |
+          npm config set provenance true
+          npm publish --access public --provenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Fast-forward main
-        if: steps.changesets.outputs.published == 'true'
         run: |
           git fetch origin main
           git push origin develop:main

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@ browser.js
 wasi-worker.mjs
 wasi-worker-browser.mjs
 
-# napi-rs generated platform packages
-npm/
+# napi-rs platform package binaries are ignored by *.node / *.wasm patterns above
+# Only npm/*/package.json files are tracked
 
 # Logs
 *.log

--- a/npm/darwin-arm64/README.md
+++ b/npm/darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# `rapid-fuzzy-darwin-arm64`
+
+This is the **aarch64-apple-darwin** binary for `rapid-fuzzy`

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "rapid-fuzzy-darwin-arm64",
+  "version": "0.0.0",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "rapid-fuzzy.darwin-arm64.node",
+  "files": [
+    "rapid-fuzzy.darwin-arm64.node"
+  ],
+  "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
+  "keywords": [
+    "fuzzy",
+    "fuzzy-search",
+    "string-distance",
+    "levenshtein",
+    "jaro-winkler",
+    "rust",
+    "napi",
+    "wasm",
+    "typescript",
+    "search",
+    "fuse"
+  ],
+  "author": "derodero24",
+  "homepage": "https://github.com/derodero24/rapid-fuzzy",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/derodero24/rapid-fuzzy.git"
+  },
+  "os": [
+    "darwin"
+  ]
+}

--- a/npm/darwin-x64/README.md
+++ b/npm/darwin-x64/README.md
@@ -1,0 +1,3 @@
+# `rapid-fuzzy-darwin-x64`
+
+This is the **x86_64-apple-darwin** binary for `rapid-fuzzy`

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "rapid-fuzzy-darwin-x64",
+  "version": "0.0.0",
+  "cpu": [
+    "x64"
+  ],
+  "main": "rapid-fuzzy.darwin-x64.node",
+  "files": [
+    "rapid-fuzzy.darwin-x64.node"
+  ],
+  "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
+  "keywords": [
+    "fuzzy",
+    "fuzzy-search",
+    "string-distance",
+    "levenshtein",
+    "jaro-winkler",
+    "rust",
+    "napi",
+    "wasm",
+    "typescript",
+    "search",
+    "fuse"
+  ],
+  "author": "derodero24",
+  "homepage": "https://github.com/derodero24/rapid-fuzzy",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/derodero24/rapid-fuzzy.git"
+  },
+  "os": [
+    "darwin"
+  ]
+}

--- a/npm/linux-arm64-gnu/README.md
+++ b/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `rapid-fuzzy-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** binary for `rapid-fuzzy`

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "rapid-fuzzy-linux-arm64-gnu",
+  "version": "0.0.0",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "rapid-fuzzy.linux-arm64-gnu.node",
+  "files": [
+    "rapid-fuzzy.linux-arm64-gnu.node"
+  ],
+  "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
+  "keywords": [
+    "fuzzy",
+    "fuzzy-search",
+    "string-distance",
+    "levenshtein",
+    "jaro-winkler",
+    "rust",
+    "napi",
+    "wasm",
+    "typescript",
+    "search",
+    "fuse"
+  ],
+  "author": "derodero24",
+  "homepage": "https://github.com/derodero24/rapid-fuzzy",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/derodero24/rapid-fuzzy.git"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/npm/linux-arm64-musl/README.md
+++ b/npm/linux-arm64-musl/README.md
@@ -1,0 +1,3 @@
+# `rapid-fuzzy-linux-arm64-musl`
+
+This is the **aarch64-unknown-linux-musl** binary for `rapid-fuzzy`

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "rapid-fuzzy-linux-arm64-musl",
+  "version": "0.0.0",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "rapid-fuzzy.linux-arm64-musl.node",
+  "files": [
+    "rapid-fuzzy.linux-arm64-musl.node"
+  ],
+  "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
+  "keywords": [
+    "fuzzy",
+    "fuzzy-search",
+    "string-distance",
+    "levenshtein",
+    "jaro-winkler",
+    "rust",
+    "napi",
+    "wasm",
+    "typescript",
+    "search",
+    "fuse"
+  ],
+  "author": "derodero24",
+  "homepage": "https://github.com/derodero24/rapid-fuzzy",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/derodero24/rapid-fuzzy.git"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ]
+}

--- a/npm/linux-x64-gnu/README.md
+++ b/npm/linux-x64-gnu/README.md
@@ -1,0 +1,3 @@
+# `rapid-fuzzy-linux-x64-gnu`
+
+This is the **x86_64-unknown-linux-gnu** binary for `rapid-fuzzy`

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "rapid-fuzzy-linux-x64-gnu",
+  "version": "0.0.0",
+  "cpu": [
+    "x64"
+  ],
+  "main": "rapid-fuzzy.linux-x64-gnu.node",
+  "files": [
+    "rapid-fuzzy.linux-x64-gnu.node"
+  ],
+  "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
+  "keywords": [
+    "fuzzy",
+    "fuzzy-search",
+    "string-distance",
+    "levenshtein",
+    "jaro-winkler",
+    "rust",
+    "napi",
+    "wasm",
+    "typescript",
+    "search",
+    "fuse"
+  ],
+  "author": "derodero24",
+  "homepage": "https://github.com/derodero24/rapid-fuzzy",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/derodero24/rapid-fuzzy.git"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "glibc"
+  ]
+}

--- a/npm/linux-x64-musl/README.md
+++ b/npm/linux-x64-musl/README.md
@@ -1,0 +1,3 @@
+# `rapid-fuzzy-linux-x64-musl`
+
+This is the **x86_64-unknown-linux-musl** binary for `rapid-fuzzy`

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "rapid-fuzzy-linux-x64-musl",
+  "version": "0.0.0",
+  "cpu": [
+    "x64"
+  ],
+  "main": "rapid-fuzzy.linux-x64-musl.node",
+  "files": [
+    "rapid-fuzzy.linux-x64-musl.node"
+  ],
+  "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
+  "keywords": [
+    "fuzzy",
+    "fuzzy-search",
+    "string-distance",
+    "levenshtein",
+    "jaro-winkler",
+    "rust",
+    "napi",
+    "wasm",
+    "typescript",
+    "search",
+    "fuse"
+  ],
+  "author": "derodero24",
+  "homepage": "https://github.com/derodero24/rapid-fuzzy",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/derodero24/rapid-fuzzy.git"
+  },
+  "os": [
+    "linux"
+  ],
+  "libc": [
+    "musl"
+  ]
+}

--- a/npm/wasm32-wasi/README.md
+++ b/npm/wasm32-wasi/README.md
@@ -1,0 +1,3 @@
+# `rapid-fuzzy-wasm32-wasi`
+
+This is the **wasm32-wasip1-threads** binary for `rapid-fuzzy`

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "rapid-fuzzy-wasm32-wasi",
+  "version": "0.0.0",
+  "cpu": [
+    "wasm32"
+  ],
+  "main": "rapid-fuzzy.wasi.cjs",
+  "files": [
+    "rapid-fuzzy.wasm32-wasi.wasm",
+    "rapid-fuzzy.wasi.cjs",
+    "rapid-fuzzy.wasi-browser.js",
+    "wasi-worker.mjs",
+    "wasi-worker-browser.mjs"
+  ],
+  "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
+  "keywords": [
+    "fuzzy",
+    "fuzzy-search",
+    "string-distance",
+    "levenshtein",
+    "jaro-winkler",
+    "rust",
+    "napi",
+    "wasm",
+    "typescript",
+    "search",
+    "fuse"
+  ],
+  "author": "derodero24",
+  "homepage": "https://github.com/derodero24/rapid-fuzzy",
+  "license": "MIT",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/derodero24/rapid-fuzzy.git"
+  },
+  "browser": "rapid-fuzzy.wasi-browser.js",
+  "dependencies": {
+    "@napi-rs/wasm-runtime": "^1.1.1"
+  }
+}

--- a/npm/win32-arm64-msvc/README.md
+++ b/npm/win32-arm64-msvc/README.md
@@ -1,0 +1,3 @@
+# `rapid-fuzzy-win32-arm64-msvc`
+
+This is the **aarch64-pc-windows-msvc** binary for `rapid-fuzzy`

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "rapid-fuzzy-win32-arm64-msvc",
+  "version": "0.0.0",
+  "cpu": [
+    "arm64"
+  ],
+  "main": "rapid-fuzzy.win32-arm64-msvc.node",
+  "files": [
+    "rapid-fuzzy.win32-arm64-msvc.node"
+  ],
+  "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
+  "keywords": [
+    "fuzzy",
+    "fuzzy-search",
+    "string-distance",
+    "levenshtein",
+    "jaro-winkler",
+    "rust",
+    "napi",
+    "wasm",
+    "typescript",
+    "search",
+    "fuse"
+  ],
+  "author": "derodero24",
+  "homepage": "https://github.com/derodero24/rapid-fuzzy",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/derodero24/rapid-fuzzy.git"
+  },
+  "os": [
+    "win32"
+  ]
+}

--- a/npm/win32-x64-msvc/README.md
+++ b/npm/win32-x64-msvc/README.md
@@ -1,0 +1,3 @@
+# `rapid-fuzzy-win32-x64-msvc`
+
+This is the **x86_64-pc-windows-msvc** binary for `rapid-fuzzy`

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "rapid-fuzzy-win32-x64-msvc",
+  "version": "0.0.0",
+  "cpu": [
+    "x64"
+  ],
+  "main": "rapid-fuzzy.win32-x64-msvc.node",
+  "files": [
+    "rapid-fuzzy.win32-x64-msvc.node"
+  ],
+  "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
+  "keywords": [
+    "fuzzy",
+    "fuzzy-search",
+    "string-distance",
+    "levenshtein",
+    "jaro-winkler",
+    "rust",
+    "napi",
+    "wasm",
+    "typescript",
+    "search",
+    "fuse"
+  ],
+  "author": "derodero24",
+  "homepage": "https://github.com/derodero24/rapid-fuzzy",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/derodero24/rapid-fuzzy.git"
+  },
+  "os": [
+    "win32"
+  ]
+}


### PR DESCRIPTION
## Summary

- Redesign release workflow with multi-platform native binary builds for all 9 targets
- Add Version Packages PR automation via changesets on push to develop
- Enable npm provenance for supply chain security (`id-token: write` + `--provenance`)
- Add `npm/` platform package directories (generated by `napi create-npm-dirs`)
- Update `.gitignore` to track platform `package.json` while ignoring binaries

### Workflow modes

| Trigger | Behavior |
|---------|----------|
| Push to develop | Creates/updates Version Packages PR via changesets |
| Manual dispatch | Builds all 9 platforms → publishes to npm with provenance → fast-forwards main |

### Build targets

| Platform | Runner | Method |
|----------|--------|--------|
| x86_64-apple-darwin | macos-13 | Native |
| aarch64-apple-darwin | macos-latest | Native |
| x86_64-unknown-linux-gnu | ubuntu-latest | napi-cross |
| x86_64-unknown-linux-musl | ubuntu-latest | Docker (alpine) |
| aarch64-unknown-linux-gnu | ubuntu-latest | napi-cross |
| aarch64-unknown-linux-musl | ubuntu-latest | Docker (alpine) |
| x86_64-pc-windows-msvc | windows-latest | Native |
| aarch64-pc-windows-msvc | windows-latest | Cross |
| wasm32-wasip1-threads | ubuntu-latest | Cross |

Closes #48
Closes #39

## Test plan

- [ ] Verify version job creates Version Packages PR when changesets exist
- [ ] Verify build matrix compiles for all 9 targets on manual dispatch
- [ ] Verify publish job collects artifacts and publishes to npm with provenance
- [ ] Verify `npm/` platform package.json files are properly tracked in git