### PR TITLE
fix(wasm): align Node.js engine requirement with main package

### DIFF
--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/derodero24/rapid-fuzzy",
   "license": "MIT",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=20.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Update WASM package `engines.node` from `>=14.0.0` to `>=20.0.0` to match all other platform packages and the main package.

Closes #189

## Checklist

- [x] Pre-push hooks pass
- [x] No functional changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js version requirement to 20.0.0 or higher for the wasm32-wasi package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->