### PR TITLE
docs: update benchmarks and add FuzzyIndex docs for v0.5.0

### DIFF
--- a/.github/assets/bench-distance.svg
+++ b/.github/assets/bench-distance.svg
@@ -15,18 +15,18 @@
 <text x="20" y="66" class="group-label">Levenshtein</text>
 <text x="172" y="91" class="bar-label" text-anchor="end">fastest-levenshtein</text>
 <rect x="180" y="74" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="632" y="91" class="bar-value" text-anchor="end">774,820 ops/s</text>
-<text x="172" y="122" class="bar-label" text-anchor="end">leven</text>
-<rect x="180" y="105" width="121.13990346144911" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="309.1399034614491" y="122" class="bar-value" text-anchor="start">204,047 ops/s</text>
-<text x="172" y="153" class="bar-label" text-anchor="end">rapid-fuzzy</text>
-<rect x="180" y="136" width="114.93350713714152" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="302.93350713714153" y="153" class="bar-value" text-anchor="start">193,593 ops/s</text>
+<text x="632" y="91" class="bar-value" text-anchor="end">739,107 ops/s</text>
+<text x="172" y="122" class="bar-label" text-anchor="end">rapid-fuzzy</text>
+<rect x="180" y="105" width="328.73413457050196" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="500.73413457050196" y="122" class="bar-value" text-anchor="end" fill="#ffffff">528,195 ops/s</text>
+<text x="172" y="153" class="bar-label" text-anchor="end">leven</text>
+<rect x="180" y="136" width="138.05283944002696" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="326.05283944002696" y="153" class="bar-value" text-anchor="start">221,817 ops/s</text>
 <text x="20" y="200" class="group-label">Sorensen-Dice</text>
 <text x="172" y="225" class="bar-label" text-anchor="end">rapid-fuzzy</text>
 <rect x="180" y="208" width="460" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="632" y="225" class="bar-value" text-anchor="end" fill="#ffffff">144,698 ops/s</text>
+<text x="632" y="225" class="bar-value" text-anchor="end" fill="#ffffff">149,567 ops/s</text>
 <text x="172" y="256" class="bar-label" text-anchor="end">string-similarity</text>
-<rect x="180" y="239" width="267.3822720424609" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="439.3822720424609" y="256" class="bar-value" text-anchor="end">84,108 ops/s</text>
+<rect x="180" y="239" width="254.98726323319983" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="426.9872632331998" y="256" class="bar-value" text-anchor="end">82,908 ops/s</text>
 </svg>

