### PR TITLE
docs(bench): update README benchmarks and add automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 | Function | rapid-fuzzy | fastest-levenshtein | leven | string-similarity |
 |---|---:|---:|---:|---:|
-| Levenshtein | 67,346 ops/s | **243,026 ops/s** | 51,789 ops/s | — |
-| Normalized Levenshtein | **64,592 ops/s** | — | — | — |
-| Sorensen-Dice | **61,050 ops/s** | — | — | 40,241 ops/s |
-| Jaro-Winkler | **198,140 ops/s** | — | — | — |
-| Damerau-Levenshtein | **58,888 ops/s** | — | — | — |
+| Levenshtein | 193,593 ops/s | **774,820 ops/s** | 204,047 ops/s | — |
+| Normalized Levenshtein | **136,854 ops/s** | — | — | — |
+| Sorensen-Dice | **144,698 ops/s** | — | — | 84,108 ops/s |
+| Jaro-Winkler | **291,673 ops/s** | — | — | — |
+| Damerau-Levenshtein | **72,238 ops/s** | — | — | — |
 
 > **Note**: For single-pair Levenshtein distance, fastest-levenshtein is faster due to its highly optimized pure-JS implementation that avoids FFI overhead. rapid-fuzzy provides broader algorithm coverage and excels in batch / search scenarios.
 
@@ -147,23 +147,23 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 | Dataset size | rapid-fuzzy | fuse.js | fuzzysort |
 |---|---:|---:|---:|
-| 20 items | 171,967 ops/s | 121,978 ops/s | **2,537,323 ops/s** |
-| 1,000 items | 4,941 ops/s | 376 ops/s | **55,388 ops/s** |
-| 10,000 items | 588 ops/s | 14 ops/s | **15,005 ops/s** |
+| Small (20 items) | 179,222 ops/s | 109,059 ops/s | **2,501,773 ops/s** |
+| Medium (1K items) | 6,614 ops/s | 381 ops/s | **63,032 ops/s** |
+| Large (10K items) | 794 ops/s | 20 ops/s | **28,616 ops/s** |
 
 ### Closest Match (Levenshtein-based)
 
 | Dataset size | rapid-fuzzy | fastest-levenshtein |
 |---|---:|---:|
-| 1,000 items | **5,912 ops/s** | 3,974 ops/s |
-| 10,000 items | **387 ops/s** | 126 ops/s |
+| Medium (1K items) | 8,416 ops/s | **8,762 ops/s** |
+| Large (10K items) | **905 ops/s** | 662 ops/s |
 
-> rapid-fuzzy is up to **3x faster** than fastest-levenshtein for closest-match lookups on large datasets.
+> rapid-fuzzy is up to **1.4x faster** than fastest-levenshtein for closest-match lookups on large datasets.
 
 ### Why these numbers matter
 
-- **vs fuse.js**: rapid-fuzzy is **13x faster** on medium datasets and **41x faster** on large datasets for fuzzy search.
-- **vs fastest-levenshtein**: rapid-fuzzy wins on closest-match (1.5–3x faster) where batch FFI overhead is amortized.
+- **vs fuse.js**: rapid-fuzzy is **17x faster** on medium datasets and **40x faster** on large datasets for fuzzy search.
+- **vs fastest-levenshtein**: rapid-fuzzy wins on closest-match at scale where batch FFI overhead is amortized.
 - **fuzzysort** uses a different (substring-based) matching algorithm that is extremely fast but produces different ranking results. Choose based on your matching needs.
 
 Run benchmarks yourself:

