### PR TITLE
fix(ci): replace Docker with cargo-zigbuild for musl builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,13 @@ jobs:
             use-cross: true
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            use-zig: true
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            use-zig: true
           - host: windows-latest
             target: x86_64-pc-windows-msvc
           - host: windows-latest
@@ -123,52 +123,29 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
-        if: ${{ !matrix.settings.docker }}
       - uses: actions/setup-node@v6
-        if: ${{ !matrix.settings.docker }}
         with:
           node-version-file: .nvmrc
           cache: pnpm
       - uses: dtolnay/rust-toolchain@stable
-        if: ${{ !matrix.settings.docker }}
         with:
           targets: ${{ matrix.settings.target }}
       - uses: Swatinem/rust-cache@v2
-        if: ${{ !matrix.settings.docker }}
         with:
           shared-key: release-${{ matrix.settings.target }}
 
       - run: pnpm install --frozen-lockfile
-        if: ${{ !matrix.settings.docker }}
+
+      - name: Install cargo-zigbuild
+        if: ${{ matrix.settings.use-zig }}
+        run: pip3 install ziglang && cargo install cargo-zigbuild
 
       - name: Build
-        if: ${{ !matrix.settings.docker }}
         run: >-
           pnpm build
           --target ${{ matrix.settings.target }}
           ${{ matrix.settings.use-cross && '--use-napi-cross' || '' }}
-
-      - name: Build in Docker
-        if: ${{ matrix.settings.docker }}
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ matrix.settings.docker }}
-          options: >-
-            --user 0:0
-            -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db
-            -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache
-            -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index
-            -v ${{ github.workspace }}:/build
-            -w /build
-          run: |
-            set -e
-            git config --global safe.directory /build
-            npm install -g corepack@latest
-            corepack enable
-            corepack install
-            rustup target add ${{ matrix.settings.target }}
-            pnpm install --frozen-lockfile --config.engine-strict=false
-            pnpm build --target ${{ matrix.settings.target }}
+          ${{ matrix.settings.use-zig && '--zig' || '' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Replace Docker-based musl builds with cargo-zigbuild + napi `--zig` flag
- The napi-rs Docker image (lts-alpine) ships Node 18, incompatible with napi-rs CLI v3.5+ which requires Node 20+ (`node:util.styleText` API)
- cargo-zigbuild uses Zig's bundled musl libc for cross-compilation, eliminating all Docker-related issues
- Simplifies the build matrix by removing Docker-specific conditional steps

### Before (Docker)
- corepack signature verification failures
- Node 18 vs engines.node>=20 incompatibility
- git safe.directory ownership issues

### After (cargo-zigbuild)
- Standard GitHub Actions runner with Node 22
- `pip3 install ziglang && cargo install cargo-zigbuild`
- `pnpm build --target <musl-target> --zig`

## Test plan

- [ ] x86_64-unknown-linux-musl builds successfully with cargo-zigbuild
- [ ] aarch64-unknown-linux-musl builds successfully with cargo-zigbuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ビルドプロセスのインフラストラクチャを更新し、リリース生成の効率性と信頼性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->