### PR TITLE
ci(release): automate release PR and npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-13
+          - host: macos-latest
             target: x86_64-apple-darwin
           - host: macos-latest
             target: aarch64-apple-darwin


### PR DESCRIPTION
## Summary

- Replace `changesets/action` with custom version + release PR automation
- On develop push with changesets: run `changeset version` inline, commit to develop, create release PR (develop → main)
- On main push: check if version is unpublished, build all 9 platforms, publish to npm with provenance
- Add version check to prevent duplicate publishes
- Keep `workflow_dispatch` as manual fallback

### New release flow

```
1. Developer adds changeset → pushes to develop
2. Release workflow: version bump + create PR (develop → main)
3. Admin merges release PR
4. Release workflow: build 9 platforms → npm publish
```

Closes #80

## Test plan

- [ ] Push changeset to develop → verify release PR is auto-created
- [ ] Merge release PR → verify build + publish triggers
- [ ] Push to main without version change → verify publish is skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースワークフローを改善しました。開発ブランチへのプッシュ時に変更内容を確認してバージョンを自動更新し、リリースプルリクエストを作成します。メインブランチへのプッシュ時には、バージョンがまだ公開されていない場合のみパッケージを公開するようになり、重複公開を防ぐようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->