### PR TITLE
fix(ci): add git safe.directory for Docker musl builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,7 @@ jobs:
             -w /build
           run: |
             set -e
+            git config --global safe.directory /build
             npm install -g corepack@latest
             corepack enable
             corepack install


### PR DESCRIPTION
## Summary

- Add `git config --global safe.directory /build` to Docker build step
- Docker runs as root (user 0:0) but the mounted workspace is owned by the GitHub Actions runner user, causing git to reject operations with "dubious ownership" error
- Verified locally: `docker run` with safe.directory config passes pnpm install successfully