### PR TITLE
fix(ci): use Node 22 Docker image for musl builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,13 @@ jobs:
             use-cross: true
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:22-alpine
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:22-alpine
           - host: windows-latest
             target: x86_64-pc-windows-msvc
           - host: windows-latest


### PR DESCRIPTION
## Summary

- Switch musl Docker image from `lts-alpine` (Node 18) to `22-alpine` (Node 22)
- Fixes `ERR_PNPM_UNSUPPORTED_ENGINE` error: engines.node requires >=20 but Docker image had v18

Required for v0.1.0 release.