### PR TITLE
fix(docs): correct SVG chart height calculation

### DIFF
--- a/.github/assets/bench-distance.svg
+++ b/.github/assets/bench-distance.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 279" width="680" height="279">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 313" width="680" height="313">
 <style>
   text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
   .title { font-size: 16px; font-weight: 600; fill: #1f2937; }
@@ -8,8 +8,8 @@
   .bar-value { font-size: 12px; fill: #374151; font-weight: 500; }
   .multiplier { font-size: 11px; fill: #059669; font-weight: 600; }
 </style>
-<rect width="680" height="279" rx="8" fill="#ffffff" />
-<rect x="0.5" y="0.5" width="679" height="278" rx="8" fill="none" stroke="#e5e7eb" />
+<rect width="680" height="313" rx="8" fill="#ffffff" />
+<rect x="0.5" y="0.5" width="679" height="312" rx="8" fill="none" stroke="#e5e7eb" />
 <text x="20" y="28" class="title">Distance Function Performance</text>
 <text x="20" y="44" class="subtitle">ops/s (higher is better)</text>
 <text x="20" y="66" class="group-label">Levenshtein</text>

--- a/.github/assets/bench-search.svg
+++ b/.github/assets/bench-search.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 730" width="680" height="730">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 798" width="680" height="798">
 <style>
   text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
   .title { font-size: 16px; font-weight: 600; fill: #1f2937; }
@@ -8,8 +8,8 @@
   .bar-value { font-size: 12px; fill: #374151; font-weight: 500; }
   .multiplier { font-size: 11px; fill: #059669; font-weight: 600; }
 </style>
-<rect width="680" height="730" rx="8" fill="#ffffff" />
-<rect x="0.5" y="0.5" width="679" height="729" rx="8" fill="none" stroke="#e5e7eb" />
+<rect width="680" height="798" rx="8" fill="#ffffff" />
+<rect x="0.5" y="0.5" width="679" height="797" rx="8" fill="none" stroke="#e5e7eb" />
 <text x="20" y="28" class="title">Fuzzy Search Performance</text>
 <text x="20" y="44" class="subtitle">ops/s (higher is better)</text>
 <text x="20" y="66" class="group-label">Small</text>

--- a/scripts/generate-bench-charts.ts
+++ b/scripts/generate-bench-charts.ts
@@ -121,9 +121,12 @@ function generateSvg(data: ChartData): string {
   const paddingBottom = 24;
 
   // Calculate total height
+  // Each group contributes: 22px (label) + n × (barHeight + barGap) + (groupGap - barGap) trailing
+  const groupLabelHeight = 22;
   let totalBarHeight = 0;
   for (const group of data.groups) {
-    totalBarHeight += group.bars.length * (barHeight + barGap) + groupGap;
+    totalBarHeight +=
+      groupLabelHeight + group.bars.length * (barHeight + barGap) + groupGap - barGap;
   }
 
   const svgWidth = chartWidth + paddingX * 2;


### PR DESCRIPTION
## Summary

Fix SVG chart clipping where the XL group's last bars (uFuzzy) were cut off outside the viewBox.

**Root cause**: The `totalBarHeight` calculation in `generateSvg()` was missing the 22px group label height per group, resulting in an SVG height of 730px while content extended to 750px.

**Fix**: Include `groupLabelHeight` (22px) in the per-group height calculation.

## Checklist

- [x] `pnpm run check` (Biome lint)
- [x] `pnpm run bench:charts` regenerates correct SVGs
- [x] No changeset needed (docs tooling fix)