### PR TITLE
fix(ci): release workflow fixes for v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,13 @@ jobs:
             use-cross: true
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:22-alpine
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:22-alpine
           - host: windows-latest
             target: x86_64-pc-windows-msvc
           - host: windows-latest


### PR DESCRIPTION
Fix musl Docker builds: use Node 22 image (was Node 18, incompatible with engines.node>=20).