### PR TITLE
fix(ci): batch changesets into single version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [develop, main]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -15,13 +15,16 @@ permissions:
   id-token: write
 
 jobs:
-  # ──── On develop push: version packages and create release PR to main ────
+  # ──── Manual trigger: version packages and create release PR to main ────
   version:
     name: Version
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: develop
+          fetch-depth: 0
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -34,27 +37,40 @@ jobs:
         run: |
           COUNT=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | wc -l | tr -d ' ')
           echo "count=$COUNT" >> $GITHUB_OUTPUT
+          if [ "$COUNT" = "0" ]; then
+            echo "No pending changesets found. Nothing to release."
+          else
+            echo "Found $COUNT pending changeset(s)"
+          fi
 
-      - name: Version packages and create release PR
+      - name: Version packages
         if: steps.changesets.outputs.count != '0'
         run: |
           pnpm changeset version
           VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "chore(release): version packages for v${VERSION}" --no-verify
           git push origin develop --no-verify
+        id: version
 
+      - name: Create or update release PR
+        if: steps.changesets.outputs.count != '0'
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
           EXISTING=$(gh pr list --base main --head develop --json number --jq '.[0].number')
+          BODY=$(printf '## Release v%s\n\nMerging this PR will:\n1. Build native binaries for all 9 platforms\n2. Publish to npm with provenance\n\n### Changelog\n\n```\n%s\n```' "$VERSION" "$(head -50 CHANGELOG.md)")
+
           if [ -n "$EXISTING" ]; then
-            gh pr edit "$EXISTING" --title "chore(release): release v${VERSION}"
+            gh pr edit "$EXISTING" --title "chore(release): release v${VERSION}" --body "$BODY"
             echo "Updated existing release PR #${EXISTING}"
           else
             gh pr create --base main --head develop \
               --title "chore(release): release v${VERSION}" \
-              --body "$(printf '## Release v%s\n\nMerging this PR will:\n1. Build native binaries for all 9 platforms\n2. Publish to npm with provenance\n\n### Changelog\n\n```\n%s\n```' "$VERSION" "$(head -30 CHANGELOG.md)")"
+              --body "$BODY"
             echo "Created release PR for v${VERSION}"
           fi
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,20 @@
 # rapid-fuzzy
 
-## 0.5.0
-
-### Minor Changes
-
-- 0b29f3f: Add match highlight positions to search results.
-
-  SearchResult now includes a `positions` field containing indices of matched characters. Enable by setting `includePositions: true` in SearchOptions. Positions are computed via nucleo-matcher's indices API, sorted and deduplicated. When not requested, positions is an empty array with zero overhead.
-
-## 0.4.0
-
-### Minor Changes
-
-- dcc313c: Add token-based matching algorithms inspired by Python's RapidFuzz.
-
-  Four new similarity functions: tokenSortRatio (order-independent via sorted tokens), tokenSetRatio (set intersection-based), partialRatio (best substring match via sliding window), and weightedRatio (maximum across all methods). Each includes batch and many variants for efficient bulk comparisons.
-
 ## 0.3.0
 
 ### Minor Changes
 
-- a98d757: Add score threshold filtering to search() and closest() functions.
+- Add score threshold filtering to search() and closest() functions.
 
   search() now accepts a SearchOptions object with maxResults and minScore fields, while maintaining backward compatibility with the existing number argument for maxResults. closest() accepts an optional minScore parameter to return null when the best match is below the threshold.
+
+- Add token-based matching algorithms inspired by Python's RapidFuzz.
+
+  Four new similarity functions: tokenSortRatio (order-independent via sorted tokens), tokenSetRatio (set intersection-based), partialRatio (best substring match via sliding window), and weightedRatio (maximum across all methods). Each includes batch and many variants for efficient bulk comparisons.
+
+- Add match highlight positions to search results.
+
+  SearchResult now includes a `positions` field containing indices of matched characters. Enable by setting `includePositions: true` in SearchOptions. Positions are computed via nucleo-matcher's indices API, sorted and deduplicated. When not requested, positions is an empty array with zero overhead.
 
 ## 0.2.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rapid-fuzzy",
-  "version": "0.5.0",
+  "version": "0.3.0",
   "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
   "license": "MIT",
   "author": "derodero24",


### PR DESCRIPTION
## Summary

- Change the release workflow `version` job from automatic (on develop push) to manual (`workflow_dispatch` only)
- Changesets now accumulate on `develop` until a release is intentionally triggered
- All pending changesets are consumed at once → single version bump
- Fix version 0.5.0 → 0.3.0 (three separate minor bumps consolidated into one)
- Consolidate split CHANGELOG entries (0.3.0, 0.4.0, 0.5.0) into a single 0.3.0 entry

## Expected Release Flow

1. Feature PRs with changesets merge to `develop` → changesets accumulate
2. When ready to release: trigger "Release" workflow manually via `workflow_dispatch`
3. All changesets consumed → single version bump → release PR to `main` created/updated
4. Merge release PR to `main` → build + npm publish

## Closes #137

## Checklist

- [x] Release workflow updated to manual trigger
- [x] Version fixed: 0.5.0 → 0.3.0
- [x] CHANGELOG consolidated into single 0.3.0 entry
- [x] All checks pass (lint, typecheck, test, clippy, cargo test)