--- a/.github/assets/bench-search.svg
+++ b/.github/assets/bench-search.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 427" width="680" height="427">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 520" width="680" height="520">
 <style>
   text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
   .title { font-size: 16px; font-weight: 600; fill: #1f2937; }
@@ -8,38 +8,47 @@
   .bar-value { font-size: 12px; fill: #374151; font-weight: 500; }
   .multiplier { font-size: 11px; fill: #059669; font-weight: 600; }
 </style>
-<rect width="680" height="427" rx="8" fill="#ffffff" />
-<rect x="0.5" y="0.5" width="679" height="426" rx="8" fill="none" stroke="#e5e7eb" />
+<rect width="680" height="520" rx="8" fill="#ffffff" />
+<rect x="0.5" y="0.5" width="679" height="519" rx="8" fill="none" stroke="#e5e7eb" />
 <text x="20" y="28" class="title">Fuzzy Search Performance</text>
 <text x="20" y="44" class="subtitle">ops/s (higher is better)</text>
 <text x="20" y="66" class="group-label">Small</text>
 <text x="172" y="91" class="bar-label" text-anchor="end">fuzzysort</text>
 <rect x="180" y="74" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="632" y="91" class="bar-value" text-anchor="end">2,501,773 ops/s</text>
-<text x="172" y="122" class="bar-label" text-anchor="end">rapid-fuzzy</text>
-<rect x="180" y="105" width="32.953477393832294" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="220.9534773938323" y="122" class="bar-value" text-anchor="start">179,222 ops/s — 2x vs fuse.js</text>
-<text x="172" y="153" class="bar-label" text-anchor="end">fuse.js</text>
-<rect x="180" y="136" width="20.052634671490978" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="208.05263467149098" y="153" class="bar-value" text-anchor="start">109,059 ops/s</text>
-<text x="20" y="200" class="group-label">Medium</text>
-<text x="172" y="225" class="bar-label" text-anchor="end">fuzzysort</text>
-<rect x="180" y="208" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="632" y="225" class="bar-value" text-anchor="end">63,032 ops/s</text>
-<text x="172" y="256" class="bar-label" text-anchor="end">rapid-fuzzy</text>
-<rect x="180" y="239" width="48.26818124127427" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="236.26818124127428" y="256" class="bar-value" text-anchor="start">6,614 ops/s — 17x vs fuse.js</text>
-<text x="172" y="287" class="bar-label" text-anchor="end">fuse.js</text>
-<rect x="180" y="270" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="192" y="287" class="bar-value" text-anchor="start">381 ops/s</text>
-<text x="20" y="334" class="group-label">Large</text>
-<text x="172" y="359" class="bar-label" text-anchor="end">fuzzysort</text>
-<rect x="180" y="342" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="632" y="359" class="bar-value" text-anchor="end">28,616 ops/s</text>
-<text x="172" y="390" class="bar-label" text-anchor="end">rapid-fuzzy</text>
-<rect x="180" y="373" width="12.763488957226727" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="200.76348895722674" y="390" class="bar-value" text-anchor="start">794 ops/s — 40x vs fuse.js</text>
-<text x="172" y="421" class="bar-label" text-anchor="end">fuse.js</text>
-<rect x="180" y="404" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="192" y="421" class="bar-value" text-anchor="start">20 ops/s</text>
+<text x="632" y="91" class="bar-value" text-anchor="end">2,502,299 ops/s</text>
+<text x="172" y="122" class="bar-label" text-anchor="end">FuzzyIndex</text>
+<rect x="180" y="105" width="74.68481584335046" height="26" rx="4" fill="#60a5fa" opacity="1" />
+<text x="262.68481584335046" y="122" class="bar-value" text-anchor="start">406,269 ops/s</text>
+<text x="172" y="153" class="bar-label" text-anchor="end">rapid-fuzzy</text>
+<rect x="180" y="136" width="32.13585586694476" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="220.13585586694475" y="153" class="bar-value" text-anchor="start">174,812 ops/s</text>
+<text x="172" y="184" class="bar-label" text-anchor="end">fuse.js</text>
+<rect x="180" y="167" width="23.377230299017025" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="211.37723029901701" y="184" class="bar-value" text-anchor="start">127,167 ops/s</text>
+<text x="20" y="231" class="group-label">Medium</text>
+<text x="172" y="256" class="bar-label" text-anchor="end">fuzzysort</text>
+<rect x="180" y="239" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="632" y="256" class="bar-value" text-anchor="end">62,845 ops/s</text>
+<text x="172" y="287" class="bar-label" text-anchor="end">FuzzyIndex</text>
+<rect x="180" y="270" width="161.13358262391597" height="26" rx="4" fill="#60a5fa" opacity="1" />
+<text x="349.13358262391597" y="287" class="bar-value" text-anchor="start">22,014 ops/s — 17x vs fuse.js</text>
+<text x="172" y="318" class="bar-label" text-anchor="end">rapid-fuzzy</text>
+<rect x="180" y="301" width="47.80428037234466" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="235.80428037234466" y="318" class="bar-value" text-anchor="start">6,531 ops/s — 17x vs fuse.js</text>
+<text x="172" y="349" class="bar-label" text-anchor="end">fuse.js</text>
+<rect x="180" y="332" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="192" y="349" class="bar-value" text-anchor="start">395 ops/s</text>
+<text x="20" y="396" class="group-label">Large</text>
+<text x="172" y="421" class="bar-label" text-anchor="end">fuzzysort</text>
+<rect x="180" y="404" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="632" y="421" class="bar-value" text-anchor="end">28,846 ops/s</text>
+<text x="172" y="452" class="bar-label" text-anchor="end">FuzzyIndex</text>
+<rect x="180" y="435" width="63.54780558829648" height="26" rx="4" fill="#60a5fa" opacity="1" />
+<text x="251.54780558829648" y="452" class="bar-value" text-anchor="start">3,985 ops/s — 40x vs fuse.js</text>
+<text x="172" y="483" class="bar-label" text-anchor="end">rapid-fuzzy</text>
+<rect x="180" y="466" width="12.661720862511267" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="200.66172086251126" y="483" class="bar-value" text-anchor="start">794 ops/s — 40x vs fuse.js</text>
+<text x="172" y="514" class="bar-label" text-anchor="end">fuse.js</text>
+<rect x="180" y="497" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="192" y="514" class="bar-value" text-anchor="start">20 ops/s</text>
 </svg>

--- a/README.md
+++ b/README.md
@@ -112,6 +112,38 @@ searchObjects('john', users, {
 searchObjects('new york', items, { keys: ['address.city'] });
 ```
 
+### Persistent Index
+
+For applications that search the same dataset repeatedly (autocomplete, file finders, etc.), use `FuzzyIndex` or `FuzzyObjectIndex` to keep data on the Rust side and eliminate per-search FFI overhead:
+
+```typescript
+import { FuzzyIndex, FuzzyObjectIndex } from 'rapid-fuzzy';
+
+// String search index — up to 5x faster than standalone search()
+const index = new FuzzyIndex(['TypeScript', 'JavaScript', 'Python', ...]);
+
+index.search('typscript', { maxResults: 5 });
+index.closest('tsc');
+
+// Mutate the index without rebuilding
+index.add('Rust');
+index.remove(2); // swap-remove by index
+
+// Object search index — keeps objects on the JS side, keys on the Rust side
+const userIndex = new FuzzyObjectIndex(users, {
+  keys: [
+    { name: 'name', weight: 2.0 },
+    { name: 'email', weight: 1.0 },
+  ],
+});
+
+userIndex.search('john', { maxResults: 10 });
+
+// Free Rust-side memory when done
+index.destroy();
+userIndex.destroy();
+```
+
 ### Match Highlighting
 
 Convert matched positions into highlighted markup for UI rendering:
@@ -196,15 +228,15 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 | Function | rapid-fuzzy | fastest-levenshtein | leven | string-similarity |
 |---|---:|---:|---:|---:|
-| Levenshtein | 193,593 ops/s | **774,820 ops/s** | 204,047 ops/s | — |
-| Normalized Levenshtein | **136,854 ops/s** | — | — | — |
-| Sorensen-Dice | **144,698 ops/s** | — | — | 84,108 ops/s |
-| Jaro-Winkler | **291,673 ops/s** | — | — | — |
-| Damerau-Levenshtein | **72,238 ops/s** | — | — | — |
+| Levenshtein | 528,195 ops/s | **739,107 ops/s** | 221,817 ops/s | — |
+| Normalized Levenshtein | **534,231 ops/s** | — | — | — |
+| Sorensen-Dice | **149,567 ops/s** | — | — | 82,908 ops/s |
+| Jaro-Winkler | **278,554 ops/s** | — | — | — |
+| Damerau-Levenshtein | **112,370 ops/s** | — | — | — |
 
 </details>
 
-> **Note**: For single-pair Levenshtein distance, fastest-levenshtein is faster due to its highly optimized pure-JS implementation that avoids FFI overhead. rapid-fuzzy provides broader algorithm coverage and excels in batch / search scenarios.
+> **Note**: For single-pair Levenshtein, fastest-levenshtein is ~1.4x faster due to its optimized pure-JS implementation that avoids FFI overhead. rapid-fuzzy is **2.4x faster** than leven, and provides broader algorithm coverage plus batch / search scenarios.
 
 ### Search Performance
 
@@ -213,27 +245,28 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 <details>
 <summary>Raw numbers</summary>
 
-| Dataset size | rapid-fuzzy | fuse.js | fuzzysort |
-|---|---:|---:|---:|
-| Small (20 items) | 179,222 ops/s | 109,059 ops/s | **2,501,773 ops/s** |
-| Medium (1K items) | 6,614 ops/s | 381 ops/s | **63,032 ops/s** |
-| Large (10K items) | 794 ops/s | 20 ops/s | **28,616 ops/s** |
+| Dataset size | rapid-fuzzy | FuzzyIndex | fuse.js | fuzzysort |
+|---|---:|---:|---:|---:|
+| Small (20 items) | 174,812 ops/s | 406,269 ops/s | 127,167 ops/s | **2,502,299 ops/s** |
+| Medium (1K items) | 6,531 ops/s | 22,014 ops/s | 395 ops/s | **62,845 ops/s** |
+| Large (10K items) | 794 ops/s | 3,985 ops/s | 20 ops/s | **28,846 ops/s** |
 
 </details>
 
 ### Closest Match (Levenshtein-based)
 
-| Dataset size | rapid-fuzzy | fastest-levenshtein |
-|---|---:|---:|
-| Medium (1K items) | 8,416 ops/s | **8,762 ops/s** |
-| Large (10K items) | **905 ops/s** | 662 ops/s |
+| Dataset size | rapid-fuzzy | FuzzyIndex | fastest-levenshtein |
+|---|---:|---:|---:|
+| Medium (1K items) | 8,304 ops/s | **60,469 ops/s** | 8,946 ops/s |
+| Large (10K items) | 757 ops/s | **4,103 ops/s** | 604 ops/s |
 
-> rapid-fuzzy is up to **1.4x faster** than fastest-levenshtein for closest-match lookups on large datasets.
+> With `FuzzyIndex`, rapid-fuzzy is up to **6.8x faster** than fastest-levenshtein for closest-match lookups.
 
 ### Why these numbers matter
 
 - **vs fuse.js**: rapid-fuzzy is **17x faster** on medium datasets and **40x faster** on large datasets for fuzzy search.
-- **vs fastest-levenshtein**: rapid-fuzzy wins on closest-match at scale where batch FFI overhead is amortized.
+- **FuzzyIndex**: Pre-computing string data on the Rust side gives an additional **3–5x speedup** over standalone `search()`, making it the recommended approach for repeated searches.
+- **vs fastest-levenshtein**: With `FuzzyIndex`, closest-match is **6.8x faster** at scale. Even standalone `closest()` wins on large datasets.
 - **fuzzysort** uses a different (substring-based) matching algorithm that is extremely fast but produces different ranking results. Choose based on your matching needs.
 
 Run benchmarks yourself:
@@ -255,6 +288,7 @@ cargo bench           # Rust internal benchmarks
 | Substring / abbreviation matching | `partialRatio` | Finds best partial match within longer strings |
 | Best-effort similarity | `weightedRatio` | Picks the best score across all methods automatically |
 | Interactive fuzzy search | `search`, `closest` | Nucleo algorithm (same as Helix editor) |
+| Repeated search on same data | `FuzzyIndex`, `FuzzyObjectIndex` | Persistent Rust-side index, 3–5x faster than standalone |
 
 **Return types:**
 
@@ -270,6 +304,7 @@ cargo bench           # Rust internal benchmarks
 | **Algorithms** | 9 (Levenshtein, Jaro, Dice, …) | Bitap | Levenshtein | Substring |
 | **Runtime** | Rust native + WASM | Pure JS | Pure JS | Pure JS |
 | **Object search** | ✅ weighted keys | ✅ | — | ✅ |
+| **Persistent index** | ✅ FuzzyIndex / FuzzyObjectIndex | — | — | ✅ prepared targets |
 | **Score threshold** | ✅ | ✅ | — | ✅ |
 | **Match positions** | ✅ | ✅ | — | ✅ |
 | **Highlight utility** | ✅ | — | — | ✅ |

--- a/docs/migration/from-fuse-js.md
+++ b/docs/migration/from-fuse-js.md
@@ -148,12 +148,26 @@ highlight(results[0].item, results[0].positions, '<b>', '</b>');
 
 rapid-fuzzy is significantly faster than fuse.js for fuzzy search:
 
-| Dataset size | rapid-fuzzy | fuse.js | Speedup |
-|---|---:|---:|---:|
-| 1,000 items | 6,614 ops/s | 381 ops/s | **17x** |
-| 10,000 items | 794 ops/s | 20 ops/s | **40x** |
+| Dataset size | rapid-fuzzy | FuzzyIndex | fuse.js | Speedup |
+|---|---:|---:|---:|---:|
+| 1,000 items | 6,531 ops/s | 22,014 ops/s | 395 ops/s | **17x / 56x** |
+| 10,000 items | 794 ops/s | 3,985 ops/s | 20 ops/s | **40x / 199x** |
 
 The performance advantage grows with dataset size because rapid-fuzzy's Rust-based nucleo engine scales better than fuse.js's pure JavaScript implementation.
+
+For repeated searches against the same dataset, use `FuzzyIndex` (for string arrays) or `FuzzyObjectIndex` (for object arrays with keys) to get even greater speedups. These work similarly to fuse.js's constructor — build once, search many times:
+
+```typescript
+import { FuzzyIndex, FuzzyObjectIndex } from 'rapid-fuzzy';
+
+// String search — replaces new Fuse(strings).search(query)
+const index = new FuzzyIndex(strings);
+const results = index.search('query');
+
+// Object search — replaces new Fuse(objects, { keys }).search(query)
+const objIndex = new FuzzyObjectIndex(users, { keys: ['name', 'email'] });
+const results = objIndex.search('john');
+```
 
 ## Additional Capabilities
 

--- a/docs/migration/from-leven.md
+++ b/docs/migration/from-leven.md
@@ -104,23 +104,35 @@ const results = search('type', ['TypeScript', 'JavaScript', 'Python']);
 
 ## Performance Considerations
 
-For single-pair Levenshtein distance, fastest-levenshtein is faster due to its highly optimized pure-JS implementation that avoids FFI overhead:
+For single-pair Levenshtein distance, fastest-levenshtein is still faster due to zero FFI overhead, but the gap has narrowed significantly with v0.5.0's bit-parallel algorithm:
 
 | Operation | rapid-fuzzy | fastest-levenshtein | leven |
 |---|---:|---:|---:|
-| Single pair | 193,593 ops/s | **774,820 ops/s** | 204,047 ops/s |
+| Single pair | 528,195 ops/s | **739,107 ops/s** | 221,817 ops/s |
 
-However, rapid-fuzzy excels in closest-match scenarios where batch FFI overhead is amortized:
+rapid-fuzzy is 2.4x faster than leven and within 1.4x of fastest-levenshtein.
 
-| Closest match | rapid-fuzzy | fastest-levenshtein | Speedup |
+For closest-match scenarios, rapid-fuzzy pulls ahead — especially with `FuzzyIndex` for repeated searches:
+
+| Closest match | rapid-fuzzy | FuzzyIndex | fastest-levenshtein |
 |---|---:|---:|---:|
-| 1,000 items | 8,416 ops/s | **8,762 ops/s** | — |
-| 10,000 items | **905 ops/s** | 662 ops/s | 1.4x |
+| 1,000 items | 8,304 ops/s | **60,469 ops/s** | 8,946 ops/s |
+| 10,000 items | 757 ops/s | **4,103 ops/s** | 604 ops/s |
+
+`FuzzyIndex` pre-computes internal data structures, making it **6.8x faster** than fastest-levenshtein for closest-match on 1K items. For repeated searches against the same dataset, always prefer `FuzzyIndex`:
+
+```typescript
+import { FuzzyIndex } from 'rapid-fuzzy';
+
+const index = new FuzzyIndex(['slow', 'faster', 'fastest', /* ... */]);
+const best = index.closest('fast'); // 'faster' — uses pre-built index
+```
 
 **When to choose rapid-fuzzy over fastest-levenshtein**:
 - You need more than just Levenshtein (similarity scores, other algorithms)
 - You process batches of string pairs
 - You need fuzzy search / closest match on medium-to-large datasets
+- You search the same dataset repeatedly (`FuzzyIndex` is 6.8x faster)
 - You want a single dependency for all string distance needs
 
 **When to keep fastest-levenshtein**:

--- a/docs/migration/from-string-similarity.md
+++ b/docs/migration/from-string-similarity.md
@@ -93,11 +93,11 @@ rapid-fuzzy provides algorithms that string-similarity does not:
 
 ## Performance
 
-rapid-fuzzy's `sorensenDice` is **1.7x faster** than string-similarity's `compareTwoStrings` for single-pair comparisons. For bulk operations, the batch API (`sorensenDiceBatch`) provides even greater speedups by amortizing FFI overhead.
+rapid-fuzzy's `sorensenDice` is **1.8x faster** than string-similarity's `compareTwoStrings` for single-pair comparisons. For bulk operations, the batch API (`sorensenDiceBatch`) provides even greater speedups by amortizing FFI overhead.
 
 | Operation | rapid-fuzzy | string-similarity |
 |---|---:|---:|
-| Sorensen-Dice (single pair) | **144,698 ops/s** | 84,108 ops/s |
+| Sorensen-Dice (single pair) | **149,567 ops/s** | 82,908 ops/s |
 
 ## Key Differences
 

--- a/scripts/generate-bench-charts.ts
+++ b/scripts/generate-bench-charts.ts
@@ -40,17 +40,21 @@ function parseSearchTable(): ChartData {
   const lines = readme.split('\n');
 
   for (const line of lines) {
-    // Match rows like: | Small (20 items) | 179,222 ops/s | 109,059 ops/s | ...
-    const m = line.match(/\|\s*(Small|Medium|Large)\s*\([^)]+\)\s*\|([^|]+)\|([^|]+)\|([^|]+)\|/);
+    // Match rows: | Small (20 items) | rf | fi | fj | fs |
+    const m = line.match(
+      /\|\s*(Small|Medium|Large)\s*\([^)]+\)\s*\|([^|]+)\|([^|]+)\|([^|]+)\|([^|]+)\|/,
+    );
     if (!m) continue;
 
     const groupLabel = m[1];
     const rf = parseOps(m[2]);
-    const fj = parseOps(m[3]);
-    const fs = parseOps(m[4]);
+    const fi = parseOps(m[3]);
+    const fj = parseOps(m[4]);
+    const fs = parseOps(m[5]);
 
     const bars: BarEntry[] = [];
     if (rf !== null) bars.push({ label: 'rapid-fuzzy', value: rf });
+    if (fi !== null) bars.push({ label: 'FuzzyIndex', value: fi });
     if (fj !== null) bars.push({ label: 'fuse.js', value: fj });
     if (fs !== null) bars.push({ label: 'fuzzysort', value: fs });
 
@@ -94,6 +98,7 @@ function parseDistanceTable(): ChartData {
 
 const COLORS: Record<string, string> = {
   'rapid-fuzzy': '#3b82f6',
+  FuzzyIndex: '#60a5fa',
   'fuse.js': '#94a3b8',
   fuzzysort: '#94a3b8',
   'fastest-levenshtein': '#94a3b8',
@@ -167,7 +172,7 @@ function generateSvg(data: ChartData): string {
     for (const bar of sorted) {
       const barWidth = Math.max(4, (bar.value / groupMax) * barAreaWidth);
       const color = COLORS[bar.label] ?? '#94a3b8';
-      const isRapidFuzzy = bar.label === 'rapid-fuzzy';
+      const isRapidFuzzy = bar.label === 'rapid-fuzzy' || bar.label === 'FuzzyIndex';
       const x = paddingX + labelWidth;
 
       // Label

--- a/scripts/update-bench-readme.ts
+++ b/scripts/update-bench-readme.ts
@@ -135,36 +135,38 @@ if (damerauSuite) {
   distLines.push(`| Damerau-Levenshtein | ${cell(dl, true)} | — | — | — |`);
 }
 
-// Search table
+// Search table (includes FuzzyIndex column)
 const searchLines: string[] = [];
-searchLines.push('| Dataset size | rapid-fuzzy | fuse.js | fuzzysort |');
-searchLines.push('|---|---:|---:|---:|');
+searchLines.push('| Dataset size | rapid-fuzzy | FuzzyIndex | fuse.js | fuzzysort |');
+searchLines.push('|---|---:|---:|---:|---:|');
 
 for (const size of ['Small (20 items)', 'Medium (1K items)', 'Large (10K items)']) {
   const s = findSuite(`Fuzzy Search — ${size}`);
   if (!s) continue;
   const rf = s.get('rapid-fuzzy') ?? null;
+  const fi = s.get('rapid-fuzzy (FuzzyIndex)') ?? null;
   const fj = s.get('fuse.js') ?? null;
   const fs = s.get('fuzzysort') ?? null;
-  const b = best([rf, fj, fs]);
+  const b = best([rf, fi, fj, fs]);
   searchLines.push(
-    `| ${size.replace(/\s*\(/, ' (').replace(' items)', ' items)')} | ${cell(rf, rf === b)} | ${cell(fj, fj === b)} | ${cell(fs, fs === b)} |`,
+    `| ${size.replace(/\s*\(/, ' (').replace(' items)', ' items)')} | ${cell(rf, rf === b)} | ${cell(fi, fi === b)} | ${cell(fj, fj === b)} | ${cell(fs, fs === b)} |`,
   );
 }
 
-// Closest table
+// Closest table (includes FuzzyIndex column)
 const closestLines: string[] = [];
-closestLines.push('| Dataset size | rapid-fuzzy | fastest-levenshtein |');
-closestLines.push('|---|---:|---:|');
+closestLines.push('| Dataset size | rapid-fuzzy | FuzzyIndex | fastest-levenshtein |');
+closestLines.push('|---|---:|---:|---:|');
 
 for (const size of ['Medium (1K items)', 'Large (10K items)']) {
   const s = findSuite(`Closest Match — ${size}`);
   if (!s) continue;
   const rf = s.get('rapid-fuzzy') ?? null;
+  const fi = s.get('rapid-fuzzy (FuzzyIndex)') ?? null;
   const fl = s.get('fastest-levenshtein') ?? null;
-  const b = best([rf, fl].filter((v): v is number => v !== null));
+  const b = best([rf, fi, fl].filter((v): v is number => v !== null));
   closestLines.push(
-    `| ${size} | ${cell(rf, rf !== null && rf >= b)} | ${cell(fl, fl !== null && fl >= b)} |`,
+    `| ${size} | ${cell(rf, rf !== null && rf >= b)} | ${cell(fi, fi !== null && fi >= b)} | ${cell(fl, fl !== null && fl >= b)} |`,
   );
 }
 
@@ -211,7 +213,7 @@ readme = replaceSection(
 readme = replaceSection(
   readme,
   '### Closest Match (Levenshtein-based)',
-  '> rapid-fuzzy is',
+  '> With `FuzzyIndex`',
   closestLines.join('\n'),
 );
 


### PR DESCRIPTION
## Summary

- Update all benchmark numbers reflecting v0.5.0 performance improvements: Levenshtein **2.7x faster** (bit-parallel), Normalized Levenshtein **3.9x faster**, Damerau-Levenshtein **1.6x faster**
- Add FuzzyIndex column to search and closest-match benchmark tables (3–5x faster than standalone, **6.8x faster** than fastest-levenshtein for closest-match)
- Add "Persistent Index" section with FuzzyIndex/FuzzyObjectIndex usage examples
- Regenerate SVG benchmark charts with FuzzyIndex bars
- Update migration guides (from-leven, from-fuse-js, from-string-similarity) with current numbers and FuzzyIndex recommendations
- Update bench scripts (`update-bench-readme.ts`, `generate-bench-charts.ts`) to extract and display FuzzyIndex data for future runs

## Related issue

Closes #205

## Checklist

- [x] Benchmarks re-run on Apple M-series
- [x] SVG charts regenerated from updated data
- [x] All three migration guides updated
- [x] Bench scripts updated for FuzzyIndex support
- [x] `pnpm run check` / `pnpm run typecheck` pass