### PR TITLE
ci: add cross-platform test execution for macOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,13 +183,21 @@ jobs:
           if-no-files-found: ignore
 
   test:
-    name: Test - Node ${{ matrix.node }}
+    name: Test - Node ${{ matrix.node }} / ${{ matrix.os }}
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         node: [20, 22, 24]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            artifact: bindings-x86_64-unknown-linux-gnu
+          - os: macos-latest
+            artifact: bindings-aarch64-apple-darwin
+          - os: windows-latest
+            artifact: bindings-x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
@@ -198,10 +206,10 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Download x86_64 linux artifact
+      - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: bindings-x86_64-unknown-linux-gnu
+          name: ${{ matrix.artifact }}
           path: .
       - run: pnpm test
       - name: ESM import smoke test


### PR DESCRIPTION
## Summary

- Extend test matrix to run on **macOS (ARM)** and **Windows (x86_64)** in addition to Ubuntu
- Each OS downloads its corresponding native binary artifact from the build job
- Test matrix: 3 Node versions × 3 OS = 9 test jobs

## Changes

- Add `os` dimension to test job matrix: `[ubuntu-latest, macos-latest, windows-latest]`
- Use `include` to map each OS to its correct build artifact (`bindings-*` naming convention)
- Parameterize artifact download step with `${{ matrix.artifact }}`

## Platform mapping

| Runner | Architecture | Artifact |
|--------|-------------|----------|
| `ubuntu-latest` | x86_64 | `bindings-x86_64-unknown-linux-gnu` |
| `macos-latest` | ARM (M-series) | `bindings-aarch64-apple-darwin` |
| `windows-latest` | x86_64 | `bindings-x86_64-pc-windows-msvc` |

## Test plan

- [ ] CI runs all 9 test jobs (3 Node × 3 OS) successfully
- [ ] Verify macOS ARM binary loads correctly
- [ ] Verify Windows x86_64 binary loads correctly
- [ ] ESM import smoke test passes on all platforms

Closes #44