### PR TITLE
perf(core): add character-presence pre-filter to FuzzyIndex

### DIFF
--- a/.changeset/char-prefilter.md
+++ b/.changeset/char-prefilter.md
@@ -1,0 +1,5 @@
+---
+"rapid-fuzzy": patch
+---
+
+Add character-presence pre-filter to FuzzyIndex to skip non-matching items before scoring, reducing search time by ~2x

--- a/crates/core/src/search/index.rs
+++ b/crates/core/src/search/index.rs
@@ -6,7 +6,8 @@ use nucleo_matcher::pattern::CaseMatching;
 use nucleo_matcher::{Config, Matcher, Utf32String};
 
 use super::{
-    PrecomputedSearch, SearchOptions, SearchResult, resolve_case_matching, search_over_precomputed,
+    PrecomputedSearch, SearchOptions, SearchResult, compute_char_mask, resolve_case_matching,
+    search_over_precomputed,
 };
 
 /// A persistent fuzzy search index backed by Rust-side data.
@@ -21,6 +22,7 @@ use super::{
 pub struct FuzzyIndex {
     items: Vec<String>,
     utf32_items: Vec<Utf32String>,
+    char_masks: Vec<u64>,
     matcher: RefCell<Matcher>,
 }
 
@@ -33,9 +35,11 @@ impl FuzzyIndex {
             .iter()
             .map(|s| Utf32String::from(s.as_str()))
             .collect();
+        let char_masks: Vec<u64> = items.iter().map(|s| compute_char_mask(s)).collect();
         Self {
             items,
             utf32_items,
+            char_masks,
             matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
         }
     }
@@ -89,6 +93,7 @@ impl FuzzyIndex {
     #[napi]
     pub fn add(&mut self, item: String) {
         self.utf32_items.push(Utf32String::from(item.as_str()));
+        self.char_masks.push(compute_char_mask(&item));
         self.items.push(item);
     }
 
@@ -97,6 +102,7 @@ impl FuzzyIndex {
     pub fn add_many(&mut self, items: Vec<String>) {
         for item in &items {
             self.utf32_items.push(Utf32String::from(item.as_str()));
+            self.char_masks.push(compute_char_mask(item));
         }
         self.items.extend(items);
     }
@@ -110,6 +116,7 @@ impl FuzzyIndex {
         if idx < self.items.len() {
             self.items.swap_remove(idx);
             self.utf32_items.swap_remove(idx);
+            self.char_masks.swap_remove(idx);
             true
         } else {
             false
@@ -121,6 +128,7 @@ impl FuzzyIndex {
     pub fn destroy(&mut self) {
         self.items = Vec::new();
         self.utf32_items = Vec::new();
+        self.char_masks = Vec::new();
     }
 
     fn search_impl(
@@ -134,6 +142,7 @@ impl FuzzyIndex {
         let ctx = PrecomputedSearch {
             items: &self.items,
             utf32_items: &self.utf32_items,
+            char_masks: &self.char_masks,
             matcher: &self.matcher,
         };
         search_over_precomputed(

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -142,7 +142,44 @@ pub(crate) fn search_over_items(
 pub(crate) struct PrecomputedSearch<'a> {
     pub items: &'a [String],
     pub utf32_items: &'a [Utf32String],
+    pub char_masks: &'a [u64],
     pub matcher: &'a RefCell<Matcher>,
+}
+
+/// Compute a character-presence bitmask for quick pre-filtering.
+///
+/// Bit layout: 0–25 = a–z (case-insensitive), 26–35 = 0–9.
+/// Characters outside this range are ignored (conservative — no false negatives).
+pub(crate) fn compute_char_mask(s: &str) -> u64 {
+    let mut mask = 0u64;
+    for c in s.chars() {
+        let bit = match c {
+            'a'..='z' => Some(c as u32 - 'a' as u32),
+            'A'..='Z' => Some(c as u32 - 'A' as u32),
+            '0'..='9' => Some(26 + c as u32 - '0' as u32),
+            _ => None,
+        };
+        if let Some(b) = bit {
+            mask |= 1u64 << b;
+        }
+    }
+    mask
+}
+
+/// Extract a character-presence bitmask from a query string, considering
+/// only positive (non-inverted) terms. Inverted terms (`!term`) and
+/// syntax prefixes/suffixes (`^`, `'`, `$`) are stripped.
+pub(crate) fn compute_query_mask(query: &str) -> u64 {
+    let mut mask = 0u64;
+    for term in query.split_whitespace() {
+        if term.starts_with('!') {
+            continue;
+        }
+        let term = term.trim_start_matches(['^', '\'']);
+        let term = term.trim_end_matches('$');
+        mask |= compute_char_mask(term);
+    }
+    mask
 }
 
 /// Search over pre-computed Utf32String items with a reusable Matcher.
@@ -167,12 +204,18 @@ pub(crate) fn search_over_precomputed(
     let pattern = Pattern::parse(query, case_matching, Normalization::Smart);
     let max_score = compute_max_score(query, &pattern, &mut matcher);
     let threshold = min_score.unwrap_or(0.0);
+    let query_mask = compute_query_mask(query);
+    let char_masks = ctx.char_masks;
 
     // Pass 1: Score all items, collect (index, score) only — no String cloning.
     let mut scored: Vec<(u32, f64)> = utf32_items
         .iter()
         .enumerate()
         .filter_map(|(index, utf32_item)| {
+            // Pre-filter: skip items that lack required query characters.
+            if query_mask != 0 && (char_masks[index] & query_mask) != query_mask {
+                return None;
+            }
             let atoms = utf32_item.slice(..);
             let raw_score = pattern.score(atoms, &mut matcher)?;
             let normalized = (raw_score as f64 / max_score).min(1.0);


### PR DESCRIPTION
## Summary

- Pre-compute a `u64` character bitmask per item at FuzzyIndex construction time (bits 0–25 for a–z case-insensitive, 26–35 for 0–9)
- Before calling `pattern.score()`, check `item_mask & query_mask == query_mask` — an O(1) rejection of items that cannot match
- Correctly handles nucleo query syntax: inverted terms (`!term`) are excluded, syntax prefixes/suffixes (`^`, `'`, `$`) are stripped from the query mask
- Applied to `search_over_precomputed()` (FuzzyIndex path); standalone search is unaffected

### Performance impact

Benchmarks show **~2x speedup** for FuzzyIndex search:

| Dataset | Before | After | Speedup |
|---:|---:|---:|---|
| 1K items | ~19 µs | ~10 µs | ~1.9x |
| 10K items | ~170 µs | ~77 µs | ~2.2x |

The pre-filter is conservative (no false negatives): items passing the bitmask check may still not match during full scoring, but items failing the check definitely cannot match.

### Memory overhead

+8 bytes per item (`u64` per entry). For 100K items: +800 KB vs ~3.8 MB total FuzzyIndex memory (~21% increase).

## Related issue

Closes #208

## Checklist

- [x] `cargo test` — 169 tests pass (including proptest, unicode, consistency-with-standalone)
- [x] `cargo clippy` — clean
- [x] `pnpm run build` + `pnpm test` — 188 tests pass
- [x] `pnpm run check` + `pnpm run typecheck` — pass
- [x] Changeset added
- [x] FuzzyIndex mutations (add, addMany, remove, destroy) all update char_masks
- [x] No public API changes