### PR TITLE
fix(ci): use --cross-compile flag for napi zigbuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
           pnpm build
           --target ${{ matrix.settings.target }}
           ${{ matrix.settings.use-cross && '--use-napi-cross' || '' }}
-          ${{ matrix.settings.use-zig && '--zig' || '' }}
+          ${{ matrix.settings.use-zig && '--cross-compile' || '' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Fix: napi-rs CLI v3.5 uses --cross-compile, not --zig. Verified locally with npx napi build --help.