### PR TITLE
fix(ci): correct napi artifacts flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
           path: artifacts
 
       - name: Move artifacts to platform packages
-        run: pnpm napi artifacts --dir artifacts
+        run: pnpm napi artifacts --output-dir artifacts
 
       - name: List packages
         run: |


### PR DESCRIPTION
Use --output-dir instead of --dir for napi artifacts command.