### PR TITLE
fix(docs): update fuse.js benchmark comparison text

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ cargo bench           # Rust internal benchmarks
 Switching from another library? These guides provide API mapping tables, code examples, and performance comparisons:
 
 - [**From string-similarity**](docs/migration/from-string-similarity.md) — Same Dice coefficient algorithm, now maintained and faster
-- [**From fuse.js**](docs/migration/from-fuse-js.md) — 13–41x faster fuzzy search with a simpler API
+- [**From fuse.js**](docs/migration/from-fuse-js.md) — 17–40x faster fuzzy search with a simpler API
 - [**From leven / fastest-levenshtein**](docs/migration/from-leven.md) — Multi-algorithm upgrade with batch APIs
 
 ## License


### PR DESCRIPTION
## Summary

- Fix migration guide link text: "13–41x faster" → "17–40x faster" to match current benchmark data

Follow-up from CodeRabbit review on #173.

## Checklist

- [x] Text matches benchmark tables in README and from-fuse-js.md