### PR TITLE
feat: add verify and clean convenience scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
     "bench": "vitest bench",
     "publint": "publint",
     "bench:rust": "cargo bench -p rapid-fuzzy-bench",
+    "verify": "pnpm run check && cargo clippy -- -W clippy::all && cargo test && pnpm run build && pnpm run typecheck && pnpm test",
+    "clean": "rm -rf target coverage *.node *.wasm",
     "prepare": "lefthook install"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Add `verify` script: runs all validation checks in the correct order — lint (`check`), Rust checks (`cargo clippy`, `cargo test`), napi-rs build, TypeScript type checking, and JS tests. This provides a single command to validate the entire project before pushing.
- Add `clean` script: removes build artifacts (`target/`, `coverage/`, `*.node`, `*.wasm`) for a fresh start.

Closes #97

## Checklist

- [x] `verify` script runs checks in dependency-aware order (build before typecheck)
- [x] `clean` script removes all generated artifacts
- [x] No changes to `src/` or `crates/` (no changeset needed)