### PR TITLE
perf(core): optimize search with buffer reuse

### DIFF
--- a/.changeset/search-optimization.md
+++ b/.changeset/search-optimization.md
@@ -1,0 +1,5 @@
+---
+"rapid-fuzzy": patch
+---
+
+Optimize search performance by reusing UTF-32 conversion buffers across items and switching to unstable sort. Reduces allocations in the hot scoring loop, yielding ~30% improvement on medium-sized datasets (1K items).

--- a/crates/core/src/search/index.rs
+++ b/crates/core/src/search/index.rs
@@ -110,12 +110,14 @@ impl FuzzyIndex {
         let max_score = compute_max_score(query, &pattern, &mut matcher);
         let threshold = min_score.unwrap_or(0.0);
 
+        let mut buf = Vec::new();
+
         let mut results: Vec<SearchResult> = self
             .items
             .iter()
             .enumerate()
             .filter_map(|(index, item)| {
-                let mut buf = Vec::new();
+                buf.clear();
                 let atoms = nucleo_matcher::Utf32Str::new(item, &mut buf);
 
                 let (raw_score, positions) = if include_positions {
@@ -143,7 +145,7 @@ impl FuzzyIndex {
             })
             .collect();
 
-        results.sort_by(|a, b| {
+        results.sort_unstable_by(|a, b| {
             b.score
                 .partial_cmp(&a.score)
                 .unwrap_or(std::cmp::Ordering::Equal)

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -57,11 +57,13 @@ pub(crate) fn search_impl(
     let max_score = compute_max_score(&query, &pattern, &mut matcher);
     let threshold = min_score.unwrap_or(0.0);
 
+    let mut buf = Vec::new();
+
     let mut results: Vec<SearchResult> = items
         .iter()
         .enumerate()
         .filter_map(|(index, item)| {
-            let mut buf = Vec::new();
+            buf.clear();
             let atoms = nucleo_matcher::Utf32Str::new(item, &mut buf);
 
             let (raw_score, positions) = if include_positions {
@@ -89,7 +91,7 @@ pub(crate) fn search_impl(
         })
         .collect();
 
-    results.sort_by(|a, b| {
+    results.sort_unstable_by(|a, b| {
         b.score
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)


### PR DESCRIPTION
## Summary

- Reuse UTF-32 conversion buffer across items instead of allocating per iteration
- Switch from `sort_by` to `sort_unstable_by` for results sorting
- Same optimizations applied to both standalone `search()` and `FuzzyIndex.search()`

### Benchmark Results

| Dataset | Before | After | Change |
|---|---:|---:|---|
| Search — Small (20) | 179,024 ops/s | 180,554 ops/s | ~0% (noise) |
| Search — Medium (1K) | 4,945 ops/s | 6,559 ops/s | **+33%** |
| Search — Large (10K) | 804 ops/s | 796 ops/s | ~0% (noise) |

The 10K dataset performance is dominated by nucleo-matcher's scoring algorithm. Further improvement at this scale would require algorithmic changes (e.g., early termination, pre-filtering) or parallelism with careful Matcher pooling — tracked as future work.

## Related Issue

Closes #71

## Checklist

- [x] Buffer reuse for UTF-32 conversion in `search_impl`
- [x] Buffer reuse in `FuzzyIndex::search_impl`
- [x] `sort_unstable_by` instead of `sort_by`
- [x] Benchmark each optimization
- [x] No regression in search quality (all 138 Rust + 119 JS tests pass)
- [x] Changeset included