### PR TITLE
ci: add ESM import smoke test to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,8 @@ jobs:
           name: bindings-x86_64-unknown-linux-gnu
           path: .
       - run: pnpm test
+      - name: ESM import smoke test
+        run: node __test__/esm-import.mjs
 
   coverage:
     name: Coverage


### PR DESCRIPTION
## Summary

- `__test__/esm-import.mjs` exists as an ESM validation script that tests `levenshtein`, `search`, and `closest` imports, but it was never executed in the CI pipeline
- Add an "ESM import smoke test" step to the CI test job, running immediately after `pnpm test`, to catch ESM import regressions across all tested Node.js versions (20, 22, 24)

## Related issue

Closes #98

## Checklist

- [x] CI workflow updated to include `node __test__/esm-import.mjs` step
- [x] Step runs after `pnpm test` in the test matrix (Node 20, 22, 24)
- [x] No changes to application source code or tests