--- a/biome.json
+++ b/biome.json
@@ -77,6 +77,19 @@
       }
     },
     {
+      "includes": ["scripts/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          },
+          "style": {
+            "noDefaultExport": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["index.d.mts"],
       "linter": {
         "rules": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test:wasm": "vitest run __test__/wasm.spec.ts",
     "test:watch": "vitest watch",
     "bench": "vitest bench",
+    "bench:readme": "npx tsx scripts/update-bench-readme.ts",
     "publint": "publint",
     "bench:rust": "cargo bench -p rapid-fuzzy-bench",
     "verify": "pnpm run check && cargo clippy -- -W clippy::all && cargo test && pnpm run build && pnpm run typecheck && pnpm test",

--- a/scripts/update-bench-readme.ts
+++ b/scripts/update-bench-readme.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env npx tsx
+/**
+ * Run benchmarks and update README.md with the latest numbers.
+ *
+ * Usage:
+ *   pnpm bench:readme          # run benchmarks and update README
+ *   npx tsx scripts/update-bench-readme.ts
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+// ---------------------------------------------------------------------------
+// 1. Run benchmarks and capture output
+// ---------------------------------------------------------------------------
+
+console.log('Running benchmarks…');
+const raw = execSync('pnpm run bench', {
+  encoding: 'utf-8',
+  timeout: 600_000,
+  env: { ...process.env, FORCE_COLOR: '0' },
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+
+// Strip ANSI escape codes
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape stripping requires matching ESC (0x1B)
+const clean = raw.replace(/\x1b\[[0-9;]*m/g, '');
+
+// ---------------------------------------------------------------------------
+// 2. Parse results — extract (name, hz) from each "· name  hz …" line
+// ---------------------------------------------------------------------------
+
+interface BenchEntry {
+  name: string;
+  hz: number;
+}
+
+const entries: BenchEntry[] = [];
+for (const line of clean.split('\n')) {
+  //  "   · rapid-fuzzy  179,371.64  …"
+  const m = line.match(/^\s+·\s+(.+?)\s{2,}([\d,]+(?:\.\d+)?)\s/);
+  if (m) {
+    entries.push({ name: m[1].trim(), hz: Number(m[2].replace(/,/g, '')) });
+  }
+}
+
+// Group by benchmark suite (detect suite headers)
+interface Suite {
+  suite: string;
+  results: Map<string, number>;
+}
+
+const suites: Suite[] = [];
+let currentSuite = '';
+let currentMap = new Map<string, number>();
+
+for (const line of clean.split('\n')) {
+  // "  ✓ __test__/search.bench.ts > Fuzzy Search — Small (20 items)"
+  const sm = line.match(/[✓]\s+\S+\s+>\s+(.+?)(?:\s+\d+ms)?$/);
+  if (sm) {
+    if (currentSuite) {
+      suites.push({ suite: currentSuite, results: currentMap });
+    }
+    currentSuite = sm[1].trim();
+    currentMap = new Map();
+    continue;
+  }
+  const em = line.match(/^\s+·\s+(.+?)\s{2,}([\d,]+(?:\.\d+)?)\s/);
+  if (em && currentSuite) {
+    currentMap.set(em[1].trim(), Number(em[2].replace(/,/g, '')));
+  }
+}
+if (currentSuite) {
+  suites.push({ suite: currentSuite, results: currentMap });
+}
+
+// ---------------------------------------------------------------------------
+// 3. Build markdown tables
+// ---------------------------------------------------------------------------
+
+function fmt(n: number): string {
+  return Math.round(n).toLocaleString('en-US');
+}
+
+function best(vals: (number | null)[]): number {
+  return Math.max(...vals.filter((v): v is number => v !== null));
+}
+
+function cell(val: number | null, isBest: boolean): string {
+  if (val === null) return '—';
+  const s = `${fmt(val)} ops/s`;
+  return isBest ? `**${s}**` : s;
+}
+
+function findSuite(name: string): Map<string, number> | undefined {
+  return suites.find((s) => s.suite === name)?.results;
+}
+
+// Distance table
+const distLines: string[] = [];
+distLines.push('| Function | rapid-fuzzy | fastest-levenshtein | leven | string-similarity |');
+distLines.push('|---|---:|---:|---:|---:|');
+
+const levSuite = findSuite('Levenshtein Distance');
+const normSuite = findSuite('Normalized Similarity');
+const jaroSuite = findSuite('Jaro / Jaro-Winkler');
+const damerauSuite = findSuite('Damerau-Levenshtein');
+
+if (levSuite) {
+  const rf = levSuite.get('rapid-fuzzy') ?? null;
+  const fl = levSuite.get('fastest-levenshtein') ?? null;
+  const lv = levSuite.get('leven') ?? null;
+  const b = best([rf, fl, lv]);
+  distLines.push(
+    `| Levenshtein | ${cell(rf, rf === b)} | ${cell(fl, fl === b)} | ${cell(lv, lv === b)} | — |`,
+  );
+}
+if (normSuite) {
+  const nl = normSuite.get('rapid-fuzzy (normalizedLevenshtein)') ?? null;
+  distLines.push(`| Normalized Levenshtein | ${cell(nl, true)} | — | — | — |`);
+
+  const sd = normSuite.get('rapid-fuzzy (sorensenDice)') ?? null;
+  const ss = normSuite.get('string-similarity (compareTwoStrings / Dice)') ?? null;
+  const b = best([sd, ss]);
+  distLines.push(
+    `| Sorensen-Dice | ${cell(sd, sd !== null && sd >= b)} | — | — | ${cell(ss, ss !== null && ss >= b)} |`,
+  );
+}
+if (jaroSuite) {
+  const jw = jaroSuite.get('rapid-fuzzy (jaroWinkler)') ?? null;
+  distLines.push(`| Jaro-Winkler | ${cell(jw, true)} | — | — | — |`);
+}
+if (damerauSuite) {
+  const dl = damerauSuite.get('rapid-fuzzy') ?? null;
+  distLines.push(`| Damerau-Levenshtein | ${cell(dl, true)} | — | — | — |`);
+}
+
+// Search table
+const searchLines: string[] = [];
+searchLines.push('| Dataset size | rapid-fuzzy | fuse.js | fuzzysort |');
+searchLines.push('|---|---:|---:|---:|');
+
+for (const size of ['Small (20 items)', 'Medium (1K items)', 'Large (10K items)']) {
+  const s = findSuite(`Fuzzy Search — ${size}`);
+  if (!s) continue;
+  const rf = s.get('rapid-fuzzy') ?? null;
+  const fj = s.get('fuse.js') ?? null;
+  const fs = s.get('fuzzysort') ?? null;
+  const b = best([rf, fj, fs]);
+  searchLines.push(
+    `| ${size.replace(/\s*\(/, ' (').replace(' items)', ' items)')} | ${cell(rf, rf === b)} | ${cell(fj, fj === b)} | ${cell(fs, fs === b)} |`,
+  );
+}
+
+// Closest table
+const closestLines: string[] = [];
+closestLines.push('| Dataset size | rapid-fuzzy | fastest-levenshtein |');
+closestLines.push('|---|---:|---:|');
+
+for (const size of ['Medium (1K items)', 'Large (10K items)']) {
+  const s = findSuite(`Closest Match — ${size}`);
+  if (!s) continue;
+  const rf = s.get('rapid-fuzzy') ?? null;
+  const fl = s.get('fastest-levenshtein') ?? null;
+  const b = best([rf, fl].filter((v): v is number => v !== null));
+  closestLines.push(
+    `| ${size} | ${cell(rf, rf !== null && rf >= b)} | ${cell(fl, fl !== null && fl >= b)} |`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Replace tables in README
+// ---------------------------------------------------------------------------
+
+const readmePath = 'README.md';
+let readme = readFileSync(readmePath, 'utf-8');
+
+function replaceSection(
+  content: string,
+  afterLiteral: string,
+  beforeLiteral: string,
+  table: string,
+): string {
+  const afterIdx = content.indexOf(afterLiteral);
+  if (afterIdx === -1) {
+    console.warn(`  ⚠ Could not find "${afterLiteral}"`);
+    return content;
+  }
+  // Find the first table after the header (starts with "|")
+  const afterEnd = content.indexOf('\n\n', afterIdx) + 2;
+  const tableStart = content.indexOf('|', afterEnd);
+
+  const beforeIdx = content.indexOf(beforeLiteral, tableStart);
+  if (beforeIdx === -1) {
+    console.warn(`  ⚠ Could not find "${beforeLiteral}"`);
+    return content;
+  }
+  // Go back to find the end of the table (last line before beforeLiteral)
+  const tableEnd = content.lastIndexOf('\n', beforeIdx - 2) + 1;
+
+  return `${content.slice(0, tableStart)}${table}\n\n${content.slice(tableEnd)}`;
+}
+
+readme = replaceSection(readme, '### Distance Functions', '> **Note**', distLines.join('\n'));
+readme = replaceSection(
+  readme,
+  '### Search Performance',
+  '### Closest Match',
+  searchLines.join('\n'),
+);
+readme = replaceSection(
+  readme,
+  '### Closest Match (Levenshtein-based)',
+  '> rapid-fuzzy is',
+  closestLines.join('\n'),
+);
+
+writeFileSync(readmePath, readme);
+console.log('✓ README.md updated with latest benchmark numbers.');


### PR DESCRIPTION
## Summary

- Update all README benchmark tables with numbers from current codebase (v0.4.0)
- Add `scripts/update-bench-readme.ts` for automated README benchmark updates
- Add `pnpm bench:readme` npm script
- Update competitive comparison multipliers to match new data
- Add biome override for scripts/ directory

### Updated Numbers

**Distance Functions:**
| Function | Before | After |
|---|---|---|
| Levenshtein | 67,346 | 193,593 |
| Jaro-Winkler | 198,140 | 291,673 |

**Search:**
| Dataset | Before | After |
|---|---|---|
| Medium (1K) | 4,941 | 6,614 (+34%) |
| Large (10K) | 588 | 794 (+35%) |

**Closest Match:**
| Dataset | Before | After |
|---|---|---|
| Large (10K) | 387 | 905 (+134%) |

### Automation

```bash
pnpm bench:readme   # run benchmarks and update README in one step
```

## Related Issue

Closes #152

## Checklist

- [x] All benchmark tables updated
- [x] Competitive comparison multipliers recalculated
- [x] `scripts/update-bench-readme.ts` automation script
- [x] `bench:readme` npm script
- [x] biome override for scripts/
- [x] All checks pass