### PR TITLE
fix(ci): update corepack in Docker for musl builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,7 @@ jobs:
             -w /build
           run: |
             set -e
+            npm install -g corepack@latest
             corepack enable
             corepack install
             rustup target add ${{ matrix.settings.target }}


### PR DESCRIPTION
## Summary

- Fix musl target build failures caused by outdated corepack in napi-rs Docker image
- Add `npm install -g corepack@latest` before `corepack enable` in Docker build step
- This resolves "Cannot find matching keyid" signature verification errors with pnpm@10

Required for v0.1.0 release — musl builds (x86_64 and aarch64) are currently failing.

## Test plan

- [ ] Verify x86_64-unknown-linux-musl Docker build succeeds
- [ ] Verify aarch64-unknown-linux-musl Docker build succeeds