### PR TITLE
feat(core): add score threshold filtering to search and closest

### DIFF
--- a/.changeset/score-threshold.md
+++ b/.changeset/score-threshold.md
@@ -1,0 +1,7 @@
+---
+"rapid-fuzzy": minor
+---
+
+Add score threshold filtering to search() and closest() functions.
+
+search() now accepts a SearchOptions object with maxResults and minScore fields, while maintaining backward compatibility with the existing number argument for maxResults. closest() accepts an optional minScore parameter to return null when the best match is below the threshold.

--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -303,6 +303,42 @@ describe('search', () => {
       expect(exact.score).toBeGreaterThan(partial.score);
     }
   });
+
+  it('should accept SearchOptions object', () => {
+    const results = search('a', items, { maxResults: 2 });
+    expect(results.length).toBeLessThanOrEqual(2);
+  });
+
+  it('should filter by minScore', () => {
+    const all = search('apple', items);
+    const filtered = search('apple', items, { minScore: 0.5 });
+    expect(filtered.length).toBeLessThanOrEqual(all.length);
+    for (const r of filtered) {
+      expect(r.score).toBeGreaterThanOrEqual(0.5);
+    }
+  });
+
+  it('should return only exact matches with minScore 1.0', () => {
+    const results = search('apple', ['apple', 'application', 'banana'], {
+      minScore: 1.0,
+    });
+    expect(results.length).toBe(1);
+    expect(results[0]?.item).toBe('apple');
+  });
+
+  it('should combine maxResults and minScore', () => {
+    const results = search('app', items, { maxResults: 1, minScore: 0.1 });
+    expect(results.length).toBeLessThanOrEqual(1);
+    if (results.length > 0) {
+      expect(results[0]?.score).toBeGreaterThanOrEqual(0.1);
+    }
+  });
+
+  it('should treat number arg as maxResults (backward compat)', () => {
+    const withNumber = search('a', items, 2);
+    const withOptions = search('a', items, { maxResults: 2 });
+    expect(withNumber.length).toBe(withOptions.length);
+  });
 });
 
 describe('closest', () => {
@@ -321,6 +357,16 @@ describe('closest', () => {
   it('should return null for empty items', () => {
     const result = closest('test', []);
     expect(result).toBeNull();
+  });
+
+  it('should return null when best match is below minScore', () => {
+    const result = closest('hello', ['xyz', 'abc'], 0.99);
+    expect(result).toBeNull();
+  });
+
+  it('should return match when above minScore', () => {
+    const result = closest('apple', ['apple', 'banana'], 0.5);
+    expect(result).toBe('apple');
   });
 });
 

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -1,3 +1,4 @@
+use napi::Either;
 use napi_derive::napi;
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher};
@@ -13,6 +14,15 @@ pub struct SearchResult {
     pub index: u32,
 }
 
+/// Options for the search function.
+#[napi(object)]
+pub struct SearchOptions {
+    /// Maximum number of results to return.
+    pub max_results: Option<u32>,
+    /// Minimum normalized score (0.0-1.0) to include in results.
+    pub min_score: Option<f64>,
+}
+
 /// Compute the maximum possible score for a given pattern by scoring
 /// the query against itself (exact match = theoretical maximum).
 fn compute_max_score(query: &str, pattern: &Pattern, matcher: &mut Matcher) -> f64 {
@@ -21,14 +31,13 @@ fn compute_max_score(query: &str, pattern: &Pattern, matcher: &mut Matcher) -> f
     pattern.score(atoms, matcher).unwrap_or(1) as f64
 }
 
-/// Perform fuzzy search over a list of strings.
-///
-/// Returns matches sorted by score (best match first).
-/// Scores are normalized to a 0.0-1.0 range where 1.0 is a perfect match.
-/// Uses the nucleo algorithm (same as Helix editor), which is
-/// significantly faster than fzf/skim for large datasets.
-#[napi]
-pub fn search(query: String, items: Vec<String>, max_results: Option<u32>) -> Vec<SearchResult> {
+/// Internal search implementation used by both the napi export and tests.
+pub(crate) fn search_impl(
+    query: String,
+    items: Vec<String>,
+    max_results: Option<u32>,
+    min_score: Option<f64>,
+) -> Vec<SearchResult> {
     if query.is_empty() || items.is_empty() {
         return Vec::new();
     }
@@ -36,6 +45,7 @@ pub fn search(query: String, items: Vec<String>, max_results: Option<u32>) -> Ve
     let mut matcher = Matcher::new(Config::DEFAULT);
     let pattern = Pattern::parse(&query, CaseMatching::Smart, Normalization::Smart);
     let max_score = compute_max_score(&query, &pattern, &mut matcher);
+    let threshold = min_score.unwrap_or(0.0);
 
     let mut results: Vec<SearchResult> = items
         .iter()
@@ -43,12 +53,16 @@ pub fn search(query: String, items: Vec<String>, max_results: Option<u32>) -> Ve
         .filter_map(|(index, item)| {
             let mut buf = Vec::new();
             let atoms = nucleo_matcher::Utf32Str::new(item, &mut buf);
-            pattern.score(atoms, &mut matcher).map(|raw_score| {
+            pattern.score(atoms, &mut matcher).and_then(|raw_score| {
                 let normalized = (raw_score as f64 / max_score).min(1.0);
-                SearchResult {
-                    item: item.clone(),
-                    score: normalized,
-                    index: index as u32,
+                if normalized >= threshold {
+                    Some(SearchResult {
+                        item: item.clone(),
+                        score: normalized,
+                        index: index as u32,
+                    })
+                } else {
+                    None
                 }
             })
         })
@@ -67,12 +81,36 @@ pub fn search(query: String, items: Vec<String>, max_results: Option<u32>) -> Ve
     results
 }
 
+/// Perform fuzzy search over a list of strings.
+///
+/// Returns matches sorted by score (best match first).
+/// Scores are normalized to a 0.0-1.0 range where 1.0 is a perfect match.
+/// Uses the nucleo algorithm (same as Helix editor), which is
+/// significantly faster than fzf/skim for large datasets.
+///
+/// The third argument accepts either a number (maxResults for backward
+/// compatibility) or a SearchOptions object with maxResults and minScore.
+#[napi]
+pub fn search(
+    query: String,
+    items: Vec<String>,
+    options: Option<Either<u32, SearchOptions>>,
+) -> Vec<SearchResult> {
+    let (max_results, min_score) = match options {
+        Some(Either::A(max)) => (Some(max), None),
+        Some(Either::B(opts)) => (opts.max_results, opts.min_score),
+        None => (None, None),
+    };
+    search_impl(query, items, max_results, min_score)
+}
+
 /// Find the closest matching string from a list.
 ///
 /// Returns the best match, or null if no match is found.
+/// If minScore is provided, returns null when the best match scores below the threshold.
 #[napi]
-pub fn closest(query: String, items: Vec<String>) -> Option<String> {
-    let results = search(query, items, Some(1));
+pub fn closest(query: String, items: Vec<String>, min_score: Option<f64>) -> Option<String> {
+    let results = search_impl(query, items, Some(1), min_score);
     results.into_iter().next().map(|r| r.item)
 }
 
@@ -88,7 +126,7 @@ mod tests {
             "Python".to_string(),
             "TypeSpec".to_string(),
         ];
-        let results = search("typscript".to_string(), items, None);
+        let results = search_impl("typscript".to_string(), items, None, None);
         assert!(!results.is_empty());
         assert_eq!(results[0].item, "TypeScript");
     }
@@ -96,7 +134,7 @@ mod tests {
     #[test]
     fn test_search_empty_query() {
         let items = vec!["foo".to_string()];
-        let results = search("".to_string(), items, None);
+        let results = search_impl("".to_string(), items, None, None);
         assert!(results.is_empty());
     }
 
@@ -107,7 +145,7 @@ mod tests {
             "application".to_string(),
             "banana".to_string(),
         ];
-        let result = closest("app".to_string(), items);
+        let result = closest("app".to_string(), items, None);
         assert!(result.is_some());
     }
 
@@ -119,7 +157,7 @@ mod tests {
             "banana".to_string(),
             "grape".to_string(),
         ];
-        let results = search("apple".to_string(), items, None);
+        let results = search_impl("apple".to_string(), items, None, None);
         for r in &results {
             assert!(
                 r.score >= 0.0 && r.score <= 1.0,
@@ -133,7 +171,7 @@ mod tests {
     #[test]
     fn test_exact_match_scores_one() {
         let items = vec!["hello".to_string(), "world".to_string()];
-        let results = search("hello".to_string(), items, None);
+        let results = search_impl("hello".to_string(), items, None, None);
         let exact = results.iter().find(|r| r.item == "hello").unwrap();
         assert!(
             (exact.score - 1.0).abs() < f64::EPSILON,
@@ -145,7 +183,7 @@ mod tests {
     #[test]
     fn test_partial_match_scores_below_one() {
         let items = vec!["TypeScript".to_string(), "JavaScript".to_string()];
-        let results = search("type".to_string(), items, None);
+        let results = search_impl("type".to_string(), items, None, None);
         for r in &results {
             assert!(
                 r.score > 0.0 && r.score <= 1.0,
@@ -154,6 +192,76 @@ mod tests {
                 r.item
             );
         }
+    }
+
+    #[test]
+    fn test_min_score_filters_low_quality() {
+        let items = vec![
+            "apple".to_string(),
+            "application".to_string(),
+            "xyz".to_string(),
+        ];
+        let all_results = search_impl("apple".to_string(), items.clone(), None, None);
+        let filtered = search_impl("apple".to_string(), items, None, Some(0.5));
+        assert!(filtered.len() <= all_results.len());
+        for r in &filtered {
+            assert!(
+                r.score >= 0.5,
+                "score {} below min_score 0.5 for '{}'",
+                r.score,
+                r.item
+            );
+        }
+    }
+
+    #[test]
+    fn test_min_score_one_returns_only_exact() {
+        let items = vec!["hello".to_string(), "help".to_string(), "world".to_string()];
+        let results = search_impl("hello".to_string(), items, None, Some(1.0));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].item, "hello");
+    }
+
+    #[test]
+    fn test_min_score_zero_same_as_none() {
+        let items = vec![
+            "apple".to_string(),
+            "banana".to_string(),
+            "grape".to_string(),
+        ];
+        let no_threshold = search_impl("ap".to_string(), items.clone(), None, None);
+        let zero_threshold = search_impl("ap".to_string(), items, None, Some(0.0));
+        assert_eq!(no_threshold.len(), zero_threshold.len());
+    }
+
+    #[test]
+    fn test_min_score_with_max_results() {
+        let items = vec![
+            "apple".to_string(),
+            "application".to_string(),
+            "appetizer".to_string(),
+            "xyz".to_string(),
+        ];
+        let results = search_impl("apple".to_string(), items, Some(2), Some(0.3));
+        assert!(results.len() <= 2);
+        for r in &results {
+            assert!(r.score >= 0.3);
+        }
+    }
+
+    #[test]
+    fn test_closest_with_min_score() {
+        let items = vec!["xyz".to_string(), "abc".to_string()];
+        // With a very high threshold, closest should return None
+        let result = closest("hello".to_string(), items, Some(0.99));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_closest_without_min_score() {
+        let items = vec!["apple".to_string(), "banana".to_string()];
+        let result = closest("app".to_string(), items, None);
+        assert!(result.is_some());
     }
 
     mod proptest_search {
@@ -167,7 +275,7 @@ mod tests {
                 items in prop::collection::vec("[a-z]{1,10}", 1..20),
                 max in 1u32..10
             ) {
-                let results = search(query, items, Some(max));
+                let results = search_impl(query, items, Some(max), None);
                 prop_assert!(results.len() <= max as usize);
             }
 
@@ -176,7 +284,7 @@ mod tests {
                 query in "[a-z]{1,5}",
                 items in prop::collection::vec("[a-z]{1,10}", 1..20),
             ) {
-                let results = search(query, items, None);
+                let results = search_impl(query, items, None, None);
                 for window in results.windows(2) {
                     prop_assert!(
                         window[0].score >= window[1].score,
@@ -192,7 +300,7 @@ mod tests {
                 query in "[a-z]{1,5}",
                 items in prop::collection::vec("[a-z]{1,10}", 1..20),
             ) {
-                let results = search(query, items, None);
+                let results = search_impl(query, items, None, None);
                 for r in &results {
                     prop_assert!(
                         r.score >= 0.0 && r.score <= 1.0,
@@ -207,8 +315,8 @@ mod tests {
                 query in "[a-z]{1,5}",
                 items in prop::collection::vec("[a-z]{1,10}", 1..20),
             ) {
-                let closest_result = closest(query.clone(), items.clone());
-                let search_results = search(query, items, None);
+                let closest_result = closest(query.clone(), items.clone(), None);
+                let search_results = search_impl(query, items, None, None);
 
                 match (closest_result, search_results.first()) {
                     (Some(c), Some(first)) => {
@@ -227,9 +335,26 @@ mod tests {
                 items in prop::collection::vec("[a-z]{1,10}", 1..20),
             ) {
                 let len = items.len();
-                let results = search(query, items, None);
+                let results = search_impl(query, items, None, None);
                 for r in &results {
                     prop_assert!((r.index as usize) < len, "index {} out of bounds (len={})", r.index, len);
+                }
+            }
+
+            #[test]
+            fn search_min_score_respected(
+                query in "[a-z]{1,5}",
+                items in prop::collection::vec("[a-z]{1,10}", 1..20),
+                threshold in 0.0f64..1.0
+            ) {
+                let results = search_impl(query, items, None, Some(threshold));
+                for r in &results {
+                    prop_assert!(
+                        r.score >= threshold,
+                        "score {} below threshold {}",
+                        r.score,
+                        threshold
+                    );
                 }
             }
         }
@@ -241,7 +366,7 @@ mod tests {
         #[test]
         fn test_search_cjk() {
             let items = vec!["東京".to_string(), "大阪".to_string(), "京都".to_string()];
-            let results = search("東".to_string(), items, None);
+            let results = search_impl("東".to_string(), items, None, None);
             assert!(!results.is_empty());
         }
 
@@ -252,7 +377,7 @@ mod tests {
                 "🎊 celebration".to_string(),
                 "work".to_string(),
             ];
-            let results = search("party".to_string(), items, None);
+            let results = search_impl("party".to_string(), items, None, None);
             assert!(!results.is_empty());
             assert!(results[0].item.contains("party"));
         }
@@ -264,14 +389,14 @@ mod tests {
                 "resume".to_string(),
                 "naïve".to_string(),
             ];
-            let results = search("cafe".to_string(), items, None);
+            let results = search_impl("cafe".to_string(), items, None, None);
             assert!(!results.is_empty());
         }
 
         #[test]
         fn test_closest_cjk() {
             let items = vec!["大阪".to_string(), "京都".to_string(), "東京都".to_string()];
-            let result = closest("東京".to_string(), items);
+            let result = closest("東京".to_string(), items, None);
             assert!(result.is_some());
         }
 
@@ -282,7 +407,7 @@ mod tests {
                 "goodbye世間".to_string(),
                 "test".to_string(),
             ];
-            let results = search("hello".to_string(), items, None);
+            let results = search_impl("hello".to_string(), items, None, None);
             assert!(!results.is_empty());
             assert!(results[0].item.contains("hello"));
         }
@@ -299,7 +424,7 @@ mod tests {
                 items in prop::collection::vec("\\PC{1,10}", 1..20),
                 max in 1u32..10
             ) {
-                let results = search(query, items, Some(max));
+                let results = search_impl(query, items, Some(max), None);
                 prop_assert!(results.len() <= max as usize);
             }
 
@@ -308,7 +433,7 @@ mod tests {
                 query in "\\PC{1,5}",
                 items in prop::collection::vec("\\PC{1,10}", 1..20),
             ) {
-                let results = search(query, items, None);
+                let results = search_impl(query, items, None, None);
                 for window in results.windows(2) {
                     prop_assert!(
                         window[0].score >= window[1].score,
@@ -325,7 +450,7 @@ mod tests {
                 items in prop::collection::vec("\\PC{1,10}", 1..20),
             ) {
                 let len = items.len();
-                let results = search(query, items, None);
+                let results = search_impl(query, items, None, None);
                 for r in &results {
                     prop_assert!((r.index as usize) < len, "index {} out of bounds (len={})", r.index, len);
                 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,8 +4,9 @@
  * Find the closest matching string from a list.
  *
  * Returns the best match, or null if no match is found.
+ * If minScore is provided, returns null when the best match scores below the threshold.
  */
-export declare function closest(query: string, items: Array<string>): string | null
+export declare function closest(query: string, items: Array<string>, minScore?: number | undefined | null): string | null
 
 /**
  * Compute the Damerau-Levenshtein distance between two strings.
@@ -124,8 +125,19 @@ export declare function normalizedLevenshteinMany(reference: string, candidates:
  * Scores are normalized to a 0.0-1.0 range where 1.0 is a perfect match.
  * Uses the nucleo algorithm (same as Helix editor), which is
  * significantly faster than fzf/skim for large datasets.
+ *
+ * The third argument accepts either a number (maxResults for backward
+ * compatibility) or a SearchOptions object with maxResults and minScore.
  */
-export declare function search(query: string, items: Array<string>, maxResults?: number | undefined | null): Array<SearchResult>
+export declare function search(query: string, items: Array<string>, options?: number | SearchOptions | undefined | null): Array<SearchResult>
+
+/** Options for the search function. */
+export interface SearchOptions {
+  /** Maximum number of results to return. */
+  maxResults?: number
+  /** Minimum normalized score (0.0-1.0) to include in results. */
+  minScore?: number
+}
 
 /** A single fuzzy search result with the matched item and its score. */
 export interface SearchResult {

--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-android-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-android-arm-eabi')
         const bindingPackageVersion = require('rapid-fuzzy-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-x64-gnu')
         const bindingPackageVersion = require('rapid-fuzzy-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-x64-msvc')
         const bindingPackageVersion = require('rapid-fuzzy-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-ia32-msvc')
         const bindingPackageVersion = require('rapid-fuzzy-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-arm64-msvc')
         const bindingPackageVersion = require('rapid-fuzzy-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('rapid-fuzzy-darwin-universal')
       const bindingPackageVersion = require('rapid-fuzzy-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-darwin-x64')
         const bindingPackageVersion = require('rapid-fuzzy-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-darwin-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-freebsd-x64')
         const bindingPackageVersion = require('rapid-fuzzy-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-freebsd-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-x64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-x64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm-musleabihf')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm-gnueabihf')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-loong64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-loong64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-riscv64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-riscv64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-linux-ppc64-gnu')
         const bindingPackageVersion = require('rapid-fuzzy-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-linux-s390x-gnu')
         const bindingPackageVersion = require('rapid-fuzzy-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-openharmony-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-openharmony-x64')
         const bindingPackageVersion = require('rapid-fuzzy-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-openharmony-arm')
         const bindingPackageVersion = require('rapid-fuzzy-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.1.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.1.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {


### PR DESCRIPTION
## Summary

- Add `SearchOptions` interface with `maxResults` and `minScore` fields
- `search()` accepts either a number (backward compat) or `SearchOptions` object
- `closest()` accepts optional `minScore` parameter to return `null` for poor matches
- Results below `minScore` are excluded before sorting/truncation

## API

```typescript
// Backward compatible — number still works as maxResults
search('query', items, 5);

// New: SearchOptions object
search('query', items, { maxResults: 10, minScore: 0.3 });

// closest with threshold
closest('query', items, 0.5); // returns null if best match < 0.5
```

## Related issue

Closes #70

## Checklist

- [x] `SearchOptions` interface added to Rust bindings
- [x] `minScore` filtering implemented in `search()`
- [x] `closest()` respects threshold
- [x] Backward compatibility maintained (`search(q, items, number)`)
- [x] Rust tests added (11 new unit tests + 1 proptest)
- [x] JS tests added (7 new tests)
- [x] TypeScript types auto-generated correctly
- [x] Changeset included (minor)
- [x] All pre-push hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added score threshold filtering to search and closest match functions via optional `minScore` parameter.
  * Introduced `SearchOptions` object for combined control over result limits and minimum quality thresholds.
  * Fully backward compatible with existing API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->