### PR TITLE
feat: add devcontainer for development environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "rapid-fuzzy",
+  "image": "mcr.microsoft.com/devcontainers/rust:1-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "postCreateCommand": "corepack enable && pnpm install --ignore-scripts && pnpm run build",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "biomejs.biome"
+      ]
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,10 @@ pnpm test          # JS/TS tests
 cargo test         # Rust unit tests
 ```
 
+### GitHub Codespaces / Dev Containers
+
+You can skip local setup entirely by using [GitHub Codespaces](https://github.com/codespaces) or [VS Code Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers). The repository includes a devcontainer configuration with all required tools pre-installed.
+
 ## Project structure
 
 ```


### PR DESCRIPTION
## Summary

- Add `.devcontainer/devcontainer.json` with Rust (bookworm), Node.js 20, and pnpm pre-configured for one-click development setup
- Include VS Code extensions for rust-analyzer and Biome
- Run `postCreateCommand` to enable corepack, install dependencies, and build the native addon automatically
- Add a note in CONTRIBUTING.md about GitHub Codespaces / Dev Containers support

Closes #95

## Checklist

- [x] No source code changes (config/docs only)
- [x] PR title follows Conventional Commits format
- [x] Issue linked in PR body