### PR TITLE
feat(core): add FuzzyObjectIndex for persistent object search

### DIFF
--- a/.changeset/add-fuzzy-object-index.md
+++ b/.changeset/add-fuzzy-object-index.md
@@ -1,0 +1,5 @@
+---
+"rapid-fuzzy": minor
+---
+
+Add `FuzzyObjectIndex` class for persistent indexed search over object collections with weighted keys

--- a/__test__/objects.spec.ts
+++ b/__test__/objects.spec.ts
@@ -155,3 +155,104 @@ describe('searchObjects', () => {
     }
   });
 });
+
+describe('FuzzyObjectIndex', () => {
+  const { FuzzyObjectIndex } = require('../objects.js');
+
+  const users = [
+    { name: 'John Smith', email: 'john@example.com' },
+    { name: 'Jane Doe', email: 'jane@example.com' },
+    { name: 'Bob Johnson', email: 'bob@example.com' },
+  ];
+
+  it('should construct and report size', () => {
+    const index = new FuzzyObjectIndex(users, { keys: ['name', 'email'] });
+    expect(index.size).toBe(3);
+  });
+
+  it('should search with weighted keys', () => {
+    const index = new FuzzyObjectIndex(users, {
+      keys: [{ name: 'name', weight: 2.0 }, 'email'],
+    });
+    const results = index.search('john');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].item.name).toBe('John Smith');
+    expect(results[0].score).toBeGreaterThan(0);
+    expect(results[0].keyScores.length).toBe(2);
+  });
+
+  it('should find closest match', () => {
+    const index = new FuzzyObjectIndex(users, { keys: ['name'] });
+    const result = index.closest('jane');
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe('Jane Doe');
+  });
+
+  it('should return null from closest when minScore is too high', () => {
+    const index = new FuzzyObjectIndex(users, { keys: ['name'] });
+    const result = index.closest('zzzzz', 0.99);
+    expect(result).toBeNull();
+  });
+
+  it('should support add', () => {
+    const index = new FuzzyObjectIndex(users, { keys: ['name'] });
+    expect(index.size).toBe(3);
+    index.add({ name: 'Alice Wonder', email: 'alice@example.com' });
+    expect(index.size).toBe(4);
+    const results = index.search('alice');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].item.name).toBe('Alice Wonder');
+  });
+
+  it('should support addMany', () => {
+    const index = new FuzzyObjectIndex([], { keys: ['name'] });
+    index.addMany(users);
+    expect(index.size).toBe(3);
+  });
+
+  it('should support remove with swap-remove semantics', () => {
+    const index = new FuzzyObjectIndex(users, { keys: ['name'] });
+    expect(index.remove(1)).toBe(true); // Remove Jane Doe
+    expect(index.size).toBe(2);
+    expect(index.remove(10)).toBe(false); // Out of bounds
+  });
+
+  it('should support destroy', () => {
+    const index = new FuzzyObjectIndex(users, { keys: ['name'] });
+    index.destroy();
+    expect(index.size).toBe(0);
+  });
+
+  it('should support maxResults and minScore options', () => {
+    const index = new FuzzyObjectIndex(users, { keys: ['name'] });
+    const results = index.search('o', { maxResults: 1 });
+    expect(results.length).toBeLessThanOrEqual(1);
+  });
+
+  it('should match searchObjects results for same data', () => {
+    const index = new FuzzyObjectIndex(users, {
+      keys: [{ name: 'name', weight: 2.0 }, 'email'],
+    });
+    const indexResults = index.search('john');
+    const directResults = searchObjects('john', users, {
+      keys: [{ name: 'name', weight: 2.0 }, 'email'],
+    });
+
+    expect(indexResults.length).toBe(directResults.length);
+    for (let i = 0; i < indexResults.length; i++) {
+      expect(indexResults[i].item).toEqual(directResults[i].item);
+      expect(Math.abs(indexResults[i].score - directResults[i].score)).toBeLessThan(0.001);
+    }
+  });
+
+  it('should support nested key paths', () => {
+    const data = [
+      { user: { name: 'Alice' }, id: 1 },
+      { user: { name: 'Bob' }, id: 2 },
+    ];
+    const index = new FuzzyObjectIndex(data, { keys: ['user.name'] });
+    const results = index.search('alice');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].item.user.name).toBe('Alice');
+  });
+});

