### PR TITLE
fix(ci): use changesets/action for automatic version PR management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [develop, main]
   workflow_dispatch:
 
 concurrency:
@@ -15,15 +15,14 @@ permissions:
   id-token: write
 
 jobs:
-  # ──── Manual trigger: version packages and create release PR to main ────
+  # ──── On develop push: manage version PR and create release PR ────
   version:
     name: Version
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: develop
           fetch-depth: 0
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -32,35 +31,27 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
-      - name: Check for changesets
+      - name: Create version PR or detect release
         id: changesets
-        run: |
-          COUNT=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | wc -l | tr -d ' ')
-          echo "count=$COUNT" >> $GITHUB_OUTPUT
-          if [ "$COUNT" = "0" ]; then
-            echo "No pending changesets found. Nothing to release."
-          else
-            echo "Found $COUNT pending changeset(s)"
-          fi
-
-      - name: Version packages
-        if: steps.changesets.outputs.count != '0'
-        run: |
-          pnpm changeset version
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "chore(release): version packages for v${VERSION}" --no-verify
-          git push origin develop --no-verify
-        id: version
+        uses: changesets/action@ce079ea084e08a340947ed4d6ecedb2433c8f293 # v1
+        with:
+          version: pnpm changeset version
+          title: "chore(release): version packages"
+          commit: "chore(release): version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create or update release PR
-        if: steps.changesets.outputs.count != '0'
+        if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           VERSION=$(node -p "require('./package.json').version")
+
+          # Skip if already published
+          if npm view "rapid-fuzzy@${VERSION}" version 2>/dev/null; then
+            echo "Version ${VERSION} already published, skipping release PR"
+            exit 0
+          fi
+
           EXISTING=$(gh pr list --base main --head develop --json number --jq '.[0].number')
           BODY=$(printf '## Release v%s\n\nMerging this PR will:\n1. Build native binaries for all 9 platforms\n2. Publish to npm with provenance\n\n### Changelog\n\n```\n%s\n```' "$VERSION" "$(head -50 CHANGELOG.md)")
 


### PR DESCRIPTION
## Summary

Replace the manual `workflow_dispatch` versioning (from #138) with the official `changesets/action@v1`, matching the proven pattern used in react-web3-icons and many other changesets-based projects.

## Changes

- Use `changesets/action@v1` on develop push to automatically create/update a "Version Packages" PR
- When the Version PR is merged (all changesets consumed at once → single version bump), automatically create a release PR (develop → main)
- Restore `on.push.branches: [develop, main]` trigger (develop for versioning, main for publishing)
- Pin `changesets/action` to commit SHA for supply chain security

## Release Flow

1. Feature PRs with changesets merge to `develop` → changesets accumulate
2. `changesets/action` automatically creates a "Version Packages" PR (`changeset-release/develop` → `develop`)
3. When ready to release: merge the Version PR → all changesets consumed, single version bump
4. Release PR (`develop` → `main`) is automatically created
5. Merge release PR → multi-platform build + npm publish

## Why This Change

PR #138 switched to `workflow_dispatch` to fix the per-push versioning bug. However, `changesets/action` solves the same problem more elegantly by:
- Automatically showing pending releases via the Version PR
- Using the standard changesets pattern (familiar to contributors)
- Matching the approach used in our other OSS project (react-web3-icons)

Closes #137

## Checklist

- [x] Uses `changesets/action@v1` (pinned to SHA)
- [x] Version PR created automatically on develop push
- [x] Release PR created after version is bumped
- [x] All local checks pass