### PR TITLE
fix(test): update browser e2e assertion for length tiebreaker

### DIFF
--- a/e2e/browser.spec.ts
+++ b/e2e/browser.spec.ts
@@ -112,9 +112,14 @@ test.describe('search', () => {
   test('search returns sorted results', async ({ page }) => {
     const results = await page.evaluate(() => window.__results.search);
     expect(results.length).toBeGreaterThan(0);
-    expect(results[0].item).toBe('TypeScript');
+    // First result should be one of the "Type*" prefix matches
+    expect(results[0].item).toMatch(/^Type/);
     expect(results[0]).toHaveProperty('score');
     expect(results[0]).toHaveProperty('index');
+    // Results should be sorted by score descending
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].score).toBeLessThanOrEqual(results[i - 1].score);
+    }
   });
 
   test('search returns empty for empty query', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fix the Browser WASM Test failure introduced by #237 (quickselect + length tiebreaker).

The search tiebreaker now favors shorter items when scores are equal, so `"TypeSpec"` (8 chars) ranks above `"TypeScript"` (10 chars) for query `"type"`. The e2e test was hardcoded to expect `TypeScript` as the first result.

### Change

```diff
- expect(results[0].item).toBe('TypeScript');
+ expect(results[0].item).toMatch(/^Type/);
+ for (let i = 1; i < results.length; i++) {
+   expect(results[i].score).toBeLessThanOrEqual(results[i - 1].score);
+ }
```

The updated assertion verifies:
1. First result is a `Type*` prefix match (correct behavior)
2. Results are sorted by score descending (the actual invariant)