### PR TITLE
fix: revert version 0.4.0 back to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,5 @@
 # rapid-fuzzy
 
-## 0.4.0
-
-### Minor Changes
-
-- 4645a6d: Add FuzzyIndex class for persistent indexed search.
-
-  A Rust-backed class that holds items in memory, eliminating repeated FFI overhead for applications searching the same dataset multiple times. Supports search with all existing options (maxResults, minScore, includePositions), closest match, and incremental updates via add/addMany/remove methods.
-
-### Patch Changes
-
-- ca38f81: Optimize search performance by reusing UTF-32 conversion buffers across items and switching to unstable sort. Reduces allocations in the hot scoring loop, yielding ~30% improvement on medium-sized datasets (1K items).
-
 ## 0.3.0
 
 ### Minor Changes
@@ -27,6 +15,14 @@
 - Add match highlight positions to search results.
 
   SearchResult now includes a `positions` field containing indices of matched characters. Enable by setting `includePositions: true` in SearchOptions. Positions are computed via nucleo-matcher's indices API, sorted and deduplicated. When not requested, positions is an empty array with zero overhead.
+
+- Add FuzzyIndex class for persistent indexed search.
+
+  A Rust-backed class that holds items in memory, eliminating repeated FFI overhead for applications searching the same dataset multiple times. Supports search with all existing options (maxResults, minScore, includePositions), closest match, and incremental updates via add/addMany/remove methods.
+
+### Patch Changes
+
+- Optimize search performance by reusing UTF-32 conversion buffers across items and switching to unstable sort. Reduces allocations in the hot scoring loop, yielding ~30% improvement on medium-sized datasets (1K items).
 
 ## 0.2.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rapid-fuzzy",
-  "version": "0.4.0",
+  "version": "0.3.0",
   "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
   "license": "MIT",
   "author": "derodero24",


### PR DESCRIPTION
## Summary

Revert version from 0.4.0 back to 0.3.0. The `changesets/action` (#151) incorrectly bumped the unreleased 0.3.0 to 0.4.0.

Since 0.3.0 was never published to npm (current published version: 0.2.0), all accumulated minor changes should be released as a single 0.3.0.

### Changes

- `package.json`: 0.4.0 → 0.3.0
- `CHANGELOG.md`: Consolidate 0.4.0 entries into 0.3.0

## Checklist

- [x] Version reverted to 0.3.0
- [x] CHANGELOG consolidated
- [x] All checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CHANGELOG with 0.4.0 release information, including FuzzyIndex class entry describing an in-memory item store with persistent indexed search capabilities, search options, closest match functionality, and incremental updates support.

* **Chores**
  * Adjusted version number to 0.3.0 in package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->