### PR TITLE
docs: clarify FuzzyIndex as rapid-fuzzy indexed mode

### DIFF
--- a/.github/assets/bench-search.svg
+++ b/.github/assets/bench-search.svg
@@ -19,7 +19,7 @@
 <text x="172" y="122" class="bar-label" text-anchor="end">uFuzzy</text>
 <rect x="180" y="105" width="162.91157054535884" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
 <text x="350.9115705453588" y="122" class="bar-value" text-anchor="start">923,069 ops/s</text>
-<text x="172" y="153" class="bar-label" text-anchor="end">FuzzyIndex</text>
+<text x="172" y="153" class="bar-label" text-anchor="end">rapid-fuzzy (indexed)</text>
 <rect x="180" y="136" width="71.58466448280652" height="26" rx="4" fill="#60a5fa" opacity="1" />
 <text x="259.5846644828065" y="153" class="bar-value" text-anchor="start">405,604 ops/s — 3x vs fuse.js</text>
 <text x="172" y="184" class="bar-label" text-anchor="end">rapid-fuzzy</text>
@@ -29,7 +29,7 @@
 <rect x="180" y="198" width="18.63159599047573" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
 <text x="206.63159599047572" y="215" class="bar-value" text-anchor="start">105,568 ops/s</text>
 <text x="20" y="262" class="group-label">Medium</text>
-<text x="172" y="287" class="bar-label" text-anchor="end">FuzzyIndex</text>
+<text x="172" y="287" class="bar-label" text-anchor="end">rapid-fuzzy (indexed)</text>
 <rect x="180" y="270" width="460" height="26" rx="4" fill="#60a5fa" opacity="1" />
 <text x="632" y="287" class="bar-value" text-anchor="end" fill="#ffffff">80,579 ops/s — 18x vs fuse.js</text>
 <text x="172" y="318" class="bar-label" text-anchor="end">fuzzysort</text>
@@ -45,7 +45,7 @@
 <rect x="180" y="394" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
 <text x="192" y="411" class="bar-value" text-anchor="start">367 ops/s</text>
 <text x="20" y="458" class="group-label">Large</text>
-<text x="172" y="483" class="bar-label" text-anchor="end">FuzzyIndex</text>
+<text x="172" y="483" class="bar-label" text-anchor="end">rapid-fuzzy (indexed)</text>
 <rect x="180" y="466" width="460" height="26" rx="4" fill="#60a5fa" opacity="1" />
 <text x="632" y="483" class="bar-value" text-anchor="end" fill="#ffffff">136,528 ops/s — 40x vs fuse.js</text>
 <text x="172" y="514" class="bar-label" text-anchor="end">fuzzysort</text>
@@ -61,7 +61,7 @@
 <rect x="180" y="590" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
 <text x="192" y="607" class="bar-value" text-anchor="start">19 ops/s</text>
 <text x="20" y="654" class="group-label">XL</text>
