### PR TITLE
feat(core): add searchObjects for ergonomic object search

### DIFF
--- a/.changeset/add-search-objects.md
+++ b/.changeset/add-search-objects.md
@@ -1,0 +1,5 @@
+---
+"rapid-fuzzy": minor
+---
+
+Add `searchObjects` function for ergonomic object array search with weighted keys

--- a/__test__/objects.spec.ts
+++ b/__test__/objects.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+const { searchObjects } = require('../objects.js');
+
+const users = [
+  { name: 'John Smith', email: 'john@example.com', role: 'admin' },
+  { name: 'Jane Doe', email: 'jane@example.com', role: 'user' },
+  { name: 'Bob Johnson', email: 'bob@test.com', role: 'admin' },
+];
+
+describe('searchObjects', () => {
+  it('should find matches across multiple keys', () => {
+    const results = searchObjects('john', users, {
+      keys: ['name', 'email'],
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.item.name).toBe('John Smith');
+  });
+
+  it('should return original objects as items', () => {
+    const results = searchObjects('jane', users, {
+      keys: ['name'],
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.item).toBe(users[1]);
+  });
+
+  it('should accept string keys with equal weight', () => {
+    const results = searchObjects('john', users, {
+      keys: ['name', 'email'],
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.keyScores).toHaveLength(2);
+  });
+
+  it('should accept weighted key objects', () => {
+    const results = searchObjects('john', users, {
+      keys: [
+        { name: 'name', weight: 2.0 },
+        { name: 'email', weight: 1.0 },
+      ],
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.item.name).toBe('John Smith');
+  });
+
+  it('should accept mixed string and weighted keys', () => {
+    const results = searchObjects('john', users, {
+      keys: ['name', { name: 'email', weight: 0.5 }],
+    });
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('should respect maxResults', () => {
+    const results = searchObjects('o', users, {
+      keys: ['name', 'email'],
+      maxResults: 1,
+    });
+    expect(results.length).toBeLessThanOrEqual(1);
+  });
+
+  it('should respect minScore', () => {
+    const results = searchObjects('john', users, {
+      keys: ['name'],
+      minScore: 0.5,
+    });
+    for (const r of results) {
+      expect(r.score).toBeGreaterThanOrEqual(0.5);
+    }
+  });
+
+  it('should return scores in 0.0-1.0 range', () => {
+    const results = searchObjects('john', users, {
+      keys: ['name', 'email'],
+    });
+    for (const r of results) {
+      expect(r.score).toBeGreaterThanOrEqual(0);
+      expect(r.score).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('should return sorted results (best first)', () => {
+    const results = searchObjects('john', users, {
+      keys: ['name', 'email'],
+    });
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1]?.score).toBeGreaterThanOrEqual(results[i]?.score ?? 0);
+    }
+  });
+
+  it('should return empty for empty query', () => {
+    const results = searchObjects('', users, { keys: ['name'] });
+    expect(results).toEqual([]);
+  });
+
+  it('should return empty for empty items', () => {
+    const results = searchObjects('test', [], { keys: ['name'] });
+    expect(results).toEqual([]);
+  });
+
+  it('should support nested key paths', () => {
+    const items = [
+      { name: 'Alice', address: { city: 'New York', state: 'NY' } },
+      { name: 'Bob', address: { city: 'Los Angeles', state: 'CA' } },
+    ];
+    const results = searchObjects('new york', items, {
+      keys: ['address.city'],
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.item.name).toBe('Alice');
+  });
+
+  it('should handle missing nested keys gracefully', () => {
+    const items = [{ name: 'Alice', meta: { tag: 'hello' } }, { name: 'Bob' }] as Array<{
+      name: string;
+      meta?: { tag: string };
+    }>;
+    const results = searchObjects('hello', items, {
+      keys: ['meta.tag'],
+    });
+    expect(results.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should support isCaseSensitive option', () => {
+    const results = searchObjects('john', users, {
+      keys: ['name'],
+      isCaseSensitive: true,
+      minScore: 1.0,
+    });
+    // 'john' (lowercase) won't exactly match 'John Smith' in case-sensitive mode
+    expect(results.length).toBe(0);
+  });
+
+  it('should match single-key results with searchKeys', () => {
+    const { searchKeys } = require('../index.js');
+    const names = users.map((u) => u.name);
+    const objResults = searchObjects('john', users, { keys: ['name'] });
+    const keyResults = searchKeys('john', [names], [1.0]);
+    expect(objResults.length).toBe(keyResults.length);
+    for (let i = 0; i < objResults.length; i++) {
+      expect(objResults[i]?.index).toBe(keyResults[i]?.index);
+      expect(objResults[i]?.score).toBeCloseTo(keyResults[i]?.score ?? 0);
+    }
+  });
+});

--- a/biome.json
+++ b/biome.json
@@ -57,6 +57,16 @@
   },
   "overrides": [
     {
+      "includes": ["index.mjs"],
+      "linter": {
+        "rules": {
+          "performance": {
+            "noBarrelFile": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": [
         "vitest.config.mts",
         "commitlint.config.ts",

--- a/index.d.mts
+++ b/index.d.mts
@@ -1,3 +1,5 @@
 export * from './index.d.ts';
 export { highlight, highlightRanges } from './highlight.d.ts';
 export type { HighlightRange } from './highlight.d.ts';
+export { searchObjects } from './objects';
+export type { KeyConfig, ObjectSearchOptions, ObjectSearchResult } from './objects';

--- a/index.mjs
+++ b/index.mjs
@@ -41,3 +41,5 @@ export const {
   highlight,
   highlightRanges,
 } = { ...binding, ...require('./highlight.js') };
+
+export const { searchObjects } = require('./objects.js');

--- a/objects.d.ts
+++ b/objects.d.ts
@@ -1,0 +1,42 @@
+import type { SearchOptions } from './index';
+
+export interface KeyConfig {
+  name: string;
+  weight?: number;
+}
+
+export interface ObjectSearchOptions extends SearchOptions {
+  keys: Array<string | KeyConfig>;
+}
+
+export interface ObjectSearchResult<T> {
+  item: T;
+  index: number;
+  score: number;
+  keyScores: Array<number>;
+}
+
+/**
+ * Perform fuzzy search across object arrays with weighted keys.
+ *
+ * Wraps `searchKeys()` with an ergonomic API that accepts row-oriented
+ * objects and returns matched items directly.
+ *
+ * @example
+ * ```typescript
+ * const users = [
+ *   { name: 'John Smith', email: 'john@example.com' },
+ *   { name: 'Jane Doe', email: 'jane@example.com' },
+ * ];
+ *
+ * const results = searchObjects('john', users, {
+ *   keys: [{ name: 'name', weight: 2.0 }, 'email'],
+ * });
+ * // results[0].item → { name: 'John Smith', email: 'john@example.com' }
+ * ```
+ */
+export declare function searchObjects<T>(
+  query: string,
+  items: Array<T>,
+  options: ObjectSearchOptions,
+): Array<ObjectSearchResult<T>>;

--- a/objects.js
+++ b/objects.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { searchKeys } = require('./index.js');
+
+/**
+ * Get a nested property value from an object using a dot-separated path.
+ * @param {Record<string, unknown>} obj
+ * @param {string} path
+ * @returns {string}
+ */
+function getNestedValue(obj, path) {
+  let current = obj;
+  for (const key of path.split('.')) {
+    if (current == null) return '';
+    current = current[key];
+  }
+  return current == null ? '' : String(current);
+}
+
+/**
+ * Perform fuzzy search across object arrays with weighted keys.
+ *
+ * Wraps `searchKeys()` with an ergonomic API that accepts row-oriented
+ * objects and returns matched items directly.
+ *
+ * @template T
+ * @param {string} query - The search query.
+ * @param {T[]} items - Array of objects to search.
+ * @param {object} options - Search options with keys configuration.
+ * @param {Array<string | { name: string; weight?: number }>} options.keys - Keys to search.
+ * @param {number} [options.maxResults] - Maximum results to return.
+ * @param {number} [options.minScore] - Minimum score threshold.
+ * @param {boolean} [options.isCaseSensitive] - Enable case-sensitive matching.
+ * @returns {Array<{ item: T; index: number; score: number; keyScores: number[] }>}
+ */
+function searchObjects(query, items, options) {
+  const { keys, ...searchOpts } = options;
+
+  const normalizedKeys = keys.map((k) =>
+    typeof k === 'string' ? { name: k, weight: 1.0 } : { name: k.name, weight: k.weight ?? 1.0 },
+  );
+
+  const keyTexts = normalizedKeys.map((k) => items.map((item) => getNestedValue(item, k.name)));
+  const weights = normalizedKeys.map((k) => k.weight);
+
+  const nativeOpts =
+    searchOpts.maxResults != null ||
+    searchOpts.minScore != null ||
+    searchOpts.isCaseSensitive != null
+      ? searchOpts
+      : undefined;
+
+  const results = searchKeys(query, keyTexts, weights, nativeOpts);
+
+  return results.map((r) => ({
+    item: items[r.index],
+    index: r.index,
+    score: r.score,
+    keyScores: r.keyScores,
+  }));
+}
+
+module.exports = { searchObjects };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "index.mjs",
     "index.d.ts",
     "index.d.mts",
+    "objects.js",
+    "objects.d.ts",
     "browser.js",
     "highlight.js",
     "highlight.mjs",


### PR DESCRIPTION
## Summary

- Add `searchObjects()` function that wraps `searchKeys()` with a fuse.js-like ergonomic API
- Accepts row-oriented object arrays with declarative `keys` option (string or weighted)
- Supports nested key paths (e.g., `'address.city'`)
- Returns original objects in results via `item` property
- Pure JS/TS implementation — no Rust changes needed

### Usage

```typescript
import { searchObjects } from 'rapid-fuzzy';

const users = [
  { name: 'John Smith', email: 'john@example.com' },
  { name: 'Jane Doe', email: 'jane@example.com' },
];

const results = searchObjects('john', users, {
  keys: [{ name: 'name', weight: 2.0 }, 'email'],
});
// results[0].item → { name: 'John Smith', email: 'john@example.com' }
```

## Related issue

Closes #161

## Checklist

- [x] `searchObjects()` with type-safe key extraction
- [x] String keys (equal weight) and weighted key objects
- [x] Nested key paths (`'address.city'`)
- [x] Original objects returned via `item` property
- [x] CJS (`objects.js`) + ESM re-export (`index.mjs`)
- [x] Type definitions with generics (`objects.d.ts`)
- [x] 15 unit tests including parity with `searchKeys`
- [x] All checks pass (biome, typecheck, vitest, clippy, cargo test)
- [x] Changeset added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `searchObjects` function for fuzzy searching object arrays with configurable weighted keys and nested property support.
  * Returns enriched results including matched items, indices, overall scores, and per-key scores.
  * Supports maxResults, minScore, and case sensitivity control options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->