### PR TITLE
perf(core): pre-compute Utf32String in FuzzyIndex

### DIFF
--- a/crates/core/src/search/index.rs
+++ b/crates/core/src/search/index.rs
@@ -1,18 +1,27 @@
+use std::cell::RefCell;
+
 use napi::Either;
 use napi_derive::napi;
 use nucleo_matcher::pattern::CaseMatching;
+use nucleo_matcher::{Config, Matcher, Utf32String};
 
-use super::{SearchOptions, SearchResult, resolve_case_matching, search_over_items};
+use super::{
+    PrecomputedSearch, SearchOptions, SearchResult, resolve_case_matching, search_over_precomputed,
+};
 
 /// A persistent fuzzy search index backed by Rust-side data.
 ///
 /// Holds items in memory on the Rust side, avoiding repeated FFI overhead
 /// for applications that search the same dataset multiple times.
+/// Pre-computes Utf32String representations for each item, eliminating
+/// per-search string conversion overhead.
 /// Memory is freed when the JavaScript garbage collector collects the instance
 /// or when `destroy()` is called explicitly.
 #[napi]
 pub struct FuzzyIndex {
     items: Vec<String>,
+    utf32_items: Vec<Utf32String>,
+    matcher: RefCell<Matcher>,
 }
 
 #[napi]
@@ -20,7 +29,15 @@ impl FuzzyIndex {
     /// Create a new FuzzyIndex from an array of strings.
     #[napi(constructor)]
     pub fn new(items: Vec<String>) -> Self {
-        Self { items }
+        let utf32_items: Vec<Utf32String> = items
+            .iter()
+            .map(|s| Utf32String::from(s.as_str()))
+            .collect();
+        Self {
+            items,
+            utf32_items,
+            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
+        }
     }
 
     /// Return the number of items in the index.
@@ -71,12 +88,16 @@ impl FuzzyIndex {
     /// Add a single item to the index.
     #[napi]
     pub fn add(&mut self, item: String) {
+        self.utf32_items.push(Utf32String::from(item.as_str()));
         self.items.push(item);
     }
 
     /// Add multiple items to the index at once.
     #[napi]
     pub fn add_many(&mut self, items: Vec<String>) {
+        for item in &items {
+            self.utf32_items.push(Utf32String::from(item.as_str()));
+        }
         self.items.extend(items);
     }
 
@@ -88,6 +109,7 @@ impl FuzzyIndex {
         let idx = index as usize;
         if idx < self.items.len() {
             self.items.swap_remove(idx);
+            self.utf32_items.swap_remove(idx);
             true
         } else {
             false
@@ -98,6 +120,7 @@ impl FuzzyIndex {
     #[napi]
     pub fn destroy(&mut self) {
         self.items = Vec::new();
+        self.utf32_items = Vec::new();
     }
 
     fn search_impl(
@@ -108,9 +131,14 @@ impl FuzzyIndex {
         include_positions: bool,
         case_matching: CaseMatching,
     ) -> Vec<SearchResult> {
-        search_over_items(
+        let ctx = PrecomputedSearch {
+            items: &self.items,
+            utf32_items: &self.utf32_items,
+            matcher: &self.matcher,
+        };
+        search_over_precomputed(
             query,
-            &self.items,
+            &ctx,
             max_results,
             min_score,
             include_positions,

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -4,10 +4,12 @@ mod keys;
 pub use index::FuzzyIndex;
 pub use keys::search_keys;
 
+use std::cell::RefCell;
+
 use napi::Either;
 use napi_derive::napi;
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
-use nucleo_matcher::{Config, Matcher};
+use nucleo_matcher::{Config, Matcher, Utf32String};
 
 /// A single fuzzy search result with the matched item and its score.
 #[napi(object)]
@@ -82,6 +84,81 @@ pub(crate) fn search_over_items(
         .filter_map(|(index, item)| {
             buf.clear();
             let atoms = nucleo_matcher::Utf32Str::new(item, &mut buf);
+
+            let (raw_score, positions) = if include_positions {
+                let mut indices = Vec::new();
+                let score = pattern.indices(atoms, &mut matcher, &mut indices)?;
+                indices.sort_unstable();
+                indices.dedup();
+                (score, indices)
+            } else {
+                let score = pattern.score(atoms, &mut matcher)?;
+                (score, Vec::new())
+            };
+
+            let normalized = (raw_score as f64 / max_score).min(1.0);
+            if normalized >= threshold {
+                Some(SearchResult {
+                    item: item.clone(),
+                    score: normalized,
+                    index: index as u32,
+                    positions,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    results.sort_unstable_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    if let Some(max) = max_results {
+        results.truncate(max as usize);
+    }
+
+    results
+}
+
+/// Pre-computed search context for FuzzyIndex.
+pub(crate) struct PrecomputedSearch<'a> {
+    pub items: &'a [String],
+    pub utf32_items: &'a [Utf32String],
+    pub matcher: &'a RefCell<Matcher>,
+}
+
+/// Search over pre-computed Utf32String items with a reusable Matcher.
+///
+/// Used by FuzzyIndex to avoid per-search string conversion and Matcher allocation.
+pub(crate) fn search_over_precomputed(
+    query: &str,
+    ctx: &PrecomputedSearch<'_>,
+    max_results: Option<u32>,
+    min_score: Option<f64>,
+    include_positions: bool,
+    case_matching: CaseMatching,
+) -> Vec<SearchResult> {
+    let items = ctx.items;
+    let utf32_items = ctx.utf32_items;
+    let matcher_cell = ctx.matcher;
+    if query.is_empty() || items.is_empty() {
+        return Vec::new();
+    }
+
+    let mut matcher = matcher_cell.borrow_mut();
+    let pattern = Pattern::parse(query, case_matching, Normalization::Smart);
+    let max_score = compute_max_score(query, &pattern, &mut matcher);
+    let threshold = min_score.unwrap_or(0.0);
+
+    let mut results: Vec<SearchResult> = items
+        .iter()
+        .zip(utf32_items.iter())
+        .enumerate()
+        .filter_map(|(index, (item, utf32_item))| {
+            let atoms = utf32_item.slice(..);
 
             let (raw_score, positions) = if include_positions {
                 let mut indices = Vec::new();


### PR DESCRIPTION
## Summary

Optimize `FuzzyIndex` by eliminating per-search overhead:

- **Pre-compute Utf32String**: Store `Utf32String` (nucleo-matcher's owned UTF-32 representation) for each item at construction time. On search, use zero-copy `slice(..)` instead of `Utf32Str::new()` which runs `is_ascii()` O(n) scan + potential grapheme segmentation per item per search call.

- **Cache Matcher**: Store a `Matcher` via `RefCell<Matcher>` to avoid re-allocating ~135KB scratch space on every search call.

- **New `search_over_precomputed()`**: Internal function that accepts pre-computed `Utf32String` slices and a reusable `Matcher`. The standalone `search()` function continues to use on-the-fly conversion.

This directly addresses the performance gap identified in benchmarks where FuzzyIndex lagged behind fuzzysort due to repeated string conversion overhead.

Closes #192

## Checklist

- [x] `cargo test` — 160 tests pass
- [x] `cargo clippy -- -W clippy::all` — no warnings
- [x] `pnpm test` — 177 JS tests pass
- [x] Pre-push hooks pass
- [x] Full backward compatibility (no API changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved search implementation with internal optimizations for efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->