### PR TITLE
perf(core): optimize search result construction with two-pass scoring

### DIFF
--- a/.changeset/search-result-allocation.md
+++ b/.changeset/search-result-allocation.md
@@ -1,0 +1,5 @@
+---
+'rapid-fuzzy': patch
+---
+
+Optimize search result construction with two-pass scoring to reduce heap allocations

--- a/crates/core/src/search/keyed_index.rs
+++ b/crates/core/src/search/keyed_index.rs
@@ -104,15 +104,14 @@ impl KeyedFuzzyIndex {
             per_key_scores.push(scores);
         }
 
-        let mut results: Vec<KeySearchResult> = (0..num_items)
+        // Pass 1: Compute combined scores, collect (index, score) only.
+        let mut scored: Vec<(u32, f64)> = (0..num_items)
             .filter_map(|i| {
                 let mut weighted_sum = 0.0;
                 let mut matched_any = false;
-                let mut key_scores = Vec::with_capacity(num_keys);
 
                 for (k, key_score_vec) in per_key_scores.iter().enumerate() {
                     let score = key_score_vec[i];
-                    key_scores.push(score);
                     if score > 0.0 {
                         weighted_sum += score * self.weights[k];
                         matched_any = true;
@@ -125,28 +124,34 @@ impl KeyedFuzzyIndex {
 
                 let combined = weighted_sum / self.total_weight;
                 if combined >= threshold {
-                    Some(KeySearchResult {
-                        index: i as u32,
-                        score: combined,
-                        key_scores,
-                    })
+                    Some((i as u32, combined))
                 } else {
                     None
                 }
             })
             .collect();
 
-        results.sort_unstable_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        scored.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
         if let Some(max) = max_results {
-            results.truncate(max as usize);
+            scored.truncate(max as usize);
         }
 
-        results
+        // Pass 2: Construct KeySearchResult only for the final top-k items.
+        scored
+            .into_iter()
+            .map(|(index, score)| {
+                let key_scores: Vec<f64> = per_key_scores
+                    .iter()
+                    .map(|scores| scores[index as usize])
+                    .collect();
+                KeySearchResult {
+                    index,
+                    score,
+                    key_scores,
+                }
+            })
+            .collect()
     }
 
     /// Add a single item to the index.

--- a/crates/core/src/search/keys.rs
+++ b/crates/core/src/search/keys.rs
@@ -91,16 +91,14 @@ pub fn search_keys(
         per_key_scores.push(scores);
     }
 
-    // Combine weighted scores per item
-    let mut results: Vec<KeySearchResult> = (0..num_items)
+    // Pass 1: Compute combined scores, collect (index, score) only.
+    let mut scored: Vec<(u32, f64)> = (0..num_items)
         .filter_map(|i| {
             let mut weighted_sum = 0.0;
             let mut matched_any = false;
-            let mut key_scores = Vec::with_capacity(num_keys);
 
             for k in 0..num_keys {
                 let score = per_key_scores[k][i];
-                key_scores.push(score);
                 if score > 0.0 {
                     weighted_sum += score * weights[k];
                     matched_any = true;
@@ -113,28 +111,34 @@ pub fn search_keys(
 
             let combined = weighted_sum / total_weight;
             if combined >= threshold {
-                Some(KeySearchResult {
-                    index: i as u32,
-                    score: combined,
-                    key_scores,
-                })
+                Some((i as u32, combined))
             } else {
                 None
             }
         })
         .collect();
 
-    results.sort_unstable_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    scored.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
     if let Some(max) = max_results {
-        results.truncate(max as usize);
+        scored.truncate(max as usize);
     }
 
-    results
+    // Pass 2: Construct KeySearchResult only for the final top-k items.
+    scored
+        .into_iter()
+        .map(|(index, score)| {
+            let key_scores: Vec<f64> = per_key_scores
+                .iter()
+                .map(|scores| scores[index as usize])
+                .collect();
+            KeySearchResult {
+                index,
+                score,
+                key_scores,
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -80,49 +80,53 @@ pub(crate) fn search_over_items(
 
     let mut buf = Vec::new();
 
-    let mut results: Vec<SearchResult> = items
+    // Pass 1: Score all items, collect (index, score) only — no String cloning.
+    let mut scored: Vec<(u32, f64)> = items
         .iter()
         .enumerate()
         .filter_map(|(index, item)| {
             buf.clear();
             let atoms = nucleo_matcher::Utf32Str::new(item, &mut buf);
-
-            let (raw_score, positions) = if include_positions {
-                let mut indices = Vec::new();
-                let score = pattern.indices(atoms, &mut matcher, &mut indices)?;
-                indices.sort_unstable();
-                indices.dedup();
-                (score, indices)
-            } else {
-                let score = pattern.score(atoms, &mut matcher)?;
-                (score, Vec::new())
-            };
-
+            let raw_score = pattern.score(atoms, &mut matcher)?;
             let normalized = (raw_score as f64 / max_score).min(1.0);
             if normalized >= threshold {
-                Some(SearchResult {
-                    item: item.clone(),
-                    score: normalized,
-                    index: index as u32,
-                    positions,
-                })
+                Some((index as u32, normalized))
             } else {
                 None
             }
         })
         .collect();
 
-    results.sort_unstable_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    scored.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
     if let Some(max) = max_results {
-        results.truncate(max as usize);
+        scored.truncate(max as usize);
     }
 
-    results
+    // Pass 2: Construct results only for the final top-k items.
+    scored
+        .into_iter()
+        .map(|(index, score)| {
+            let positions = if include_positions {
+                buf.clear();
+                let atoms = nucleo_matcher::Utf32Str::new(&items[index as usize], &mut buf);
+                let mut indices = Vec::new();
+                pattern.indices(atoms, &mut matcher, &mut indices);
+                indices.sort_unstable();
+                indices.dedup();
+                indices
+            } else {
+                Vec::new()
+            };
+
+            SearchResult {
+                item: items[index as usize].clone(),
+                score,
+                index,
+                positions,
+            }
+        })
+        .collect()
 }
 
 /// Pre-computed search context for FuzzyIndex.
@@ -155,49 +159,51 @@ pub(crate) fn search_over_precomputed(
     let max_score = compute_max_score(query, &pattern, &mut matcher);
     let threshold = min_score.unwrap_or(0.0);
 
-    let mut results: Vec<SearchResult> = items
+    // Pass 1: Score all items, collect (index, score) only — no String cloning.
+    let mut scored: Vec<(u32, f64)> = utf32_items
         .iter()
-        .zip(utf32_items.iter())
         .enumerate()
-        .filter_map(|(index, (item, utf32_item))| {
+        .filter_map(|(index, utf32_item)| {
             let atoms = utf32_item.slice(..);
-
-            let (raw_score, positions) = if include_positions {
-                let mut indices = Vec::new();
-                let score = pattern.indices(atoms, &mut matcher, &mut indices)?;
-                indices.sort_unstable();
-                indices.dedup();
-                (score, indices)
-            } else {
-                let score = pattern.score(atoms, &mut matcher)?;
-                (score, Vec::new())
-            };
-
+            let raw_score = pattern.score(atoms, &mut matcher)?;
             let normalized = (raw_score as f64 / max_score).min(1.0);
             if normalized >= threshold {
-                Some(SearchResult {
-                    item: item.clone(),
-                    score: normalized,
-                    index: index as u32,
-                    positions,
-                })
+                Some((index as u32, normalized))
             } else {
                 None
             }
         })
         .collect();
 
-    results.sort_unstable_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    scored.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
     if let Some(max) = max_results {
-        results.truncate(max as usize);
+        scored.truncate(max as usize);
     }
 
-    results
+    // Pass 2: Construct results only for the final top-k items.
+    scored
+        .into_iter()
+        .map(|(index, score)| {
+            let positions = if include_positions {
+                let atoms = utf32_items[index as usize].slice(..);
+                let mut indices = Vec::new();
+                pattern.indices(atoms, &mut matcher, &mut indices);
+                indices.sort_unstable();
+                indices.dedup();
+                indices
+            } else {
+                Vec::new()
+            };
+
+            SearchResult {
+                item: items[index as usize].clone(),
+                score,
+                index,
+                positions,
+            }
+        })
+        .collect()
 }
 
 /// Internal search implementation used by both the napi export and tests.


### PR DESCRIPTION
## Summary

- Adopt two-pass approach for all search functions: score-only pass first (`(index, score)` tuples), then construct full results only for the final top-k items after sort+truncate
- Eliminates unnecessary `String::clone()` and `Vec<u32>` position allocations for non-top-k matched items
- Applied consistently across `search_over_items`, `search_over_precomputed`, `search_keys`, and `KeyedFuzzyIndex::search`

For a 10K dataset with ~5K matches and `maxResults: 10`, this reduces String clones from ~5000 to 10 and skips ~4990 unnecessary position Vec allocations.

## Related issue

Closes #193

## Checklist

- [x] `cargo test` — 169 tests pass
- [x] `pnpm test` — 188 tests pass
- [x] `cargo clippy` — clean
- [x] `pnpm run check` — clean
- [x] `pnpm run typecheck` — clean
- [x] Changeset added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced search performance through optimized result computation and reduced memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->