### PR TITLE
refactor(core): consolidate search_impl into shared function

### DIFF
--- a/crates/core/src/search/index.rs
+++ b/crates/core/src/search/index.rs
@@ -1,9 +1,8 @@
 use napi::Either;
 use napi_derive::napi;
-use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
-use nucleo_matcher::{Config, Matcher};
+use nucleo_matcher::pattern::CaseMatching;
 
-use super::{SearchOptions, SearchResult, compute_max_score, resolve_case_matching};
+use super::{SearchOptions, SearchResult, resolve_case_matching, search_over_items};
 
 /// A persistent fuzzy search index backed by Rust-side data.
 ///
@@ -109,61 +108,14 @@ impl FuzzyIndex {
         include_positions: bool,
         case_matching: CaseMatching,
     ) -> Vec<SearchResult> {
-        if query.is_empty() || self.items.is_empty() {
-            return Vec::new();
-        }
-
-        let mut matcher = Matcher::new(Config::DEFAULT);
-        let pattern = Pattern::parse(query, case_matching, Normalization::Smart);
-        let max_score = compute_max_score(query, &pattern, &mut matcher);
-        let threshold = min_score.unwrap_or(0.0);
-
-        let mut buf = Vec::new();
-
-        let mut results: Vec<SearchResult> = self
-            .items
-            .iter()
-            .enumerate()
-            .filter_map(|(index, item)| {
-                buf.clear();
-                let atoms = nucleo_matcher::Utf32Str::new(item, &mut buf);
-
-                let (raw_score, positions) = if include_positions {
-                    let mut indices = Vec::new();
-                    let score = pattern.indices(atoms, &mut matcher, &mut indices)?;
-                    indices.sort_unstable();
-                    indices.dedup();
-                    (score, indices)
-                } else {
-                    let score = pattern.score(atoms, &mut matcher)?;
-                    (score, Vec::new())
-                };
-
-                let normalized = (raw_score as f64 / max_score).min(1.0);
-                if normalized >= threshold {
-                    Some(SearchResult {
-                        item: item.clone(),
-                        score: normalized,
-                        index: index as u32,
-                        positions,
-                    })
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        results.sort_unstable_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-
-        if let Some(max) = max_results {
-            results.truncate(max as usize);
-        }
-
-        results
+        search_over_items(
+            query,
+            &self.items,
+            max_results,
+            min_score,
+            include_positions,
+            case_matching,
+        )
     }
 }
 

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -53,10 +53,13 @@ pub(crate) fn resolve_case_matching(is_case_sensitive: Option<bool>) -> CaseMatc
     }
 }
 
-/// Internal search implementation used by both the napi export and tests.
-pub(crate) fn search_impl(
-    query: String,
-    items: Vec<String>,
+/// Shared search logic over a borrowed slice of items.
+///
+/// Both the standalone `search_impl` and `FuzzyIndex::search_impl` delegate
+/// to this function, which contains the core scoring/filtering/sorting logic.
+pub(crate) fn search_over_items(
+    query: &str,
+    items: &[String],
     max_results: Option<u32>,
     min_score: Option<f64>,
     include_positions: bool,
@@ -67,8 +70,8 @@ pub(crate) fn search_impl(
     }
 
     let mut matcher = Matcher::new(Config::DEFAULT);
-    let pattern = Pattern::parse(&query, case_matching, Normalization::Smart);
-    let max_score = compute_max_score(&query, &pattern, &mut matcher);
+    let pattern = Pattern::parse(query, case_matching, Normalization::Smart);
+    let max_score = compute_max_score(query, &pattern, &mut matcher);
     let threshold = min_score.unwrap_or(0.0);
 
     let mut buf = Vec::new();
@@ -116,6 +119,25 @@ pub(crate) fn search_impl(
     }
 
     results
+}
+
+/// Internal search implementation used by both the napi export and tests.
+pub(crate) fn search_impl(
+    query: String,
+    items: Vec<String>,
+    max_results: Option<u32>,
+    min_score: Option<f64>,
+    include_positions: bool,
+    case_matching: CaseMatching,
+) -> Vec<SearchResult> {
+    search_over_items(
+        &query,
+        &items,
+        max_results,
+        min_score,
+        include_positions,
+        case_matching,
+    )
 }
 
 /// Perform fuzzy search over a list of strings.


### PR DESCRIPTION
## Summary

- Extract shared `search_over_items()` function that takes borrowed `&str` and `&[String]`
- Both standalone `search_impl()` and `FuzzyIndex::search_impl()` now delegate to it
- Eliminates ~50 lines of duplicated scoring/filtering/sorting logic
- Removes unused imports from `index.rs`

Closes #176

## Checklist

- [x] `cargo test` — 160 tests pass
- [x] `cargo clippy -- -W clippy::all` — no warnings
- [x] No public API changes
- [x] Pre-push hooks pass (lint, typecheck, test, cargo-test, clippy, cargo-deny)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal search implementation architecture for improved code maintainability and shared logic efficiency. All existing search functionality and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->