### PR TITLE
test(wasm): verify WASM build and add integration tests

### DIFF
--- a/__test__/wasm.spec.ts
+++ b/__test__/wasm.spec.ts
@@ -1,0 +1,271 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const wasmBinaryPath = resolve(__dirname, '../rapid-fuzzy.wasm32-wasi.wasm');
+const wasmExists = existsSync(wasmBinaryPath);
+
+// Skip all WASM tests if the binary is not built
+// Build with: pnpm run build --target wasm32-wasip1-threads
+describe.skipIf(!wasmExists)('wasm', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const wasm = wasmExists ? require('../rapid-fuzzy.wasi.cjs') : {};
+
+  describe('exports', () => {
+    it('should export all expected functions', () => {
+      const expectedExports = [
+        'closest',
+        'damerauLevenshtein',
+        'damerauLevenshteinBatch',
+        'damerauLevenshteinMany',
+        'jaro',
+        'jaroBatch',
+        'jaroMany',
+        'jaroWinkler',
+        'jaroWinklerBatch',
+        'jaroWinklerMany',
+        'levenshtein',
+        'levenshteinBatch',
+        'levenshteinMany',
+        'normalizedLevenshtein',
+        'normalizedLevenshteinBatch',
+        'normalizedLevenshteinMany',
+        'search',
+        'sorensenDice',
+        'sorensenDiceBatch',
+        'sorensenDiceMany',
+      ];
+
+      for (const name of expectedExports) {
+        expect(typeof wasm[name]).toBe('function');
+      }
+    });
+  });
+
+  describe('distance functions', () => {
+    it('levenshtein', () => {
+      expect(wasm.levenshtein('hello', 'hello')).toBe(0);
+      expect(wasm.levenshtein('hello', 'world')).toBe(4);
+      expect(wasm.levenshtein('kitten', 'sitting')).toBe(3);
+      expect(wasm.levenshtein('', '')).toBe(0);
+    });
+
+    it('normalizedLevenshtein', () => {
+      expect(wasm.normalizedLevenshtein('hello', 'hello')).toBe(1.0);
+      expect(wasm.normalizedLevenshtein('', '')).toBe(1.0);
+      const score = wasm.normalizedLevenshtein('hello', 'world');
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+
+    it('damerauLevenshtein', () => {
+      expect(wasm.damerauLevenshtein('hello', 'hello')).toBe(0);
+      expect(wasm.damerauLevenshtein('hello', 'ehllo')).toBe(1);
+    });
+
+    it('jaro', () => {
+      expect(wasm.jaro('hello', 'hello')).toBe(1.0);
+      const score = wasm.jaro('hello', 'world');
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+
+    it('jaroWinkler', () => {
+      expect(wasm.jaroWinkler('hello', 'hello')).toBe(1.0);
+      const score = wasm.jaroWinkler('hello', 'world');
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+
+    it('sorensenDice', () => {
+      expect(wasm.sorensenDice('hello', 'hello')).toBe(1.0);
+      const score = wasm.sorensenDice('hello', 'world');
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('batch functions', () => {
+    it('levenshteinBatch', () => {
+      const result = wasm.levenshteinBatch([
+        ['hello', 'hello'],
+        ['hello', 'world'],
+      ]);
+      expect(result).toEqual([0, 4]);
+    });
+
+    it('jaroBatch', () => {
+      const result = wasm.jaroBatch([
+        ['hello', 'hello'],
+        ['hello', 'world'],
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(1.0);
+      expect(result[1]).toBeGreaterThanOrEqual(0);
+    });
+
+    it('jaroWinklerBatch', () => {
+      const result = wasm.jaroWinklerBatch([
+        ['hello', 'hello'],
+        ['hello', 'world'],
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(1.0);
+    });
+
+    it('sorensenDiceBatch', () => {
+      const result = wasm.sorensenDiceBatch([
+        ['hello', 'hello'],
+        ['hello', 'world'],
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(1.0);
+    });
+
+    it('normalizedLevenshteinBatch', () => {
+      const result = wasm.normalizedLevenshteinBatch([
+        ['hello', 'hello'],
+        ['hello', 'world'],
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(1.0);
+    });
+
+    it('damerauLevenshteinBatch', () => {
+      const result = wasm.damerauLevenshteinBatch([
+        ['hello', 'hello'],
+        ['hello', 'ehllo'],
+      ]);
+      expect(result).toEqual([0, 1]);
+    });
+  });
+
+  describe('many functions', () => {
+    it('levenshteinMany', () => {
+      const result = wasm.levenshteinMany('hello', ['hello', 'world', 'help']);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toBe(0);
+    });
+
+    it('jaroMany', () => {
+      const result = wasm.jaroMany('hello', ['hello', 'world']);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(1.0);
+    });
+
+    it('jaroWinklerMany', () => {
+      const result = wasm.jaroWinklerMany('hello', ['hello', 'world']);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(1.0);
+    });
+
+    it('sorensenDiceMany', () => {
+      const result = wasm.sorensenDiceMany('hello', ['hello', 'world']);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(1.0);
+    });
+
+    it('normalizedLevenshteinMany', () => {
+      const result = wasm.normalizedLevenshteinMany('hello', ['hello', 'world']);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(1.0);
+    });
+
+    it('damerauLevenshteinMany', () => {
+      const result = wasm.damerauLevenshteinMany('hello', ['hello', 'ehllo']);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(0);
+    });
+  });
+
+  describe('search functions', () => {
+    it('search should return sorted results', () => {
+      const results = wasm.search('type', ['TypeScript', 'JavaScript', 'Python', 'TypeSpec']);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].item).toBe('TypeScript');
+      expect(results[0]).toHaveProperty('score');
+      expect(results[0]).toHaveProperty('index');
+    });
+
+    it('search should respect maxResults', () => {
+      const results = wasm.search('a', ['apple', 'avocado', 'apricot', 'banana'], 2);
+      expect(results.length).toBeLessThanOrEqual(2);
+    });
+
+    it('search should return empty for empty query', () => {
+      const results = wasm.search('', ['hello', 'world']);
+      expect(results).toEqual([]);
+    });
+
+    it('closest should return best match', () => {
+      const result = wasm.closest('apple', ['application', 'banana', 'apple pie']);
+      expect(result).not.toBeNull();
+    });
+
+    it('closest should return null for empty items', () => {
+      const result = wasm.closest('hello', []);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('native parity', () => {
+    // Import native module for comparison
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const native = require('../index.js');
+
+    const testPairs: [string, string][] = [
+      ['hello', 'hello'],
+      ['hello', 'world'],
+      ['kitten', 'sitting'],
+      ['', ''],
+      ['abc', ''],
+      ['', 'abc'],
+      ['café', 'cafe'],
+      ['東京', '京都'],
+    ];
+
+    it('levenshtein results should match native', () => {
+      for (const [a, b] of testPairs) {
+        expect(wasm.levenshtein(a, b)).toBe(native.levenshtein(a, b));
+      }
+    });
+
+    it('normalizedLevenshtein results should match native', () => {
+      for (const [a, b] of testPairs) {
+        expect(wasm.normalizedLevenshtein(a, b)).toBe(native.normalizedLevenshtein(a, b));
+      }
+    });
+
+    it('jaro results should match native', () => {
+      for (const [a, b] of testPairs) {
+        expect(wasm.jaro(a, b)).toBe(native.jaro(a, b));
+      }
+    });
+
+    it('jaroWinkler results should match native', () => {
+      for (const [a, b] of testPairs) {
+        expect(wasm.jaroWinkler(a, b)).toBe(native.jaroWinkler(a, b));
+      }
+    });
+
+    it('sorensenDice results should match native', () => {
+      for (const [a, b] of testPairs) {
+        expect(wasm.sorensenDice(a, b)).toBe(native.sorensenDice(a, b));
+      }
+    });
+
+    it('damerauLevenshtein results should match native', () => {
+      for (const [a, b] of testPairs) {
+        expect(wasm.damerauLevenshtein(a, b)).toBe(native.damerauLevenshtein(a, b));
+      }
+    });
+
+    it('batch results should match native', () => {
+      const pairs: [string, string][] = [
+        ['hello', 'world'],
+        ['kitten', 'sitting'],
+      ];
+      expect(wasm.levenshteinBatch(pairs)).toEqual(native.levenshteinBatch(pairs));
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "scripts": {
     "build": "napi build --manifest-path crates/core/Cargo.toml --platform --release --js index.js --dts index.d.ts --output-dir .",
     "build:debug": "napi build --manifest-path crates/core/Cargo.toml --platform --js index.js --dts index.d.ts --output-dir .",
+    "build:wasm": "napi build --manifest-path crates/core/Cargo.toml --platform --release --js index.js --dts index.d.ts --output-dir . --target wasm32-wasip1-threads",
     "artifacts": "napi artifacts",
     "prepublishOnly": "napi prepublish -t npm",
     "version": "napi version",
@@ -78,6 +79,7 @@
     "lint:fix": "biome check --write",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:wasm": "vitest run __test__/wasm.spec.ts",
     "test:watch": "vitest watch",
     "bench": "vitest bench",
     "publint": "publint",
@@ -94,6 +96,7 @@
     "@emnapi/core": "^1.9.0",
     "@emnapi/runtime": "^1.9.0",
     "@napi-rs/cli": "^3.5.1",
+    "@napi-rs/wasm-runtime": "^1.1.1",
     "@tybys/wasm-util": "^0.10.1",
     "@types/node": "^24.0.0",
     "@types/string-similarity": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@napi-rs/cli':
         specifier: ^3.5.1
         version: 3.5.1(@emnapi/runtime@1.9.0)(@types/node@24.12.0)
+      '@napi-rs/wasm-runtime':
+        specifier: ^1.1.1
+        version: 1.1.1
       '@tybys/wasm-util':
         specifier: ^0.10.1
         version: 0.10.1
@@ -2625,7 +2628,6 @@ snapshots:
       '@emnapi/core': 1.9.0
       '@emnapi/runtime': 1.9.0
       '@tybys/wasm-util': 0.10.1
-    optional: true
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     optional: true


### PR DESCRIPTION
## Summary

- Add WASM integration tests verifying all 20 exported functions work correctly via Node.js WASI
- Add native-WASM parity tests ensuring identical output between native binary and WASM
- Add `@napi-rs/wasm-runtime` as devDependency for WASM testing
- Add `build:wasm` and `test:wasm` convenience scripts

## Verified behavior

- **Node.js**: All functions work correctly via WASM ✅
- **Bun**: `node:wasi` module incomplete (`wasi.initialize` not implemented) ❌
- **Deno**: Not tested (not available in current environment)

## Test details

31 new tests organized in 6 groups:
- **exports**: Verifies all 20 functions are exported
- **distance functions**: Tests individual distance/similarity functions
- **batch functions**: Tests all batch operations
- **many functions**: Tests all many (one-vs-many) operations
- **search functions**: Tests search and closest
- **native parity**: Compares WASM output against native binary for identical results

Tests auto-skip when the WASM binary is not built (requires `pnpm run build:wasm` first).

## Related issues

Partial fix for #29 — Node.js WASM verification complete.
Follow-up issues for remaining runtimes:
- #125 — Browser WASM testing
- #126 — Deno and Bun WASM testing

## Checklist

- [x] WASM build produces working `.wasm` binary
- [x] All 20 exported functions verified in Node.js WASI environment
- [x] WASM results match native binary output
- [x] Tests pass locally (`pnpm test`)
- [x] Lint passes (`pnpm run check`)
- [x] TypeScript types check (`pnpm run typecheck`)
- [x] All pre-push hooks pass