### PR TITLE
chore(deps): ignore deprecated string-similarity in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended"],
   "baseBranchPatterns": ["develop"],
   "prConcurrentLimit": 10,
+  "ignoreDeps": ["string-similarity", "@types/string-similarity"],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,


### PR DESCRIPTION
## Summary

- Add `string-similarity` and `@types/string-similarity` to Renovate's `ignoreDeps` to suppress the Dependency Dashboard deprecation warning

These packages are intentionally included as benchmark comparison targets (devDependency only). The deprecation is known and expected — the package was last updated in 2021 and will never receive new versions. A migration guide already exists at `docs/migration/from-string-similarity.md`.

Closes #246

## Checklist

- [x] `renovate.json` updated with `ignoreDeps`
- [x] No code changes — config-only fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->