### PR TITLE
fix(ci): sync release workflow fixes for v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,7 @@ jobs:
             -w /build
           run: |
             set -e
+            npm install -g corepack@latest
             corepack enable
             corepack install
             rustup target add ${{ matrix.settings.target }}


### PR DESCRIPTION
## Summary

- Fix musl Docker builds: update corepack to resolve pnpm signature verification failure

Required for v0.1.0 release — previous attempts failed due to macos-13 deprecation and corepack signature errors.