-<text x="172" y="679" class="bar-label" text-anchor="end">FuzzyIndex</text>
+<text x="172" y="679" class="bar-label" text-anchor="end">rapid-fuzzy (indexed)</text>
 <rect x="180" y="662" width="460" height="26" rx="4" fill="#60a5fa" opacity="1" />
 <text x="632" y="679" class="bar-value" text-anchor="end" fill="#ffffff">31,903 ops/s</text>
 <text x="172" y="710" class="bar-label" text-anchor="end">fuzzysort</text>

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For applications that search the same dataset repeatedly (autocomplete, file fin
 ```typescript
 import { FuzzyIndex, FuzzyObjectIndex } from 'rapid-fuzzy';
 
-// String search index — up to 5x faster than standalone search()
+// String search index — up to 182x faster than standalone search()
 const index = new FuzzyIndex(['TypeScript', 'JavaScript', 'Python', ...]);
 
 index.search('typscript', { maxResults: 5 });
@@ -297,10 +297,12 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 <img src=".github/assets/bench-search.svg" alt="Search performance chart — rapid-fuzzy vs fuse.js vs fuzzysort vs uFuzzy" width="680" />
 
+> Both `rapid-fuzzy` columns below show the same library: standalone `search()` vs `FuzzyIndex` (indexed mode for repeated searches).
+
 <details>
 <summary>Raw numbers</summary>
 
-| Dataset size | rapid-fuzzy | FuzzyIndex | fuse.js | fuzzysort | uFuzzy |
+| Dataset size | rapid-fuzzy | rapid-fuzzy (indexed) | fuse.js | fuzzysort | uFuzzy |
 |---|---:|---:|---:|---:|---:|
 | Small (20 items) | 303,982 ops/s | 405,604 ops/s | 105,568 ops/s | **2,606,394 ops/s** | 923,069 ops/s |
 | Medium (1K items) | 6,787 ops/s | **80,579 ops/s** | 367 ops/s | 64,372 ops/s | 28,953 ops/s |
@@ -311,17 +313,17 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 ### Closest Match (Levenshtein-based)
 
-| Dataset size | rapid-fuzzy | FuzzyIndex | fastest-levenshtein |
+| Dataset size | rapid-fuzzy | rapid-fuzzy (indexed) | fastest-levenshtein |
 |---|---:|---:|---:|
 | Medium (1K items) | 8,611 ops/s | **989,095 ops/s** | 6,797 ops/s |
 | Large (10K items) | 924 ops/s | **156,014 ops/s** | 658 ops/s |
 
-> With `FuzzyIndex`, rapid-fuzzy is up to **237x faster** than fastest-levenshtein for closest-match lookups.
+> In indexed mode (`FuzzyIndex`), rapid-fuzzy is up to **237x faster** than fastest-levenshtein for closest-match lookups.
 
 ### Why these numbers matter
 
 - **vs fuse.js**: `FuzzyIndex` is **219x faster** on medium datasets and **6,869x faster** on large datasets. Even standalone `search()` is 18x / 40x faster.
-- **FuzzyIndex**: An incremental search cache accelerates repeated and keystroke-level searches, delivering sub-millisecond autocomplete. On large datasets this is **182x faster** than standalone `search()`.
+- **Indexed mode**: `FuzzyIndex` keeps data on the Rust side with an incremental search cache, delivering sub-millisecond autocomplete. On large datasets this is **182x faster** than standalone `search()`.
 - **vs fuzzysort**: `FuzzyIndex` now **outperforms fuzzysort** on medium-and-above datasets — 1.25x faster at 1K, 5.2x at 10K, and 5.4x at 50K.
 - **vs uFuzzy**: `FuzzyIndex` is **2.8x faster** at medium and **21x faster** at large datasets.
 - **vs fastest-levenshtein**: With `FuzzyIndex`, closest-match is **145x faster** at 1K and **237x faster** at 10K.

--- a/scripts/generate-bench-charts.ts
+++ b/scripts/generate-bench-charts.ts
@@ -55,7 +55,7 @@ function parseSearchTable(): ChartData {
 
     const bars: BarEntry[] = [];
     if (rf !== null) bars.push({ label: 'rapid-fuzzy', value: rf });
-    if (fi !== null) bars.push({ label: 'FuzzyIndex', value: fi });
+    if (fi !== null) bars.push({ label: 'rapid-fuzzy (indexed)', value: fi });
     if (fj !== null) bars.push({ label: 'fuse.js', value: fj });
     if (fs !== null) bars.push({ label: 'fuzzysort', value: fs });
     if (uf !== null) bars.push({ label: 'uFuzzy', value: uf });
@@ -100,7 +100,7 @@ function parseDistanceTable(): ChartData {
 
 const COLORS: Record<string, string> = {
   'rapid-fuzzy': '#3b82f6',
-  FuzzyIndex: '#60a5fa',
+  'rapid-fuzzy (indexed)': '#60a5fa',
   'fuse.js': '#94a3b8',
   fuzzysort: '#94a3b8',
   uFuzzy: '#94a3b8',
@@ -178,7 +178,7 @@ function generateSvg(data: ChartData): string {
     for (const bar of sorted) {
       const barWidth = Math.max(4, (bar.value / groupMax) * barAreaWidth);
       const color = COLORS[bar.label] ?? '#94a3b8';
-      const isRapidFuzzy = bar.label === 'rapid-fuzzy' || bar.label === 'FuzzyIndex';
+      const isRapidFuzzy = bar.label === 'rapid-fuzzy' || bar.label === 'rapid-fuzzy (indexed)';
       const x = paddingX + labelWidth;
 
       // Label

--- a/scripts/update-bench-readme.ts
+++ b/scripts/update-bench-readme.ts
@@ -137,7 +137,7 @@ if (damerauSuite) {
 
 // Search table (includes FuzzyIndex column)
 const searchLines: string[] = [];
-searchLines.push('| Dataset size | rapid-fuzzy | FuzzyIndex | fuse.js | fuzzysort |');
+searchLines.push('| Dataset size | rapid-fuzzy | rapid-fuzzy (indexed) | fuse.js | fuzzysort |');
 searchLines.push('|---|---:|---:|---:|---:|');
 
 for (const size of ['Small (20 items)', 'Medium (1K items)', 'Large (10K items)']) {
@@ -155,7 +155,7 @@ for (const size of ['Small (20 items)', 'Medium (1K items)', 'Large (10K items)'
 
 // Closest table (includes FuzzyIndex column)
 const closestLines: string[] = [];
-closestLines.push('| Dataset size | rapid-fuzzy | FuzzyIndex | fastest-levenshtein |');
+closestLines.push('| Dataset size | rapid-fuzzy | rapid-fuzzy (indexed) | fastest-levenshtein |');
 closestLines.push('|---|---:|---:|---:|');
 
 for (const size of ['Medium (1K items)', 'Large (10K items)']) {
@@ -213,7 +213,7 @@ readme = replaceSection(
 readme = replaceSection(
   readme,
   '### Closest Match (Levenshtein-based)',
-  '> With `FuzzyIndex`',
+  '> In indexed mode (`FuzzyIndex`)',
   closestLines.join('\n'),
 );
 


### PR DESCRIPTION
## Summary

Clarify that `FuzzyIndex` is a feature of rapid-fuzzy, not a separate library:

- Rename benchmark table column `FuzzyIndex` → `rapid-fuzzy (indexed)` in both Search Performance and Closest Match tables
- Add explanation note before benchmark table: both columns show the same library
- Reword "Why these numbers matter" to use "Indexed mode" language
- Fix stale "5x faster" → "182x faster" in Persistent Index section (predated incremental cache)
- Update chart generation and bench-update scripts to use new label
- Regenerate SVG charts with updated labels

Closes #238

## Checklist

- [x] `pnpm run check` (Biome lint)
- [x] `pnpm run typecheck` (TypeScript)
- [x] `pnpm test` (Vitest)
- [x] `cargo test` (Rust)
- [x] Charts regenerated with `npx tsx scripts/generate-bench-charts.ts`
- [x] No changeset needed (docs-only change)