### PR TITLE
test(core): add multi-term search tests and document support

### DIFF
--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -784,6 +784,45 @@ describe('unicode', () => {
       expect(result).not.toBeNull();
     });
   });
+
+  describe('multi-term search', () => {
+    const contacts = ['John Smith', 'Smith, John A.', 'Jane Doe', 'John Doe', 'Bob Smith'];
+
+    it('should require all terms to match (AND semantics)', () => {
+      const results = search('john smith', contacts);
+      const items = results.map((r) => r.item);
+      expect(items).toContain('John Smith');
+      expect(items).toContain('Smith, John A.');
+      expect(items).not.toContain('John Doe');
+      expect(items).not.toContain('Bob Smith');
+    });
+
+    it('should return more results for single term than multi-term', () => {
+      const single = search('john', contacts);
+      const multi = search('john smith', contacts);
+      expect(single.length).toBeGreaterThan(multi.length);
+    });
+
+    it('should return positions spanning all matched terms', () => {
+      const results = search('john smith', contacts, { includePositions: true });
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]!.positions.length).toBeGreaterThan(0);
+    });
+
+    it('should work with FuzzyIndex', () => {
+      const { FuzzyIndex } = require('../index.js');
+      const idx = new FuzzyIndex(contacts);
+      const results = idx.search('john smith');
+      const items = results.map((r: { item: string }) => r.item);
+      expect(items).toContain('John Smith');
+      expect(items).not.toContain('John Doe');
+    });
+
+    it('single-word query should behave identically', () => {
+      const results = search('john', contacts);
+      expect(results.length).toBe(3); // John Smith, Smith John A., John Doe
+    });
+  });
 });
 
 describe('FuzzyIndex', () => {


### PR DESCRIPTION
## Summary

nucleo-matcher's `Pattern::parse()` already splits space-separated queries into individual atoms with AND semantics. This means **multi-term compound queries work out of the box** in rapid-fuzzy — no core algorithm changes needed.

This PR adds test coverage to verify and document the behavior:
- AND semantics: `"john smith"` matches items containing both terms
- Single-term queries behave identically (backward compatible)
- Positions span all matched terms
- FuzzyIndex supports multi-term queries

See [investigation comment](https://github.com/derodero24/rapid-fuzzy/issues/162#issuecomment-4060482342) for details on nucleo-matcher's built-in support, including modifier syntax (`'\''exact`, `^prefix`, `suffix$`, `!exclude`).

Closes #162

## Checklist

- [x] `pnpm test` — 177 tests pass
- [x] `pnpm run typecheck` — no errors
- [x] Pre-push hooks pass