### PR TITLE
docs: add algorithm selection guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,22 @@ pnpm run bench        # JavaScript benchmarks
 cargo bench           # Rust internal benchmarks
 ```
 
+## Choosing an Algorithm
+
+| Use case | Recommended | Why |
+|---|---|---|
+| Typo detection / spell check | `levenshtein`, `damerauLevenshtein` | Counts edits; Damerau adds transposition support |
+| Name / address matching | `jaroWinkler` | Prefix-weighted similarity for short strings |
+| Document / text similarity | `sorensenDice` | Bigram-based; handles longer text well |
+| Normalized comparison (0–1) | `normalizedLevenshtein` | Length-independent similarity score |
+| Interactive fuzzy search | `search`, `closest` | Nucleo algorithm (same as Helix editor) |
+
+**Return types:**
+
+- `levenshtein`, `damerauLevenshtein` → integer (edit count)
+- `jaro`, `jaroWinkler`, `sorensenDice`, `normalizedLevenshtein` → float between 0.0 (no match) and 1.0 (identical)
+- `search` → array of `{ item, score, index }` sorted by relevance
+
 ## Why rapid-fuzzy?
 
 | | rapid-fuzzy | fuse.js | fastest-levenshtein | fuzzysort |


### PR DESCRIPTION
## Summary

- Add a new "Choosing an Algorithm" section to README with a decision table mapping use cases to recommended functions
- Include return type reference for all distance/search functions

## Related issues

Related to #37
Closes #102

## Checklist

- [x] README updated with algorithm selection guide
- [x] No code changes (docs-only)
- [x] No changeset needed