### PR TITLE
fix(ci): disable lefthook in release Version job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
     name: Version
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
+    env:
+      LEFTHOOK: "0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary

Fix the release workflow `Version` job failure caused by lefthook pre-push hooks running during `changesets/action`'s git push.

The `changesets/action` pushes to the `changeset-release/develop` branch, which triggers lefthook's pre-push hooks (test, clippy, cargo-deny). The test hook fails because native binaries are not built in this job.

**Fix**: Set `LEFTHOOK=0` at the job level to skip git hooks. Lint/test checks are already handled by the dedicated CI workflow, so this is safe.

Closes #149

## Checklist

- [x] `LEFTHOOK=0` added to Version job
- [x] All local checks pass