### PR TITLE
fix(core): pass all search options through in searchObjects

### DIFF
--- a/__test__/objects.spec.ts
+++ b/__test__/objects.spec.ts
@@ -118,7 +118,9 @@ describe('searchObjects', () => {
     const results = searchObjects('hello', items, {
       keys: ['meta.tag'],
     });
-    expect(results.length).toBeGreaterThanOrEqual(0);
+    // Should find Alice (has meta.tag: 'hello') but not crash on Bob (missing meta)
+    expect(results.length).toBe(1);
+    expect(results[0]?.item.name).toBe('Alice');
   });
 
   it('should support isCaseSensitive option', () => {

--- a/objects.js
+++ b/objects.js
@@ -43,12 +43,7 @@ function searchObjects(query, items, options) {
   const keyTexts = normalizedKeys.map((k) => items.map((item) => getNestedValue(item, k.name)));
   const weights = normalizedKeys.map((k) => k.weight);
 
-  const nativeOpts =
-    searchOpts.maxResults != null ||
-    searchOpts.minScore != null ||
-    searchOpts.isCaseSensitive != null
-      ? searchOpts
-      : undefined;
+  const nativeOpts = Object.keys(searchOpts).length > 0 ? searchOpts : undefined;
 
   const results = searchKeys(query, keyTexts, weights, nativeOpts);
 


### PR DESCRIPTION
## Summary

- Fix `nativeOpts` conditional in `searchObjects()` to forward all options (including `includePositions`) instead of only checking specific fields
- Strengthen the "missing nested keys" test assertion from vacuous `toBeGreaterThanOrEqual(0)` to specific match verification

## Related issue

Closes #169
Follow-up from CodeRabbit review on #165

## Checklist

- [x] Fix option passthrough bug
- [x] Strengthen test assertion
- [x] All checks pass