### PR TITLE
ci: set code coverage thresholds to prevent regressions

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,10 +2,11 @@ coverage:
   status:
     project:
       default:
-        informational: true
+        target: auto
+        threshold: 5%
     patch:
       default:
-        informational: true
+        target: 70%
 
 comment:
   layout: 'condensed_header, condensed_files, condensed_footer'


### PR DESCRIPTION
## Summary

- Replace informational-only Codecov status checks with enforced thresholds
- **Project coverage**: target `auto` (current level) with a `5%` threshold — PRs that drop overall coverage by more than 5 percentage points will fail the check
- **Patch coverage**: target `70%` — new/changed lines must have at least 70% test coverage

These thresholds catch coverage regressions early while still allowing reasonable flexibility for infrastructure or config changes that may not need full coverage.

Closes #101

## Checklist

- [x] Updated `codecov.yml` with project and patch thresholds
- [x] No code changes — config-only, no changeset needed
- [x] Existing CI workflows unaffected