### PR TITLE
test(core): add missing batch and WASM search test coverage

### DIFF
--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -543,6 +543,10 @@ describe('token-based matching', () => {
       expect(result[0]).toBe(1.0);
       expect(result[1]).toBeLessThan(0.5);
     });
+
+    it('should return empty array for empty input', () => {
+      expect(tokenSortRatioBatch([])).toEqual([]);
+    });
   });
 
   describe('tokenSortRatioMany', () => {
@@ -581,6 +585,10 @@ describe('token-based matching', () => {
       ]);
       expect(result[0]).toBe(1.0);
       expect(result[1]).toBeLessThan(0.5);
+    });
+
+    it('should return empty array for empty input', () => {
+      expect(tokenSetRatioBatch([])).toEqual([]);
     });
   });
 
@@ -627,6 +635,10 @@ describe('token-based matching', () => {
       expect(result[0]).toBe(1.0);
       expect(result[1]).toBeLessThan(0.5);
     });
+
+    it('should return empty array for empty input', () => {
+      expect(partialRatioBatch([])).toEqual([]);
+    });
   });
 
   describe('partialRatioMany', () => {
@@ -669,6 +681,10 @@ describe('token-based matching', () => {
       ]);
       expect(result[0]).toBe(1.0);
       expect(result[1]).toBeLessThan(0.5);
+    });
+
+    it('should return empty array for empty input', () => {
+      expect(weightedRatioBatch([])).toEqual([]);
     });
   });
 

--- a/__test__/wasm.spec.ts
+++ b/__test__/wasm.spec.ts
@@ -267,5 +267,21 @@ describe.skipIf(!wasmExists)('wasm', () => {
       ];
       expect(wasm.levenshteinBatch(pairs)).toEqual(native.levenshteinBatch(pairs));
     });
+
+    it('searchKeys results should match native', () => {
+      const names = ['John Smith', 'Jane Doe', 'Bob Johnson'];
+      const emails = ['john@example.com', 'jane@example.com', 'bob@test.com'];
+      const weights = [1, 1];
+
+      const wasmResults = wasm.searchKeys('john', [names, emails], weights);
+      const nativeResults = native.searchKeys('john', [names, emails], weights);
+
+      expect(wasmResults.length).toBe(nativeResults.length);
+      for (let i = 0; i < wasmResults.length; i++) {
+        expect(wasmResults[i]?.index).toBe(nativeResults[i]?.index);
+        expect(wasmResults[i]?.score).toBeCloseTo(nativeResults[i]?.score ?? 0);
+        expect(wasmResults[i]?.keyScores).toHaveLength(nativeResults[i]?.keyScores.length ?? 0);
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add empty array edge case tests for 4 batch functions: `tokenSortRatioBatch`, `tokenSetRatioBatch`, `partialRatioBatch`, `weightedRatioBatch`
- Add WASM parity test for `searchKeys` (multi-key search)

Closes #185

## Checklist

- [x] `pnpm test` — 171 tests pass
- [x] `pnpm run check` — lint clean
- [x] `pnpm run typecheck` — no errors
- [x] Pre-push hooks pass