### PR TITLE
fix(ci): use correct --output-dir flag for napi artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
           path: artifacts
 
       - name: Move artifacts to platform packages
-        run: pnpm napi artifacts --dir artifacts
+        run: pnpm napi artifacts --output-dir artifacts
 
       - name: List packages
         run: |


### PR DESCRIPTION
Fix napi artifacts flag: --output-dir, not --dir. Verified locally.