### PR TITLE
test(bench): add FuzzyIndex and many benchmarks for fair comparison

### DIFF
--- a/__test__/distance.bench.ts
+++ b/__test__/distance.bench.ts
@@ -9,7 +9,9 @@ import {
   jaroWinkler,
   levenshtein,
   levenshteinBatch,
+  levenshteinMany,
   normalizedLevenshtein,
+  normalizedLevenshteinMany,
   sorensenDice,
 } from '../index.js';
 
@@ -85,6 +87,54 @@ describe('Damerau-Levenshtein', () => {
   bench('rapid-fuzzy', () => {
     for (const [a, b] of pairs) {
       damerauLevenshtein(a, b);
+    }
+  });
+});
+
+// --- Many candidates (1-to-N comparison) ---
+
+const manyCandidates = Array.from({ length: 1_000 }, (_, i) => {
+  const words = [
+    'kitten',
+    'sitting',
+    'saturday',
+    'sunday',
+    'hello',
+    'world',
+    'fuzzy',
+    'search',
+    'match',
+    'distance',
+  ];
+  return `${words[i % words.length]}${i}`;
+});
+
+describe('Levenshtein Distance — Many (1K candidates)', () => {
+  bench('rapid-fuzzy (many)', () => {
+    levenshteinMany('kitten', manyCandidates);
+  });
+
+  bench('rapid-fuzzy (loop)', () => {
+    for (const c of manyCandidates) {
+      levenshtein('kitten', c);
+    }
+  });
+
+  bench('fastest-levenshtein (loop)', () => {
+    for (const c of manyCandidates) {
+      fastestLevenshteinDistance('kitten', c);
+    }
+  });
+});
+
+describe('Normalized Levenshtein — Many (1K candidates)', () => {
+  bench('rapid-fuzzy (many)', () => {
+    normalizedLevenshteinMany('kitten', manyCandidates);
+  });
+
+  bench('rapid-fuzzy (loop)', () => {
+    for (const c of manyCandidates) {
+      normalizedLevenshtein('kitten', c);
     }
   });
 });

--- a/__test__/search.bench.ts
+++ b/__test__/search.bench.ts
@@ -4,7 +4,7 @@ import Fuse from 'fuse.js';
 import fuzzysort from 'fuzzysort';
 import { bench, describe } from 'vitest';
 
-import { closest, search } from '../index.js';
+import { closest, FuzzyIndex, search } from '../index.js';
 
 // --- Test data ---
 
@@ -90,9 +90,20 @@ const fuseLarge = new Fuse(largeItems, { threshold: 0.4 });
 const fuzzysortMediumPrepared = mediumItems.map((item) => fuzzysort.prepare(item));
 const fuzzysortLargePrepared = largeItems.map((item) => fuzzysort.prepare(item));
 
+// Pre-initialize FuzzyIndex instances (recommended pattern for repeated searches)
+const fuzzyIndexSmall = new FuzzyIndex(smallItems);
+const fuzzyIndexMedium = new FuzzyIndex(mediumItems);
+const fuzzyIndexLarge = new FuzzyIndex(largeItems);
+const fuzzyIndexClosestMedium = new FuzzyIndex(mediumItems);
+const fuzzyIndexClosestLarge = new FuzzyIndex(largeItems);
+
 describe('Fuzzy Search — Small (20 items)', () => {
   bench('rapid-fuzzy', () => {
     search('aple', smallItems, 5);
+  });
+
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    fuzzyIndexSmall.search('aple', { maxResults: 5 });
   });
 
   bench('fuse.js', () => {
@@ -109,6 +120,10 @@ describe('Fuzzy Search — Medium (1K items)', () => {
     search('utils config', mediumItems, 10);
   });
 
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    fuzzyIndexMedium.search('utils config', { maxResults: 10 });
+  });
+
   bench('fuse.js', () => {
     fuseMedium.search('utils config', { limit: 10 });
   });
@@ -121,6 +136,10 @@ describe('Fuzzy Search — Medium (1K items)', () => {
 describe('Fuzzy Search — Large (10K items)', () => {
   bench('rapid-fuzzy', () => {
     search('handler middleware', largeItems, 10);
+  });
+
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    fuzzyIndexLarge.search('handler middleware', { maxResults: 10 });
   });
 
   bench('fuse.js', () => {
@@ -137,6 +156,10 @@ describe('Closest Match — Medium (1K items)', () => {
     closest('src/utils42.ts', mediumItems);
   });
 
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    fuzzyIndexClosestMedium.closest('src/utils42.ts');
+  });
+
   bench('fastest-levenshtein', () => {
     fastestLevenshteinClosest('src/utils42.ts', mediumItems);
   });
@@ -145,6 +168,10 @@ describe('Closest Match — Medium (1K items)', () => {
 describe('Closest Match — Large (10K items)', () => {
   bench('rapid-fuzzy', () => {
     closest('handler_middleware_500', largeItems);
+  });
+
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    fuzzyIndexClosestLarge.closest('handler_middleware_500');
   });
 
   bench('fastest-levenshtein', () => {


### PR DESCRIPTION
## Summary

- Add `FuzzyIndex` benchmarks alongside standalone `search()` and `closest()` in search benchmarks for fair comparison with competitors (fuse.js, fuzzysort) that support pre-prepared targets
- Add `levenshteinMany` and `normalizedLevenshteinMany` benchmarks in distance benchmarks to measure FFI amortization benefits of 1-to-N distance calls vs individual loops

## Related issue

Closes #194

## Checklist

- [x] Biome lint passes
- [x] TypeScript type check passes
- [x] Vitest tests pass
- [x] Cargo tests pass
- [x] Cargo clippy passes
- [x] Benchmarks run successfully
- [x] No changeset needed (benchmark-only change)