--- a/crates/core/src/search/keyed_index.rs
+++ b/crates/core/src/search/keyed_index.rs
@@ -1,0 +1,312 @@
+use std::cell::RefCell;
+
+use napi_derive::napi;
+use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
+use nucleo_matcher::{Config, Matcher, Utf32String};
+
+use super::keys::KeySearchResult;
+use super::{SearchOptions, compute_max_score, resolve_case_matching};
+
+/// A persistent multi-key fuzzy search index backed by Rust-side data.
+///
+/// Holds key text arrays and weights in memory on the Rust side,
+/// avoiding repeated FFI overhead for applications that search the
+/// same dataset multiple times with multiple keys.
+/// Pre-computes Utf32String representations and reuses the Matcher
+/// instance for optimal repeated-search performance.
+///
+/// Typically wrapped by a JS-side `FuzzyObjectIndex` class that maps
+/// results back to original objects.
+#[napi]
+pub struct KeyedFuzzyIndex {
+    key_texts: Vec<Vec<String>>,
+    utf32_keys: Vec<Vec<Utf32String>>,
+    weights: Vec<f64>,
+    total_weight: f64,
+    matcher: RefCell<Matcher>,
+}
+
+fn to_utf32(texts: &[String]) -> Vec<Utf32String> {
+    texts
+        .iter()
+        .map(|s| Utf32String::from(s.as_str()))
+        .collect()
+}
+
+#[napi]
+impl KeyedFuzzyIndex {
+    /// Create a new KeyedFuzzyIndex.
+    ///
+    /// `key_texts[k]` is an array of strings for key `k`, one per item.
+    /// All inner arrays must have the same length (the number of items).
+    #[napi(constructor)]
+    pub fn new(key_texts: Vec<Vec<String>>, weights: Vec<f64>) -> Self {
+        let utf32_keys: Vec<Vec<Utf32String>> = key_texts.iter().map(|t| to_utf32(t)).collect();
+        let total_weight: f64 = weights.iter().sum();
+        Self {
+            key_texts,
+            utf32_keys,
+            weights,
+            total_weight,
+            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
+        }
+    }
+
+    /// Return the number of items in the index.
+    #[napi(getter)]
+    pub fn size(&self) -> u32 {
+        self.key_texts.first().map_or(0, |v| v.len() as u32)
+    }
+
+    /// Search the index for items matching the query.
+    ///
+    /// Returns results sorted by combined weighted score (best match first).
+    #[napi]
+    pub fn search(&self, query: String, options: Option<SearchOptions>) -> Vec<KeySearchResult> {
+        let num_keys = self.key_texts.len();
+
+        if query.is_empty() || num_keys == 0 {
+            return Vec::new();
+        }
+
+        let num_items = self.size() as usize;
+        if num_items == 0 {
+            return Vec::new();
+        }
+
+        let (max_results, min_score, case_matching) = match &options {
+            Some(opts) => (
+                opts.max_results,
+                opts.min_score,
+                resolve_case_matching(opts.is_case_sensitive),
+            ),
+            None => (None, None, CaseMatching::Smart),
+        };
+
+        let threshold = min_score.unwrap_or(0.0);
+
+        let mut matcher = self.matcher.borrow_mut();
+        let pattern = Pattern::parse(&query, case_matching, Normalization::Smart);
+        let max_score = compute_max_score(&query, &pattern, &mut matcher);
+
+        let mut per_key_scores: Vec<Vec<f64>> = Vec::with_capacity(num_keys);
+
+        for utf32_texts in &self.utf32_keys {
+            let mut scores = Vec::with_capacity(num_items);
+            for utf32_item in utf32_texts {
+                let atoms = utf32_item.slice(..);
+                let score = match pattern.score(atoms, &mut matcher) {
+                    Some(raw) => ((raw as f64) / max_score).min(1.0),
+                    None => 0.0,
+                };
+                scores.push(score);
+            }
+            per_key_scores.push(scores);
+        }
+
+        let mut results: Vec<KeySearchResult> = (0..num_items)
+            .filter_map(|i| {
+                let mut weighted_sum = 0.0;
+                let mut matched_any = false;
+                let mut key_scores = Vec::with_capacity(num_keys);
+
+                for (k, key_score_vec) in per_key_scores.iter().enumerate() {
+                    let score = key_score_vec[i];
+                    key_scores.push(score);
+                    if score > 0.0 {
+                        weighted_sum += score * self.weights[k];
+                        matched_any = true;
+                    }
+                }
+
+                if !matched_any {
+                    return None;
+                }
+
+                let combined = weighted_sum / self.total_weight;
+                if combined >= threshold {
+                    Some(KeySearchResult {
+                        index: i as u32,
+                        score: combined,
+                        key_scores,
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        results.sort_unstable_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        if let Some(max) = max_results {
+            results.truncate(max as usize);
+        }
+
+        results
+    }
+
+    /// Add a single item to the index.
+    ///
+    /// `key_values` must have the same length as the number of keys.
+    #[napi]
+    pub fn add(&mut self, key_values: Vec<String>) {
+        for (k, value) in key_values.into_iter().enumerate() {
+            if k < self.key_texts.len() {
+                self.utf32_keys[k].push(Utf32String::from(value.as_str()));
+                self.key_texts[k].push(value);
+            }
+        }
+    }
+
+    /// Add multiple items to the index at once.
+    ///
+    /// Each element of `items_key_values` is an array of key values for one item.
+    #[napi]
+    pub fn add_many(&mut self, items_key_values: Vec<Vec<String>>) {
+        for key_values in items_key_values {
+            self.add(key_values);
+        }
+    }
+
+    /// Remove the item at the given index.
+    ///
+    /// Uses swap-remove for O(1) performance. Returns false if out of bounds.
+    #[napi]
+    pub fn remove(&mut self, index: u32) -> bool {
+        let idx = index as usize;
+        let num_items = self.size() as usize;
+        if idx >= num_items {
+            return false;
+        }
+        for (texts, utf32) in self.key_texts.iter_mut().zip(self.utf32_keys.iter_mut()) {
+            texts.swap_remove(idx);
+            utf32.swap_remove(idx);
+        }
+        true
+    }
+
+    /// Free the internal data. After calling this, the index is empty.
+    #[napi]
+    pub fn destroy(&mut self) {
+        self.key_texts = Vec::new();
+        self.utf32_keys = Vec::new();
+        self.weights = Vec::new();
+        self.total_weight = 0.0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_index() -> KeyedFuzzyIndex {
+        KeyedFuzzyIndex::new(
+            vec![
+                vec![
+                    "John Smith".to_string(),
+                    "Jane Doe".to_string(),
+                    "Bob Johnson".to_string(),
+                ],
+                vec![
+                    "john@example.com".to_string(),
+                    "jane@example.com".to_string(),
+                    "bob@example.com".to_string(),
+                ],
+            ],
+            vec![2.0, 1.0],
+        )
+    }
+
+    #[test]
+    fn test_basic_search() {
+        let index = make_index();
+        let results = index.search("john".to_string(), None);
+        assert!(!results.is_empty());
+        assert_eq!(results[0].index, 0); // John Smith
+    }
+
+    #[test]
+    fn test_size() {
+        let index = make_index();
+        assert_eq!(index.size(), 3);
+    }
+
+    #[test]
+    fn test_add_and_search() {
+        let mut index = make_index();
+        index.add(vec![
+            "John Wick".to_string(),
+            "wick@example.com".to_string(),
+        ]);
+        assert_eq!(index.size(), 4);
+
+        let results = index.search("wick".to_string(), None);
+        assert!(!results.is_empty());
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut index = make_index();
+        assert!(index.remove(1)); // Remove Jane Doe
+        assert_eq!(index.size(), 2);
+        assert!(!index.remove(10)); // Out of bounds
+    }
+
+    #[test]
+    fn test_destroy() {
+        let mut index = make_index();
+        index.destroy();
+        assert_eq!(index.size(), 0);
+    }
+
+    #[test]
+    fn test_empty_query() {
+        let index = make_index();
+        let results = index.search("".to_string(), None);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_min_score() {
+        let index = make_index();
+        let results = index.search(
+            "john".to_string(),
+            Some(SearchOptions {
+                max_results: None,
+                min_score: Some(0.9),
+                include_positions: None,
+                is_case_sensitive: None,
+            }),
+        );
+        for r in &results {
+            assert!(r.score >= 0.9);
+        }
+    }
+
+    #[test]
+    fn test_max_results() {
+        let index = make_index();
+        let results = index.search(
+            "o".to_string(),
+            Some(SearchOptions {
+                max_results: Some(1),
+                min_score: None,
+                include_positions: None,
+                is_case_sensitive: None,
+            }),
+        );
+        assert!(results.len() <= 1);
+    }
+
+    #[test]
+    fn test_key_scores_populated() {
+        let index = make_index();
+        let results = index.search("john".to_string(), None);
+        assert!(!results.is_empty());
+        assert_eq!(results[0].key_scores.len(), 2);
+    }
+}

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -1,7 +1,9 @@
 mod index;
+mod keyed_index;
 mod keys;
 
 pub use index::FuzzyIndex;
+pub use keyed_index::KeyedFuzzyIndex;
 pub use keys::search_keys;
 
 use std::cell::RefCell;

--- a/index.d.mts
+++ b/index.d.mts
@@ -1,5 +1,11 @@
 export * from './index.d.ts';
 export { highlight, highlightRanges } from './highlight.d.ts';
 export type { HighlightRange } from './highlight.d.ts';
-export { searchObjects } from './objects';
-export type { KeyConfig, ObjectSearchOptions, ObjectSearchResult } from './objects';
+export { searchObjects, FuzzyObjectIndex } from './objects';
+export type {
+  KeyConfig,
+  ObjectSearchOptions,
+  ObjectSearchResult,
+  ObjectIndexOptions,
+  ObjectIndexSearchOptions,
+} from './objects';

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,8 @@
  *
  * Holds items in memory on the Rust side, avoiding repeated FFI overhead
  * for applications that search the same dataset multiple times.
+ * Pre-computes Utf32String representations for each item, eliminating
+ * per-search string conversion overhead.
  * Memory is freed when the JavaScript garbage collector collects the instance
  * or when `destroy()` is called explicitly.
  */
@@ -35,6 +37,56 @@ export declare class FuzzyIndex {
    * Remove the item at the given index.
    *
    * Returns false if the index is out of bounds.
+   */
+  remove(index: number): boolean
+  /** Free the internal data. After calling this, the index is empty. */
+  destroy(): void
+}
+
+/**
+ * A persistent multi-key fuzzy search index backed by Rust-side data.
+ *
+ * Holds key text arrays and weights in memory on the Rust side,
+ * avoiding repeated FFI overhead for applications that search the
+ * same dataset multiple times with multiple keys.
+ * Pre-computes Utf32String representations and reuses the Matcher
+ * instance for optimal repeated-search performance.
+ *
+ * Typically wrapped by a JS-side `FuzzyObjectIndex` class that maps
+ * results back to original objects.
+ */
+export declare class KeyedFuzzyIndex {
+  /**
+   * Create a new KeyedFuzzyIndex.
+   *
+   * `key_texts[k]` is an array of strings for key `k`, one per item.
+   * All inner arrays must have the same length (the number of items).
+   */
+  constructor(keyTexts: Array<Array<string>>, weights: Array<number>)
+  /** Return the number of items in the index. */
+  get size(): number
+  /**
+   * Search the index for items matching the query.
+   *
+   * Returns results sorted by combined weighted score (best match first).
+   */
+  search(query: string, options?: SearchOptions | undefined | null): Array<KeySearchResult>
+  /**
+   * Add a single item to the index.
+   *
+   * `key_values` must have the same length as the number of keys.
+   */
+  add(keyValues: Array<string>): void
+  /**
+   * Add multiple items to the index at once.
+   *
+   * Each element of `items_key_values` is an array of key values for one item.
+   */
+  addMany(itemsKeyValues: Array<Array<string>>): void
+  /**
+   * Remove the item at the given index.
+   *
+   * Uses swap-remove for O(1) performance. Returns false if out of bounds.
    */
   remove(index: number): boolean
   /** Free the internal data. After calling this, the index is empty. */

--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-android-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-android-arm-eabi')
         const bindingPackageVersion = require('rapid-fuzzy-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-x64-gnu')
         const bindingPackageVersion = require('rapid-fuzzy-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-x64-msvc')
         const bindingPackageVersion = require('rapid-fuzzy-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-ia32-msvc')
         const bindingPackageVersion = require('rapid-fuzzy-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-arm64-msvc')
         const bindingPackageVersion = require('rapid-fuzzy-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('rapid-fuzzy-darwin-universal')
       const bindingPackageVersion = require('rapid-fuzzy-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-darwin-x64')
         const bindingPackageVersion = require('rapid-fuzzy-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-darwin-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-freebsd-x64')
         const bindingPackageVersion = require('rapid-fuzzy-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-freebsd-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-x64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-x64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm-musleabihf')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm-gnueabihf')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-loong64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-loong64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-riscv64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-riscv64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-linux-ppc64-gnu')
         const bindingPackageVersion = require('rapid-fuzzy-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-linux-s390x-gnu')
         const bindingPackageVersion = require('rapid-fuzzy-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-openharmony-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-openharmony-x64')
         const bindingPackageVersion = require('rapid-fuzzy-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-openharmony-arm')
         const bindingPackageVersion = require('rapid-fuzzy-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -577,6 +577,7 @@ if (!nativeBinding) {
 
 module.exports = nativeBinding
 module.exports.FuzzyIndex = nativeBinding.FuzzyIndex
+module.exports.KeyedFuzzyIndex = nativeBinding.KeyedFuzzyIndex
 module.exports.closest = nativeBinding.closest
 module.exports.damerauLevenshtein = nativeBinding.damerauLevenshtein
 module.exports.damerauLevenshteinBatch = nativeBinding.damerauLevenshteinBatch

--- a/index.mjs
+++ b/index.mjs
@@ -42,4 +42,4 @@ export const {
   highlightRanges,
 } = { ...binding, ...require('./highlight.js') };
 
-export const { searchObjects } = require('./objects.js');
+export const { searchObjects, FuzzyObjectIndex } = require('./objects.js');

--- a/objects.d.ts
+++ b/objects.d.ts
@@ -45,3 +45,60 @@ export declare function searchObjects<T>(
   items: Array<T>,
   options: ObjectSearchOptions,
 ): Array<ObjectSearchResult<T>>;
+
+export interface ObjectIndexOptions {
+  keys: Array<string | KeyConfig>;
+}
+
+export interface ObjectIndexSearchOptions {
+  maxResults?: number;
+  minScore?: number;
+  isCaseSensitive?: boolean;
+}
+
+/**
+ * A persistent fuzzy search index for object collections with weighted keys.
+ *
+ * Pre-computes key texts and stores them on the Rust side for fast repeated
+ * searches. Use this when searching the same collection multiple times.
+ *
+ * @example
+ * ```typescript
+ * const index = new FuzzyObjectIndex(users, {
+ *   keys: [{ name: 'name', weight: 2.0 }, 'email'],
+ * });
+ *
+ * const results = index.search('john');
+ * // results[0].item → { name: 'John Smith', ... }
+ *
+ * index.add({ name: 'New User', email: 'new@example.com' });
+ * index.destroy(); // free Rust-side memory
+ * ```
+ */
+export declare class FuzzyObjectIndex<T> {
+  constructor(items: Array<T>, options: ObjectIndexOptions);
+
+  /** Number of items in the index. */
+  get size(): number;
+
+  /** Search for objects matching the query. */
+  search(
+    query: string,
+    options?: ObjectIndexSearchOptions,
+  ): Array<Omit<ObjectSearchResult<T>, 'positions'>>;
+
+  /** Find the closest matching object, or null if no match. */
+  closest(query: string, minScore?: number): T | null;
+
+  /** Add a single item to the index. */
+  add(item: T): void;
+
+  /** Add multiple items at once. */
+  addMany(items: Array<T>): void;
+
+  /** Remove the item at the given index (swap-remove semantics). */
+  remove(index: number): boolean;
+
+  /** Free all internal data. */
+  destroy(): void;
+}

--- a/objects.js
+++ b/objects.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { searchKeys } = require('./index.js');
+const { searchKeys, KeyedFuzzyIndex } = require('./index.js');
 
 /**
  * Get a nested property value from an object using a dot-separated path.
@@ -56,4 +56,115 @@ function searchObjects(query, items, options) {
   }));
 }
 
-module.exports = { searchObjects };
+/**
+ * A persistent fuzzy search index for object collections with weighted keys.
+ *
+ * Pre-computes key texts and stores them on the Rust side for fast repeated
+ * searches. Use this when searching the same collection multiple times.
+ *
+ * @template T
+ */
+class FuzzyObjectIndex {
+  /** @type {T[]} */
+  #items;
+  /** @type {KeyedFuzzyIndex} */
+  #index;
+  /** @type {Array<{ name: string; weight: number }>} */
+  #keys;
+
+  /**
+   * @param {T[]} items - Array of objects to index.
+   * @param {object} options - Index configuration.
+   * @param {Array<string | { name: string; weight?: number }>} options.keys - Keys to search.
+   */
+  constructor(items, options) {
+    this.#keys = options.keys.map((k) =>
+      typeof k === 'string' ? { name: k, weight: 1.0 } : { name: k.name, weight: k.weight ?? 1.0 },
+    );
+    this.#items = [...items];
+
+    const keyTexts = this.#keys.map((k) => items.map((item) => getNestedValue(item, k.name)));
+    const weights = this.#keys.map((k) => k.weight);
+    this.#index = new KeyedFuzzyIndex(keyTexts, weights);
+  }
+
+  /** Return the number of items in the index. */
+  get size() {
+    return this.#index.size;
+  }
+
+  /**
+   * Search the index for objects matching the query.
+   * @param {string} query
+   * @param {object} [options]
+   * @param {number} [options.maxResults]
+   * @param {number} [options.minScore]
+   * @param {boolean} [options.isCaseSensitive]
+   * @returns {Array<{ item: T; index: number; score: number; keyScores: number[] }>}
+   */
+  search(query, options) {
+    const results = this.#index.search(query, options);
+    return results.map((r) => ({
+      item: this.#items[r.index],
+      index: r.index,
+      score: r.score,
+      keyScores: r.keyScores,
+    }));
+  }
+
+  /**
+   * Find the closest matching object.
+   * @param {string} query
+   * @param {number} [minScore]
+   * @returns {T | null}
+   */
+  closest(query, minScore) {
+    const results = this.#index.search(query, { maxResults: 1, minScore });
+    return results.length > 0 ? this.#items[results[0].index] : null;
+  }
+
+  /**
+   * Add a single item to the index.
+   * @param {T} item
+   */
+  add(item) {
+    this.#items.push(item);
+    this.#index.add(this.#keys.map((k) => getNestedValue(item, k.name)));
+  }
+
+  /**
+   * Add multiple items to the index at once.
+   * @param {T[]} items
+   */
+  addMany(items) {
+    for (const item of items) {
+      this.#items.push(item);
+    }
+    this.#index.addMany(items.map((item) => this.#keys.map((k) => getNestedValue(item, k.name))));
+  }
+
+  /**
+   * Remove the item at the given index.
+   * Uses swap-remove semantics for O(1) performance.
+   * @param {number} index
+   * @returns {boolean}
+   */
+  remove(index) {
+    if (index < 0 || index >= this.#items.length) return false;
+    // Swap-remove to match Rust-side behavior
+    const lastIdx = this.#items.length - 1;
+    if (index !== lastIdx) {
+      this.#items[index] = this.#items[lastIdx];
+    }
+    this.#items.pop();
+    return this.#index.remove(index);
+  }
+
+  /** Free all internal data. */
+  destroy() {
+    this.#items = [];
+    this.#index.destroy();
+  }
+}
+
+module.exports = { searchObjects, FuzzyObjectIndex };


### PR DESCRIPTION
## Summary

Add `FuzzyObjectIndex<T>` class for persistent indexed search over object collections with weighted keys. This combines the ergonomics of `searchObjects()` with the performance benefits of `FuzzyIndex` for repeated searches on the same dataset.

### Rust side: `KeyedFuzzyIndex`
- Stores multi-key text arrays with pre-computed `Utf32String` representations
- Caches `Matcher` instance via `RefCell` for ~135KB allocation savings per search
- Same weighted scoring logic as `searchKeys()`

### JS side: `FuzzyObjectIndex<T>`
- Wraps `KeyedFuzzyIndex` with object mapping
- Supports `search()`, `closest()`, `add()`, `addMany()`, `remove()`, `destroy()`
- Nested key paths via dot notation (e.g., `'user.name'`)

```typescript
const index = new FuzzyObjectIndex(users, {
  keys: [{ name: 'name', weight: 2.0 }, 'email'],
});
const results = index.search('john');
// → [{ item: users[0], score: 0.95, keyScores: [0.98, 0.85] }]
```

Closes #163

## Checklist

- [x] `cargo test` — 169 Rust tests pass (160 + 9 new)
- [x] `pnpm test` — 188 JS tests pass (177 + 11 new)
- [x] `cargo clippy -- -W clippy::all` — no warnings
- [x] `pnpm run typecheck` — no errors
- [x] `pnpm run check` — lint clean (3 warnings only)
- [x] Pre-push hooks pass
- [x] Changeset added (minor bump)
- [x] Parity test: FuzzyObjectIndex results match searchObjects