### PR TITLE
fix(ci): add explicit tool input for taiki-e/install-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,9 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: taiki-e/install-action@3ba22c660d7a3fe71d40eeb5830575b980204503 # cargo-llvm-cov
+      - uses: taiki-e/install-action@3ba22c660d7a3fe71d40eeb5830575b980204503
+        with:
+          tool: cargo-llvm-cov
       - name: Rust coverage
         run: cargo llvm-cov --lcov --output-path rust-lcov.info
 


### PR DESCRIPTION
## Summary

- Add explicit `with: tool: cargo-llvm-cov` to `taiki-e/install-action` in the Coverage job
- Newer versions of `install-action` no longer parse the YAML comment (`# cargo-llvm-cov`) as a tool specification
- This fix unblocks the Renovate digest update PR #167

## Checklist

- [x] Coverage job should now install `cargo-llvm-cov` correctly
- [x] Unblocks #167 (taiki-e/install-action digest update)