### PR TITLE
fix(ci): musl Docker build fixes for v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,13 @@ jobs:
             use-cross: true
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:22-alpine
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:22-alpine
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           - host: windows-latest
             target: x86_64-pc-windows-msvc
           - host: windows-latest
@@ -166,7 +166,7 @@ jobs:
             corepack enable
             corepack install
             rustup target add ${{ matrix.settings.target }}
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --config.engine-strict=false
             pnpm build --target ${{ matrix.settings.target }}
 
       - name: Upload artifact


### PR DESCRIPTION
Revert to lts-alpine image and bypass engine-strict check. Verified locally with Docker.