### PR TITLE
docs: add benchmark SVG charts and improve table layout

### DIFF
--- a/.github/assets/bench-distance.svg
+++ b/.github/assets/bench-distance.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 279" width="680" height="279">
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .title { font-size: 16px; font-weight: 600; fill: #1f2937; }
+  .subtitle { font-size: 12px; fill: #6b7280; }
+  .group-label { font-size: 13px; font-weight: 600; fill: #374151; }
+  .bar-label { font-size: 12px; fill: #4b5563; }
+  .bar-value { font-size: 12px; fill: #374151; font-weight: 500; }
+  .multiplier { font-size: 11px; fill: #059669; font-weight: 600; }
+</style>
+<rect width="680" height="279" rx="8" fill="#ffffff" />
+<rect x="0.5" y="0.5" width="679" height="278" rx="8" fill="none" stroke="#e5e7eb" />
+<text x="20" y="28" class="title">Distance Function Performance</text>
+<text x="20" y="44" class="subtitle">ops/s (higher is better)</text>
+<text x="20" y="66" class="group-label">Levenshtein</text>
+<text x="172" y="91" class="bar-label" text-anchor="end">fastest-levenshtein</text>
+<rect x="180" y="74" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="632" y="91" class="bar-value" text-anchor="end">774,820 ops/s</text>
+<text x="172" y="122" class="bar-label" text-anchor="end">leven</text>
+<rect x="180" y="105" width="121.13990346144911" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="309.1399034614491" y="122" class="bar-value" text-anchor="start">204,047 ops/s</text>
+<text x="172" y="153" class="bar-label" text-anchor="end">rapid-fuzzy</text>
+<rect x="180" y="136" width="114.93350713714152" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="302.93350713714153" y="153" class="bar-value" text-anchor="start">193,593 ops/s</text>
+<text x="20" y="200" class="group-label">Sorensen-Dice</text>
+<text x="172" y="225" class="bar-label" text-anchor="end">rapid-fuzzy</text>
+<rect x="180" y="208" width="460" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="632" y="225" class="bar-value" text-anchor="end" fill="#ffffff">144,698 ops/s</text>
+<text x="172" y="256" class="bar-label" text-anchor="end">string-similarity</text>
+<rect x="180" y="239" width="267.3822720424609" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="439.3822720424609" y="256" class="bar-value" text-anchor="end">84,108 ops/s</text>
+</svg>

--- a/.github/assets/bench-search.svg
+++ b/.github/assets/bench-search.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 427" width="680" height="427">
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+  .title { font-size: 16px; font-weight: 600; fill: #1f2937; }
+  .subtitle { font-size: 12px; fill: #6b7280; }
+  .group-label { font-size: 13px; font-weight: 600; fill: #374151; }
+  .bar-label { font-size: 12px; fill: #4b5563; }
+  .bar-value { font-size: 12px; fill: #374151; font-weight: 500; }
+  .multiplier { font-size: 11px; fill: #059669; font-weight: 600; }
+</style>
+<rect width="680" height="427" rx="8" fill="#ffffff" />
+<rect x="0.5" y="0.5" width="679" height="426" rx="8" fill="none" stroke="#e5e7eb" />
+<text x="20" y="28" class="title">Fuzzy Search Performance</text>
+<text x="20" y="44" class="subtitle">ops/s (higher is better)</text>
+<text x="20" y="66" class="group-label">Small</text>
+<text x="172" y="91" class="bar-label" text-anchor="end">fuzzysort</text>
+<rect x="180" y="74" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="632" y="91" class="bar-value" text-anchor="end">2,501,773 ops/s</text>
+<text x="172" y="122" class="bar-label" text-anchor="end">rapid-fuzzy</text>
+<rect x="180" y="105" width="32.953477393832294" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="220.9534773938323" y="122" class="bar-value" text-anchor="start">179,222 ops/s — 2x vs fuse.js</text>
+<text x="172" y="153" class="bar-label" text-anchor="end">fuse.js</text>
+<rect x="180" y="136" width="20.052634671490978" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="208.05263467149098" y="153" class="bar-value" text-anchor="start">109,059 ops/s</text>
+<text x="20" y="200" class="group-label">Medium</text>
+<text x="172" y="225" class="bar-label" text-anchor="end">fuzzysort</text>
+<rect x="180" y="208" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="632" y="225" class="bar-value" text-anchor="end">63,032 ops/s</text>
+<text x="172" y="256" class="bar-label" text-anchor="end">rapid-fuzzy</text>
+<rect x="180" y="239" width="48.26818124127427" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="236.26818124127428" y="256" class="bar-value" text-anchor="start">6,614 ops/s — 17x vs fuse.js</text>
+<text x="172" y="287" class="bar-label" text-anchor="end">fuse.js</text>
+<rect x="180" y="270" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="192" y="287" class="bar-value" text-anchor="start">381 ops/s</text>
+<text x="20" y="334" class="group-label">Large</text>
+<text x="172" y="359" class="bar-label" text-anchor="end">fuzzysort</text>
+<rect x="180" y="342" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="632" y="359" class="bar-value" text-anchor="end">28,616 ops/s</text>
+<text x="172" y="390" class="bar-label" text-anchor="end">rapid-fuzzy</text>
+<rect x="180" y="373" width="12.763488957226727" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="200.76348895722674" y="390" class="bar-value" text-anchor="start">794 ops/s — 40x vs fuse.js</text>
+<text x="172" y="421" class="bar-label" text-anchor="end">fuse.js</text>
+<rect x="180" y="404" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="192" y="421" class="bar-value" text-anchor="start">20 ops/s</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 ### Distance Functions
 
+<img src=".github/assets/bench-distance.svg" alt="Distance function performance chart" width="680" />
+
+<details>
+<summary>Raw numbers</summary>
+
 | Function | rapid-fuzzy | fastest-levenshtein | leven | string-similarity |
 |---|---:|---:|---:|---:|
 | Levenshtein | 193,593 ops/s | **774,820 ops/s** | 204,047 ops/s | — |
@@ -197,15 +202,24 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 | Jaro-Winkler | **291,673 ops/s** | — | — | — |
 | Damerau-Levenshtein | **72,238 ops/s** | — | — | — |
 
+</details>
+
 > **Note**: For single-pair Levenshtein distance, fastest-levenshtein is faster due to its highly optimized pure-JS implementation that avoids FFI overhead. rapid-fuzzy provides broader algorithm coverage and excels in batch / search scenarios.
 
 ### Search Performance
+
+<img src=".github/assets/bench-search.svg" alt="Search performance chart — rapid-fuzzy vs fuse.js vs fuzzysort" width="680" />
+
+<details>
+<summary>Raw numbers</summary>
 
 | Dataset size | rapid-fuzzy | fuse.js | fuzzysort |
 |---|---:|---:|---:|
 | Small (20 items) | 179,222 ops/s | 109,059 ops/s | **2,501,773 ops/s** |
 | Medium (1K items) | 6,614 ops/s | 381 ops/s | **63,032 ops/s** |
 | Large (10K items) | 794 ops/s | 20 ops/s | **28,616 ops/s** |
+
+</details>
 
 ### Closest Match (Levenshtein-based)
 
@@ -252,17 +266,17 @@ cargo bench           # Rust internal benchmarks
 ## Why rapid-fuzzy?
 
 | | rapid-fuzzy | fuse.js | fastest-levenshtein | fuzzysort |
-|---|---|---|---|---|
-| **Algorithms** | Levenshtein, Jaro-Winkler, Sorensen-Dice, Damerau-Levenshtein, token sort/set, partial ratio, fuzzy search | Bitap-based fuzzy | Levenshtein only | Substring fuzzy |
-| **Runtime** | Rust (native + WASM) | Pure JS | Pure JS | Pure JS |
-| **Object search** | Yes (searchObjects with weighted keys) | Yes (keys option) | No | Yes (keys) |
-| **Score threshold** | Yes (minScore) | Yes (threshold) | No | Yes (threshold) |
-| **Match positions** | Yes (includePositions) | Yes | No | Yes |
-| **Highlight utility** | Yes (highlight, highlightRanges) | No (manual) | No | Yes (highlight) |
-| **Batch API** | Yes | No | No | No |
-| **Node.js native** | Yes (napi-rs) | No | No | No |
-| **Browser support** | Yes (WASM) | Yes | Yes | Yes |
-| **TypeScript** | Full (auto-generated) | Full | Yes | Yes |
+|---|:---:|:---:|:---:|:---:|
+| **Algorithms** | 9 (Levenshtein, Jaro, Dice, …) | Bitap | Levenshtein | Substring |
+| **Runtime** | Rust native + WASM | Pure JS | Pure JS | Pure JS |
+| **Object search** | ✅ weighted keys | ✅ | — | ✅ |
+| **Score threshold** | ✅ | ✅ | — | ✅ |
+| **Match positions** | ✅ | ✅ | — | ✅ |
+| **Highlight utility** | ✅ | — | — | ✅ |
+| **Batch API** | ✅ | — | — | — |
+| **Node.js native** | ✅ napi-rs | — | — | — |
+| **Browser** | ✅ WASM | ✅ | ✅ | ✅ |
+| **TypeScript** | ✅ full | ✅ full | ✅ | ✅ |
 
 ## Migration Guides
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "test:watch": "vitest watch",
     "bench": "vitest bench",
     "bench:readme": "npx tsx scripts/update-bench-readme.ts",
+    "bench:charts": "npx tsx scripts/generate-bench-charts.ts",
     "publint": "publint",
     "bench:rust": "cargo bench -p rapid-fuzzy-bench",
     "verify": "pnpm run check && cargo clippy -- -W clippy::all && cargo test && pnpm run build && pnpm run typecheck && pnpm test",

--- a/scripts/generate-bench-charts.ts
+++ b/scripts/generate-bench-charts.ts
@@ -1,0 +1,249 @@
+#!/usr/bin/env npx tsx
+/**
+ * Generate SVG bar charts from the benchmark tables in README.md.
+ *
+ * Usage:
+ *   pnpm bench:charts          # parse README and generate chart SVGs
+ *   npx tsx scripts/generate-bench-charts.ts
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ASSET_DIR = join(new URL('.', import.meta.url).pathname, '..', '.github', 'assets');
+mkdirSync(ASSET_DIR, { recursive: true });
+
+// ---------------------------------------------------------------------------
+// 1. Parse benchmark tables from README
+// ---------------------------------------------------------------------------
+
+const readme = readFileSync('README.md', 'utf-8');
+
+interface BarEntry {
+  label: string;
+  value: number;
+}
+
+interface ChartData {
+  title: string;
+  subtitle?: string;
+  groups: { groupLabel: string; bars: BarEntry[] }[];
+}
+
+function parseOps(s: string): number | null {
+  const m = s.replace(/\*\*/g, '').match(/([\d,]+)\s*ops\/s/);
+  return m ? Number(m[1].replace(/,/g, '')) : null;
+}
+
+function parseSearchTable(): ChartData {
+  const groups: ChartData['groups'] = [];
+  const lines = readme.split('\n');
+
+  for (const line of lines) {
+    // Match rows like: | Small (20 items) | 179,222 ops/s | 109,059 ops/s | ...
+    const m = line.match(/\|\s*(Small|Medium|Large)\s*\([^)]+\)\s*\|([^|]+)\|([^|]+)\|([^|]+)\|/);
+    if (!m) continue;
+
+    const groupLabel = m[1];
+    const rf = parseOps(m[2]);
+    const fj = parseOps(m[3]);
+    const fs = parseOps(m[4]);
+
+    const bars: BarEntry[] = [];
+    if (rf !== null) bars.push({ label: 'rapid-fuzzy', value: rf });
+    if (fj !== null) bars.push({ label: 'fuse.js', value: fj });
+    if (fs !== null) bars.push({ label: 'fuzzysort', value: fs });
+
+    groups.push({ groupLabel, bars });
+  }
+
+  return { title: 'Fuzzy Search Performance', subtitle: 'ops/s (higher is better)', groups };
+}
+
+function parseDistanceTable(): ChartData {
+  const groups: ChartData['groups'] = [];
+  const lines = readme.split('\n');
+
+  for (const line of lines) {
+    const m = line.match(
+      /\|\s*(Levenshtein|Normalized Levenshtein|Sorensen-Dice|Jaro-Winkler|Damerau-Levenshtein)\s*\|([^|]+)\|([^|]+)\|([^|]+)\|([^|]+)\|/,
+    );
+    if (!m) continue;
+
+    const groupLabel = m[1];
+    const rf = parseOps(m[2]);
+    const fl = parseOps(m[3]);
+    const lv = parseOps(m[4]);
+    const ss = parseOps(m[5]);
+
+    const bars: BarEntry[] = [];
+    if (rf !== null) bars.push({ label: 'rapid-fuzzy', value: rf });
+    if (fl !== null) bars.push({ label: 'fastest-levenshtein', value: fl });
+    if (lv !== null) bars.push({ label: 'leven', value: lv });
+    if (ss !== null) bars.push({ label: 'string-similarity', value: ss });
+
+    if (bars.length > 1) groups.push({ groupLabel, bars });
+  }
+
+  return { title: 'Distance Function Performance', subtitle: 'ops/s (higher is better)', groups };
+}
+
+// ---------------------------------------------------------------------------
+// 2. Generate SVG chart
+// ---------------------------------------------------------------------------
+
+const COLORS: Record<string, string> = {
+  'rapid-fuzzy': '#3b82f6',
+  'fuse.js': '#94a3b8',
+  fuzzysort: '#94a3b8',
+  'fastest-levenshtein': '#94a3b8',
+  leven: '#94a3b8',
+  'string-similarity': '#94a3b8',
+};
+
+function generateSvg(data: ChartData): string {
+  const barHeight = 26;
+  const barGap = 5;
+  const groupGap = 24;
+  const labelWidth = 160;
+  const chartWidth = 640;
+  const barAreaWidth = chartWidth - labelWidth - 20;
+  const headerHeight = 52;
+  const paddingX = 20;
+  const paddingBottom = 24;
+
+  // Calculate total height
+  let totalBarHeight = 0;
+  for (const group of data.groups) {
+    totalBarHeight += group.bars.length * (barHeight + barGap) + groupGap;
+  }
+
+  const svgWidth = chartWidth + paddingX * 2;
+  const svgHeight = headerHeight + totalBarHeight + paddingBottom;
+
+  const lines: string[] = [];
+  lines.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${svgWidth} ${svgHeight}" width="${svgWidth}" height="${svgHeight}">`,
+  );
+  lines.push('<style>');
+  lines.push(
+    '  text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }',
+  );
+  lines.push('  .title { font-size: 16px; font-weight: 600; fill: #1f2937; }');
+  lines.push('  .subtitle { font-size: 12px; fill: #6b7280; }');
+  lines.push('  .group-label { font-size: 13px; font-weight: 600; fill: #374151; }');
+  lines.push('  .bar-label { font-size: 12px; fill: #4b5563; }');
+  lines.push('  .bar-value { font-size: 12px; fill: #374151; font-weight: 500; }');
+  lines.push('  .multiplier { font-size: 11px; fill: #059669; font-weight: 600; }');
+  lines.push('</style>');
+
+  // Background
+  lines.push(`<rect width="${svgWidth}" height="${svgHeight}" rx="8" fill="#ffffff" />`);
+  lines.push(
+    `<rect x="0.5" y="0.5" width="${svgWidth - 1}" height="${svgHeight - 1}" rx="8" fill="none" stroke="#e5e7eb" />`,
+  );
+
+  // Title
+  lines.push(`<text x="${paddingX}" y="28" class="title">${escapeXml(data.title)}</text>`);
+  if (data.subtitle) {
+    lines.push(`<text x="${paddingX}" y="44" class="subtitle">${escapeXml(data.subtitle)}</text>`);
+  }
+
+  let y = headerHeight;
+
+  for (const group of data.groups) {
+    // Group label
+    lines.push(
+      `<text x="${paddingX}" y="${y + 14}" class="group-label">${escapeXml(group.groupLabel)}</text>`,
+    );
+    y += 22;
+
+    // Sort bars by value descending
+    const sorted = [...group.bars].sort((a, b) => b.value - a.value);
+    // Per-group scale: largest bar in this group fills the available width
+    const groupMax = sorted[0]?.value ?? 1;
+    const rfEntry = group.bars.find((b) => b.label === 'rapid-fuzzy');
+
+    for (const bar of sorted) {
+      const barWidth = Math.max(4, (bar.value / groupMax) * barAreaWidth);
+      const color = COLORS[bar.label] ?? '#94a3b8';
+      const isRapidFuzzy = bar.label === 'rapid-fuzzy';
+      const x = paddingX + labelWidth;
+
+      // Label
+      lines.push(
+        `<text x="${x - 8}" y="${y + barHeight / 2 + 4}" class="bar-label" text-anchor="end">${escapeXml(bar.label)}</text>`,
+      );
+
+      // Bar
+      lines.push(
+        `<rect x="${x}" y="${y}" width="${barWidth}" height="${barHeight}" rx="4" fill="${color}" opacity="${isRapidFuzzy ? 1 : 0.6}" />`,
+      );
+
+      // Value + multiplier inside or after bar
+      const formatted = formatNumber(bar.value);
+      let valueText = `${formatted} ops/s`;
+
+      // Show "Nx faster" for rapid-fuzzy vs fuse.js
+      if (isRapidFuzzy && rfEntry) {
+        const fuseEntry = group.bars.find((b) => b.label === 'fuse.js');
+        if (fuseEntry && fuseEntry.value > 0) {
+          const mult = Math.round(rfEntry.value / fuseEntry.value);
+          if (mult >= 2) {
+            valueText += ` — ${mult}x vs fuse.js`;
+          }
+        }
+      }
+
+      const textX = barWidth > 200 ? x + barWidth - 8 : x + barWidth + 8;
+      const anchor = barWidth > 200 ? 'end' : 'start';
+      const textFill = barWidth > 200 && isRapidFuzzy ? '#ffffff' : '';
+      const cls =
+        isRapidFuzzy && rfEntry && group.bars.some((b) => b.label === 'fuse.js')
+          ? 'bar-value'
+          : 'bar-value';
+
+      lines.push(
+        `<text x="${textX}" y="${y + barHeight / 2 + 4}" class="${cls}" text-anchor="${anchor}"${textFill ? ` fill="${textFill}"` : ''}>${escapeXml(valueText)}</text>`,
+      );
+
+      y += barHeight + barGap;
+    }
+
+    y += groupGap - barGap;
+  }
+
+  lines.push('</svg>');
+  return lines.join('\n');
+}
+
+function formatNumber(n: number): string {
+  return Math.round(n).toLocaleString('en-US');
+}
+
+function escapeXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// ---------------------------------------------------------------------------
+// 3. Generate and write SVGs
+// ---------------------------------------------------------------------------
+
+const searchData = parseSearchTable();
+const distData = parseDistanceTable();
+
+if (searchData.groups.length > 0) {
+  const svg = generateSvg(searchData);
+  writeFileSync(join(ASSET_DIR, 'bench-search.svg'), svg);
+  console.log(`✓ Generated bench-search.svg (${searchData.groups.length} groups)`);
+} else {
+  console.warn('⚠ No search benchmark data found in README');
+}
+
+if (distData.groups.length > 0) {
+  const svg = generateSvg(distData);
+  writeFileSync(join(ASSET_DIR, 'bench-distance.svg'), svg);
+  console.log(`✓ Generated bench-distance.svg (${distData.groups.length} groups)`);
+} else {
+  console.warn('⚠ No distance benchmark data found in README');
+}


### PR DESCRIPTION
## Summary

- Add `scripts/generate-bench-charts.ts` to parse README benchmark tables and generate SVG bar charts with per-group scaling and `vs fuse.js` multiplier labels
- Embed charts in README as `<img>` tags (works on both GitHub and npm)
- Move raw number tables into collapsible `<details>` sections
- Restructure "Why rapid-fuzzy?" comparison table: use checkmarks instead of verbose text for better narrow-screen readability
- Add `bench:charts` npm script

Closes #179

## Checklist

- [x] Charts render correctly on GitHub
- [x] Charts reference relative paths (work in repo context)
- [x] Raw numbers preserved in collapsible details
- [x] Comparison table readable on narrow viewports
- [x] Pre-push hooks pass