### PR TITLE
feat(search): add matchType classification to SearchResult

### DIFF
--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -429,6 +429,45 @@ describe('search', () => {
     });
   });
 
+  describe('matchType classification', () => {
+    it('should classify exact match', () => {
+      const results = search('apple', ['apple', 'pineapple', 'application']);
+      const exact = results.find((r) => r.item === 'apple');
+      expect(exact?.matchType).toBe('Exact');
+    });
+
+    it('should classify prefix match', () => {
+      const results = search('app', ['application']);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.matchType).toBe('Prefix');
+    });
+
+    it('should classify contains match', () => {
+      const results = search('apple', ['pineapple']);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.matchType).toBe('Contains');
+    });
+
+    it('should classify fuzzy match', () => {
+      const results = search('adf', ['abcdef']);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.matchType).toBe('Fuzzy');
+    });
+
+    it('should always be populated regardless of includePositions', () => {
+      const without = search('hello', ['hello']);
+      const with_ = search('hello', ['hello'], { includePositions: true });
+      expect(without[0]?.matchType).toBe('Exact');
+      expect(with_[0]?.matchType).toBe('Exact');
+    });
+
+    it('should classify case-insensitive exact match', () => {
+      const results = search('apple', ['Apple'], { minScore: 1.0 });
+      expect(results.length).toBe(1);
+      expect(results[0]?.matchType).toBe('Exact');
+    });
+  });
+
   describe('case sensitivity', () => {
     it('should match case-insensitively by default (smart case)', () => {
       const results = search('apple', ['Apple', 'apple', 'APPLE'], {
@@ -926,6 +965,27 @@ describe('FuzzyIndex', () => {
       const index = new FuzzyIndex(['Apple', 'apple', 'APPLE']);
       const results = index.search('apple', { minScore: 1.0 });
       expect(results.length).toBe(3);
+    });
+
+    it('should include matchType classification', () => {
+      const index = new FuzzyIndex(['apple', 'apple juice', 'pineapple']);
+      const results = index.search('apple');
+      const exact = results.find((r) => r.item === 'apple');
+      const prefix = results.find((r) => r.item === 'apple juice');
+      const contains = results.find((r) => r.item === 'pineapple');
+      expect(exact?.matchType).toBe('Exact');
+      expect(prefix?.matchType).toBe('Prefix');
+      expect(contains?.matchType).toBe('Contains');
+    });
+
+    it('should have consistent matchType with standalone search', () => {
+      const items = ['apple', 'apple juice', 'pineapple'];
+      const index = new FuzzyIndex(items);
+      const indexResults = index.search('apple');
+      const standaloneResults = search('apple', items);
+      for (let i = 0; i < indexResults.length; i++) {
+        expect(indexResults[i]?.matchType).toBe(standaloneResults[i]?.matchType);
+      }
     });
   });
 

--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -430,39 +430,44 @@ describe('search', () => {
   });
 
   describe('matchType classification', () => {
-    it('should classify exact match', () => {
-      const results = search('apple', ['apple', 'pineapple', 'application']);
+    it('should classify exact match when includePositions is true', () => {
+      const results = search('apple', ['apple', 'pineapple'], { includePositions: true });
       const exact = results.find((r) => r.item === 'apple');
       expect(exact?.matchType).toBe('Exact');
     });
 
     it('should classify prefix match', () => {
-      const results = search('app', ['application']);
+      const results = search('app', ['application'], { includePositions: true });
       expect(results.length).toBeGreaterThan(0);
       expect(results[0]?.matchType).toBe('Prefix');
     });
 
     it('should classify contains match', () => {
-      const results = search('apple', ['pineapple']);
+      const results = search('apple', ['pineapple'], { includePositions: true });
       expect(results.length).toBeGreaterThan(0);
       expect(results[0]?.matchType).toBe('Contains');
     });
 
     it('should classify fuzzy match', () => {
-      const results = search('adf', ['abcdef']);
+      const results = search('adf', ['abcdef'], { includePositions: true });
       expect(results.length).toBeGreaterThan(0);
       expect(results[0]?.matchType).toBe('Fuzzy');
     });
 
-    it('should always be populated regardless of includePositions', () => {
-      const without = search('hello', ['hello']);
-      const with_ = search('hello', ['hello'], { includePositions: true });
-      expect(without[0]?.matchType).toBe('Exact');
-      expect(with_[0]?.matchType).toBe('Exact');
+    it('should be undefined when includePositions is false', () => {
+      const results = search('hello', ['hello']);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.matchType).toBeUndefined();
+    });
+
+    it('should be set when includePositions is true', () => {
+      const results = search('hello', ['hello'], { includePositions: true });
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.matchType).toBe('Exact');
     });
 
     it('should classify case-insensitive exact match', () => {
-      const results = search('apple', ['Apple'], { minScore: 1.0 });
+      const results = search('apple', ['Apple'], { includePositions: true, minScore: 1.0 });
       expect(results.length).toBe(1);
       expect(results[0]?.matchType).toBe('Exact');
     });
@@ -967,9 +972,9 @@ describe('FuzzyIndex', () => {
       expect(results.length).toBe(3);
     });
 
-    it('should include matchType classification', () => {
+    it('should include matchType when includePositions is true', () => {
       const index = new FuzzyIndex(['apple', 'apple juice', 'pineapple']);
-      const results = index.search('apple');
+      const results = index.search('apple', { includePositions: true });
       const exact = results.find((r) => r.item === 'apple');
       const prefix = results.find((r) => r.item === 'apple juice');
       const contains = results.find((r) => r.item === 'pineapple');
@@ -978,11 +983,18 @@ describe('FuzzyIndex', () => {
       expect(contains?.matchType).toBe('Contains');
     });
 
+    it('should not include matchType without includePositions', () => {
+      const index = new FuzzyIndex(['apple']);
+      const results = index.search('apple');
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.matchType).toBeUndefined();
+    });
+
     it('should have consistent matchType with standalone search', () => {
       const items = ['apple', 'apple juice', 'pineapple'];
       const index = new FuzzyIndex(items);
-      const indexResults = index.search('apple');
-      const standaloneResults = search('apple', items);
+      const indexResults = index.search('apple', { includePositions: true });
+      const standaloneResults = search('apple', items, { includePositions: true });
       for (let i = 0; i < indexResults.length; i++) {
         expect(indexResults[i]?.matchType).toBe(standaloneResults[i]?.matchType);
       }

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -50,33 +50,64 @@ pub(crate) fn classify_match(positions: &[u32], item_char_count: usize) -> Match
     }
 }
 
-/// Classify the match type cheaply using the normalized score and string
-/// comparison, avoiding the cost of `pattern.indices()` when positions
-/// are not requested.
-///
-/// Fast path: score == 1.0 implies an exact match (all characters matched
-/// with maximum score). Otherwise, falls back to case-folded substring
-/// checks. Multi-term queries always classify as Fuzzy.
-pub(crate) fn classify_match_cheap(query: &str, item: &str, score: f64) -> MatchType {
-    // Score of 1.0 with matching length means a perfect match.
-    if (score - 1.0).abs() < f64::EPSILON && query.chars().count() == item.chars().count() {
-        return MatchType::Exact;
+/// Pre-computed query data for cheap match classification.
+/// Created once per search call and reused for every result.
+pub(crate) struct CheapClassifier {
+    /// Lowercased query characters (None if query uses extended syntax).
+    query_lower: Option<Vec<char>>,
+    /// Original query character count.
+    query_char_count: usize,
+}
+
+impl CheapClassifier {
+    pub(crate) fn new(query: &str) -> Self {
+        let query_char_count = query.chars().count();
+        // Multi-term queries or extended syntax: skip substring matching.
+        let query_lower = if query.contains(' ')
+            || query.contains('!')
+            || query.contains('^')
+            || query.contains('$')
+        {
+            None
+        } else {
+            Some(query.chars().flat_map(|c| c.to_lowercase()).collect())
+        };
+        Self {
+            query_lower,
+            query_char_count,
+        }
     }
 
-    // Multi-term queries or queries with extended syntax: classify as Fuzzy
-    // since simple substring checks cannot handle them accurately.
-    if query.contains(' ') || query.contains('!') || query.contains('^') || query.contains('$') {
-        return MatchType::Fuzzy;
-    }
+    pub(crate) fn classify(&self, item: &str, score: f64) -> MatchType {
+        let item_char_count = item.chars().count();
 
-    let query_lower: String = query.chars().flat_map(|c| c.to_lowercase()).collect();
-    let item_lower: String = item.chars().flat_map(|c| c.to_lowercase()).collect();
+        // Fast path: score 1.0 with matching length → Exact.
+        if (score - 1.0).abs() < f64::EPSILON && self.query_char_count == item_char_count {
+            return MatchType::Exact;
+        }
 
-    if item_lower.starts_with(&query_lower) {
-        MatchType::Prefix
-    } else if item_lower.contains(&query_lower) {
-        MatchType::Contains
-    } else {
+        let query_lower = match &self.query_lower {
+            Some(q) => q,
+            None => return MatchType::Fuzzy,
+        };
+
+        let qlen = query_lower.len();
+        if qlen > item_char_count {
+            return MatchType::Fuzzy;
+        }
+
+        // Case-insensitive substring scan over the item.
+        let item_chars: Vec<char> = item.chars().flat_map(|c| c.to_lowercase()).collect();
+        for start in 0..=(item_chars.len() - qlen) {
+            if item_chars[start..start + qlen] == query_lower[..] {
+                return if start == 0 {
+                    MatchType::Prefix
+                } else {
+                    MatchType::Contains
+                };
+            }
+        }
+
         MatchType::Fuzzy
     }
 }
@@ -204,6 +235,11 @@ pub(crate) fn search_over_items(
         scored.sort_unstable_by(cmp);
 
         // Pass 2: Construct results only for the final top-k items.
+        let classifier = if !include_positions {
+            Some(CheapClassifier::new(query))
+        } else {
+            None
+        };
         scored
             .into_iter()
             .map(|(index, score)| {
@@ -218,7 +254,10 @@ pub(crate) fn search_over_items(
                     let mt = classify_match(&indices, item_char_count);
                     (indices, mt)
                 } else {
-                    let mt = classify_match_cheap(query, &items[index as usize], score);
+                    let mt = classifier
+                        .as_ref()
+                        .unwrap()
+                        .classify(&items[index as usize], score);
                     (Vec::new(), mt)
                 };
 
@@ -378,6 +417,11 @@ pub(crate) fn search_over_precomputed(
     scored.sort_unstable_by(cmp);
 
     // Pass 2: Construct results only for the final top-k items.
+    let classifier = if !include_positions {
+        Some(CheapClassifier::new(query))
+    } else {
+        None
+    };
     let results = scored
         .into_iter()
         .map(|(index, score)| {
@@ -391,7 +435,10 @@ pub(crate) fn search_over_precomputed(
                 let mt = classify_match(&indices, item_char_count);
                 (indices, mt)
             } else {
-                let mt = classify_match_cheap(query, &items[index as usize], score);
+                let mt = classifier
+                    .as_ref()
+                    .unwrap()
+                    .classify(&items[index as usize], score);
                 (Vec::new(), mt)
             };
 

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -13,6 +13,43 @@ use napi_derive::napi;
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher, Utf32String};
 
+/// Classification of how a query matched an item.
+///
+/// Derived from the matched character positions:
+/// - **Exact**: all positions consecutive from index 0, covering every character in the item.
+/// - **Prefix**: all positions consecutive from index 0, but the item is longer.
+/// - **Contains**: all positions consecutive (a substring match), not starting at 0.
+/// - **Fuzzy**: positions have gaps (character-level fuzzy match).
+#[napi(string_enum)]
+#[derive(Debug)]
+pub enum MatchType {
+    Exact,
+    Prefix,
+    Contains,
+    Fuzzy,
+}
+
+/// Classify the match type from the matched character positions.
+pub(crate) fn classify_match(positions: &[u32], item_char_count: usize) -> MatchType {
+    if positions.is_empty() {
+        return MatchType::Fuzzy;
+    }
+
+    let is_consecutive = positions.len() == 1 || positions.windows(2).all(|w| w[1] == w[0] + 1);
+
+    if is_consecutive {
+        if positions[0] == 0 && positions.len() == item_char_count {
+            MatchType::Exact
+        } else if positions[0] == 0 {
+            MatchType::Prefix
+        } else {
+            MatchType::Contains
+        }
+    } else {
+        MatchType::Fuzzy
+    }
+}
+
 /// A single fuzzy search result with the matched item and its score.
 #[napi(object)]
 pub struct SearchResult {
@@ -25,6 +62,8 @@ pub struct SearchResult {
     /// Indices of matched characters in the item string.
     /// Empty unless `includePositions` is set to true in SearchOptions.
     pub positions: Vec<u32>,
+    /// How the query matched this item (e.g. exact, prefix, contains, or fuzzy).
+    pub match_type: MatchType,
 }
 
 /// Options for the search function.
@@ -134,16 +173,21 @@ pub(crate) fn search_over_items(
         scored.sort_unstable_by(cmp);
 
         // Pass 2: Construct results only for the final top-k items.
+        // Always compute positions for matchType classification.
         scored
             .into_iter()
             .map(|(index, score)| {
+                buf.clear();
+                let atoms = nucleo_matcher::Utf32Str::new(&items[index as usize], &mut buf);
+                let mut indices = Vec::new();
+                pattern.indices(atoms, &mut matcher, &mut indices);
+                indices.sort_unstable();
+                indices.dedup();
+
+                let item_char_count = items[index as usize].chars().count();
+                let match_type = classify_match(&indices, item_char_count);
+
                 let positions = if include_positions {
-                    buf.clear();
-                    let atoms = nucleo_matcher::Utf32Str::new(&items[index as usize], &mut buf);
-                    let mut indices = Vec::new();
-                    pattern.indices(atoms, &mut matcher, &mut indices);
-                    indices.sort_unstable();
-                    indices.dedup();
                     indices
                 } else {
                     Vec::new()
@@ -154,6 +198,7 @@ pub(crate) fn search_over_items(
                     score,
                     index,
                     positions,
+                    match_type,
                 }
             })
             .collect()
@@ -304,15 +349,20 @@ pub(crate) fn search_over_precomputed(
     scored.sort_unstable_by(cmp);
 
     // Pass 2: Construct results only for the final top-k items.
+    // Always compute positions for matchType classification.
     let results = scored
         .into_iter()
         .map(|(index, score)| {
+            let atoms = utf32_items[index as usize].slice(..);
+            let mut indices = Vec::new();
+            pattern.indices(atoms, &mut matcher, &mut indices);
+            indices.sort_unstable();
+            indices.dedup();
+
+            let item_char_count = items[index as usize].chars().count();
+            let match_type = classify_match(&indices, item_char_count);
+
             let positions = if include_positions {
-                let atoms = utf32_items[index as usize].slice(..);
-                let mut indices = Vec::new();
-                pattern.indices(atoms, &mut matcher, &mut indices);
-                indices.sort_unstable();
-                indices.dedup();
                 indices
             } else {
                 Vec::new()
@@ -323,6 +373,7 @@ pub(crate) fn search_over_precomputed(
                 score,
                 index,
                 positions,
+                match_type,
             }
         })
         .collect();
@@ -797,6 +848,126 @@ mod tests {
         );
         assert!(!results.is_empty());
         assert_eq!(results[0].positions, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_match_type_exact() {
+        let items = vec!["apple".to_string(), "pineapple".to_string()];
+        let results = search_impl(
+            "apple".to_string(),
+            items,
+            None,
+            None,
+            false,
+            CaseMatching::Smart,
+        );
+        let exact = results.iter().find(|r| r.item == "apple").unwrap();
+        assert!(
+            matches!(exact.match_type, MatchType::Exact),
+            "expected Exact, got {:?}",
+            exact.match_type
+        );
+    }
+
+    #[test]
+    fn test_match_type_prefix() {
+        let items = vec!["application".to_string()];
+        let results = search_impl(
+            "app".to_string(),
+            items,
+            None,
+            None,
+            false,
+            CaseMatching::Smart,
+        );
+        assert!(!results.is_empty());
+        assert!(
+            matches!(results[0].match_type, MatchType::Prefix),
+            "expected Prefix, got {:?}",
+            results[0].match_type
+        );
+    }
+
+    #[test]
+    fn test_match_type_contains() {
+        let items = vec!["pineapple".to_string()];
+        let results = search_impl(
+            "apple".to_string(),
+            items,
+            None,
+            None,
+            false,
+            CaseMatching::Smart,
+        );
+        assert!(!results.is_empty());
+        assert!(
+            matches!(results[0].match_type, MatchType::Contains),
+            "expected Contains, got {:?}",
+            results[0].match_type
+        );
+    }
+
+    #[test]
+    fn test_match_type_fuzzy() {
+        let items = vec!["abcdef".to_string()];
+        let results = search_impl(
+            "adf".to_string(),
+            items,
+            None,
+            None,
+            false,
+            CaseMatching::Smart,
+        );
+        assert!(!results.is_empty());
+        assert!(
+            matches!(results[0].match_type, MatchType::Fuzzy),
+            "expected Fuzzy, got {:?}",
+            results[0].match_type
+        );
+    }
+
+    #[test]
+    fn test_match_type_always_populated() {
+        // matchType should be set regardless of includePositions
+        let items = vec!["hello".to_string()];
+        let without = search_impl(
+            "hello".to_string(),
+            items.clone(),
+            None,
+            None,
+            false,
+            CaseMatching::Smart,
+        );
+        let with = search_impl(
+            "hello".to_string(),
+            items,
+            None,
+            None,
+            true,
+            CaseMatching::Smart,
+        );
+        assert!(matches!(without[0].match_type, MatchType::Exact));
+        assert!(matches!(with[0].match_type, MatchType::Exact));
+    }
+
+    #[test]
+    fn test_match_type_case_insensitive_exact() {
+        // "apple" matching "Apple" should be Exact (smart case)
+        let items = vec!["Apple".to_string()];
+        let results = search_impl(
+            "apple".to_string(),
+            items,
+            None,
+            None,
+            false,
+            CaseMatching::Smart,
+        );
+        assert!(!results.is_empty());
+        assert!(
+            matches!(results[0].match_type, MatchType::Exact),
+            "expected Exact for case-insensitive match, got {:?}",
+            results[0].match_type
+        );
     }
 
     #[test]

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -21,7 +21,7 @@ use nucleo_matcher::{Config, Matcher, Utf32String};
 /// - **Contains**: all positions consecutive (a substring match), not starting at 0.
 /// - **Fuzzy**: positions have gaps (character-level fuzzy match).
 #[napi(string_enum)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum MatchType {
     Exact,
     Prefix,
@@ -50,68 +50,6 @@ pub(crate) fn classify_match(positions: &[u32], item_char_count: usize) -> Match
     }
 }
 
-/// Pre-computed query data for cheap match classification.
-/// Created once per search call and reused for every result.
-pub(crate) struct CheapClassifier {
-    /// Lowercased query characters (None if query uses extended syntax).
-    query_lower: Option<Vec<char>>,
-    /// Original query character count.
-    query_char_count: usize,
-}
-
-impl CheapClassifier {
-    pub(crate) fn new(query: &str) -> Self {
-        let query_char_count = query.chars().count();
-        // Multi-term queries or extended syntax: skip substring matching.
-        let query_lower = if query.contains(' ')
-            || query.contains('!')
-            || query.contains('^')
-            || query.contains('$')
-        {
-            None
-        } else {
-            Some(query.chars().flat_map(|c| c.to_lowercase()).collect())
-        };
-        Self {
-            query_lower,
-            query_char_count,
-        }
-    }
-
-    pub(crate) fn classify(&self, item: &str, score: f64) -> MatchType {
-        let item_char_count = item.chars().count();
-
-        // Fast path: score 1.0 with matching length → Exact.
-        if (score - 1.0).abs() < f64::EPSILON && self.query_char_count == item_char_count {
-            return MatchType::Exact;
-        }
-
-        let query_lower = match &self.query_lower {
-            Some(q) => q,
-            None => return MatchType::Fuzzy,
-        };
-
-        let qlen = query_lower.len();
-        if qlen > item_char_count {
-            return MatchType::Fuzzy;
-        }
-
-        // Case-insensitive substring scan over the item.
-        let item_chars: Vec<char> = item.chars().flat_map(|c| c.to_lowercase()).collect();
-        for start in 0..=(item_chars.len() - qlen) {
-            if item_chars[start..start + qlen] == query_lower[..] {
-                return if start == 0 {
-                    MatchType::Prefix
-                } else {
-                    MatchType::Contains
-                };
-            }
-        }
-
-        MatchType::Fuzzy
-    }
-}
-
 /// A single fuzzy search result with the matched item and its score.
 #[napi(object)]
 pub struct SearchResult {
@@ -124,8 +62,10 @@ pub struct SearchResult {
     /// Indices of matched characters in the item string.
     /// Empty unless `includePositions` is set to true in SearchOptions.
     pub positions: Vec<u32>,
-    /// How the query matched this item (e.g. exact, prefix, contains, or fuzzy).
-    pub match_type: MatchType,
+    /// How the query matched this item (Exact, Prefix, Contains, or Fuzzy).
+    /// Only present when `includePositions` is set to true in SearchOptions.
+    /// Derived from positions at zero additional cost.
+    pub match_type: Option<MatchType>,
 }
 
 /// Options for the search function.
@@ -235,11 +175,6 @@ pub(crate) fn search_over_items(
         scored.sort_unstable_by(cmp);
 
         // Pass 2: Construct results only for the final top-k items.
-        let classifier = if !include_positions {
-            Some(CheapClassifier::new(query))
-        } else {
-            None
-        };
         scored
             .into_iter()
             .map(|(index, score)| {
@@ -252,13 +187,9 @@ pub(crate) fn search_over_items(
                     indices.dedup();
                     let item_char_count = items[index as usize].chars().count();
                     let mt = classify_match(&indices, item_char_count);
-                    (indices, mt)
+                    (indices, Some(mt))
                 } else {
-                    let mt = classifier
-                        .as_ref()
-                        .unwrap()
-                        .classify(&items[index as usize], score);
-                    (Vec::new(), mt)
+                    (Vec::new(), None)
                 };
 
                 SearchResult {
@@ -417,11 +348,6 @@ pub(crate) fn search_over_precomputed(
     scored.sort_unstable_by(cmp);
 
     // Pass 2: Construct results only for the final top-k items.
-    let classifier = if !include_positions {
-        Some(CheapClassifier::new(query))
-    } else {
-        None
-    };
     let results = scored
         .into_iter()
         .map(|(index, score)| {
@@ -433,13 +359,9 @@ pub(crate) fn search_over_precomputed(
                 indices.dedup();
                 let item_char_count = items[index as usize].chars().count();
                 let mt = classify_match(&indices, item_char_count);
-                (indices, mt)
+                (indices, Some(mt))
             } else {
-                let mt = classifier
-                    .as_ref()
-                    .unwrap()
-                    .classify(&items[index as usize], score);
-                (Vec::new(), mt)
+                (Vec::new(), None)
             };
 
             SearchResult {
@@ -932,15 +854,11 @@ mod tests {
             items,
             None,
             None,
-            false,
+            true,
             CaseMatching::Smart,
         );
         let exact = results.iter().find(|r| r.item == "apple").unwrap();
-        assert!(
-            matches!(exact.match_type, MatchType::Exact),
-            "expected Exact, got {:?}",
-            exact.match_type
-        );
+        assert_eq!(exact.match_type, Some(MatchType::Exact));
     }
 
     #[test]
@@ -951,15 +869,11 @@ mod tests {
             items,
             None,
             None,
-            false,
+            true,
             CaseMatching::Smart,
         );
         assert!(!results.is_empty());
-        assert!(
-            matches!(results[0].match_type, MatchType::Prefix),
-            "expected Prefix, got {:?}",
-            results[0].match_type
-        );
+        assert_eq!(results[0].match_type, Some(MatchType::Prefix));
     }
 
     #[test]
@@ -970,15 +884,11 @@ mod tests {
             items,
             None,
             None,
-            false,
+            true,
             CaseMatching::Smart,
         );
         assert!(!results.is_empty());
-        assert!(
-            matches!(results[0].match_type, MatchType::Contains),
-            "expected Contains, got {:?}",
-            results[0].match_type
-        );
+        assert_eq!(results[0].match_type, Some(MatchType::Contains));
     }
 
     #[test]
@@ -989,30 +899,32 @@ mod tests {
             items,
             None,
             None,
+            true,
+            CaseMatching::Smart,
+        );
+        assert!(!results.is_empty());
+        assert_eq!(results[0].match_type, Some(MatchType::Fuzzy));
+    }
+
+    #[test]
+    fn test_match_type_none_without_positions() {
+        let items = vec!["hello".to_string()];
+        let results = search_impl(
+            "hello".to_string(),
+            items,
+            None,
+            None,
             false,
             CaseMatching::Smart,
         );
         assert!(!results.is_empty());
-        assert!(
-            matches!(results[0].match_type, MatchType::Fuzzy),
-            "expected Fuzzy, got {:?}",
-            results[0].match_type
-        );
+        assert_eq!(results[0].match_type, None);
     }
 
     #[test]
-    fn test_match_type_always_populated() {
-        // matchType should be set regardless of includePositions
+    fn test_match_type_present_with_positions() {
         let items = vec!["hello".to_string()];
-        let without = search_impl(
-            "hello".to_string(),
-            items.clone(),
-            None,
-            None,
-            false,
-            CaseMatching::Smart,
-        );
-        let with = search_impl(
+        let results = search_impl(
             "hello".to_string(),
             items,
             None,
@@ -1020,28 +932,23 @@ mod tests {
             true,
             CaseMatching::Smart,
         );
-        assert!(matches!(without[0].match_type, MatchType::Exact));
-        assert!(matches!(with[0].match_type, MatchType::Exact));
+        assert!(!results.is_empty());
+        assert_eq!(results[0].match_type, Some(MatchType::Exact));
     }
 
     #[test]
     fn test_match_type_case_insensitive_exact() {
-        // "apple" matching "Apple" should be Exact (smart case)
         let items = vec!["Apple".to_string()];
         let results = search_impl(
             "apple".to_string(),
             items,
             None,
             None,
-            false,
+            true,
             CaseMatching::Smart,
         );
         assert!(!results.is_empty());
-        assert!(
-            matches!(results[0].match_type, MatchType::Exact),
-            "expected Exact for case-insensitive match, got {:?}",
-            results[0].match_type
-        );
+        assert_eq!(results[0].match_type, Some(MatchType::Exact));
     }
 
     #[test]

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -50,6 +50,37 @@ pub(crate) fn classify_match(positions: &[u32], item_char_count: usize) -> Match
     }
 }
 
+/// Classify the match type cheaply using the normalized score and string
+/// comparison, avoiding the cost of `pattern.indices()` when positions
+/// are not requested.
+///
+/// Fast path: score == 1.0 implies an exact match (all characters matched
+/// with maximum score). Otherwise, falls back to case-folded substring
+/// checks. Multi-term queries always classify as Fuzzy.
+pub(crate) fn classify_match_cheap(query: &str, item: &str, score: f64) -> MatchType {
+    // Score of 1.0 with matching length means a perfect match.
+    if (score - 1.0).abs() < f64::EPSILON && query.chars().count() == item.chars().count() {
+        return MatchType::Exact;
+    }
+
+    // Multi-term queries or queries with extended syntax: classify as Fuzzy
+    // since simple substring checks cannot handle them accurately.
+    if query.contains(' ') || query.contains('!') || query.contains('^') || query.contains('$') {
+        return MatchType::Fuzzy;
+    }
+
+    let query_lower: String = query.chars().flat_map(|c| c.to_lowercase()).collect();
+    let item_lower: String = item.chars().flat_map(|c| c.to_lowercase()).collect();
+
+    if item_lower.starts_with(&query_lower) {
+        MatchType::Prefix
+    } else if item_lower.contains(&query_lower) {
+        MatchType::Contains
+    } else {
+        MatchType::Fuzzy
+    }
+}
+
 /// A single fuzzy search result with the matched item and its score.
 #[napi(object)]
 pub struct SearchResult {
@@ -173,24 +204,22 @@ pub(crate) fn search_over_items(
         scored.sort_unstable_by(cmp);
 
         // Pass 2: Construct results only for the final top-k items.
-        // Always compute positions for matchType classification.
         scored
             .into_iter()
             .map(|(index, score)| {
-                buf.clear();
-                let atoms = nucleo_matcher::Utf32Str::new(&items[index as usize], &mut buf);
-                let mut indices = Vec::new();
-                pattern.indices(atoms, &mut matcher, &mut indices);
-                indices.sort_unstable();
-                indices.dedup();
-
-                let item_char_count = items[index as usize].chars().count();
-                let match_type = classify_match(&indices, item_char_count);
-
-                let positions = if include_positions {
-                    indices
+                let (positions, match_type) = if include_positions {
+                    buf.clear();
+                    let atoms = nucleo_matcher::Utf32Str::new(&items[index as usize], &mut buf);
+                    let mut indices = Vec::new();
+                    pattern.indices(atoms, &mut matcher, &mut indices);
+                    indices.sort_unstable();
+                    indices.dedup();
+                    let item_char_count = items[index as usize].chars().count();
+                    let mt = classify_match(&indices, item_char_count);
+                    (indices, mt)
                 } else {
-                    Vec::new()
+                    let mt = classify_match_cheap(query, &items[index as usize], score);
+                    (Vec::new(), mt)
                 };
 
                 SearchResult {
@@ -349,23 +378,21 @@ pub(crate) fn search_over_precomputed(
     scored.sort_unstable_by(cmp);
 
     // Pass 2: Construct results only for the final top-k items.
-    // Always compute positions for matchType classification.
     let results = scored
         .into_iter()
         .map(|(index, score)| {
-            let atoms = utf32_items[index as usize].slice(..);
-            let mut indices = Vec::new();
-            pattern.indices(atoms, &mut matcher, &mut indices);
-            indices.sort_unstable();
-            indices.dedup();
-
-            let item_char_count = items[index as usize].chars().count();
-            let match_type = classify_match(&indices, item_char_count);
-
-            let positions = if include_positions {
-                indices
+            let (positions, match_type) = if include_positions {
+                let atoms = utf32_items[index as usize].slice(..);
+                let mut indices = Vec::new();
+                pattern.indices(atoms, &mut matcher, &mut indices);
+                indices.sort_unstable();
+                indices.dedup();
+                let item_char_count = items[index as usize].chars().count();
+                let mt = classify_match(&indices, item_char_count);
+                (indices, mt)
             } else {
-                Vec::new()
+                let mt = classify_match_cheap(query, &items[index as usize], score);
+                (Vec::new(), mt)
             };
 
             SearchResult {

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,21 @@ export declare class FuzzyIndex {
   remove(index: number): boolean
   /** Free the internal data. After calling this, the index is empty. */
   destroy(): void
+  /**
+   * Serialize the index to a compact binary format.
+   *
+   * The returned Buffer can be written to disk, stored in IndexedDB,
+   * or transferred over the network. Use `FuzzyIndex.deserialize()` to
+   * reconstruct the index.
+   */
+  serialize(): Buffer
+  /**
+   * Reconstruct a FuzzyIndex from a previously serialized Buffer.
+   *
+   * Pre-computes Utf32String and character masks from the stored items,
+   * so the returned index is immediately ready for searching.
+   */
+  static deserialize(data: Buffer): FuzzyIndex
 }
 
 /**
@@ -75,12 +90,14 @@ export declare class KeyedFuzzyIndex {
    * Add a single item to the index.
    *
    * `key_values` must have the same length as the number of keys.
+   * Throws if the length does not match.
    */
   add(keyValues: Array<string>): void
   /**
    * Add multiple items to the index at once.
    *
    * Each element of `items_key_values` is an array of key values for one item.
+   * Throws if any element has the wrong number of key values.
    */
   addMany(itemsKeyValues: Array<Array<string>>): void
   /**
@@ -204,6 +221,22 @@ export declare function levenshteinBatch(pairs: Array<Array<string>>): Array<num
 export declare function levenshteinMany(reference: string, candidates: Array<string>): Array<number>
 
 /**
+ * Classification of how a query matched an item.
+ *
+ * Derived from the matched character positions:
+ * - **Exact**: all positions consecutive from index 0, covering every character in the item.
+ * - **Prefix**: all positions consecutive from index 0, but the item is longer.
+ * - **Contains**: all positions consecutive (a substring match), not starting at 0.
+ * - **Fuzzy**: positions have gaps (character-level fuzzy match).
+ */
+export declare const enum MatchType {
+  Exact = 'Exact',
+  Prefix = 'Prefix',
+  Contains = 'Contains',
+  Fuzzy = 'Fuzzy'
+}
+
+/**
  * Compute the normalized Levenshtein similarity between two strings.
  *
  * Returns a value between 0.0 (completely different) and 1.0 (identical).
@@ -300,6 +333,8 @@ export interface SearchResult {
    * Empty unless `includePositions` is set to true in SearchOptions.
    */
   positions: Array<number>
+  /** How the query matched this item (e.g. exact, prefix, contains, or fuzzy). */
+  matchType: MatchType
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -333,8 +333,12 @@ export interface SearchResult {
    * Empty unless `includePositions` is set to true in SearchOptions.
    */
   positions: Array<number>
-  /** How the query matched this item (e.g. exact, prefix, contains, or fuzzy). */
-  matchType: MatchType
+  /**
+   * How the query matched this item (Exact, Prefix, Contains, or Fuzzy).
+   * Only present when `includePositions` is set to true in SearchOptions.
+   * Derived from positions at zero additional cost.
+   */
+  matchType?: MatchType
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-android-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-android-arm-eabi')
         const bindingPackageVersion = require('rapid-fuzzy-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-x64-gnu')
         const bindingPackageVersion = require('rapid-fuzzy-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-x64-msvc')
         const bindingPackageVersion = require('rapid-fuzzy-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-ia32-msvc')
         const bindingPackageVersion = require('rapid-fuzzy-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-win32-arm64-msvc')
         const bindingPackageVersion = require('rapid-fuzzy-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('rapid-fuzzy-darwin-universal')
       const bindingPackageVersion = require('rapid-fuzzy-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-darwin-x64')
         const bindingPackageVersion = require('rapid-fuzzy-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-darwin-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-freebsd-x64')
         const bindingPackageVersion = require('rapid-fuzzy-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-freebsd-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-x64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-x64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm-musleabihf')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-arm-gnueabihf')
           const bindingPackageVersion = require('rapid-fuzzy-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-loong64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-loong64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-riscv64-musl')
           const bindingPackageVersion = require('rapid-fuzzy-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('rapid-fuzzy-linux-riscv64-gnu')
           const bindingPackageVersion = require('rapid-fuzzy-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-linux-ppc64-gnu')
         const bindingPackageVersion = require('rapid-fuzzy-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-linux-s390x-gnu')
         const bindingPackageVersion = require('rapid-fuzzy-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-openharmony-arm64')
         const bindingPackageVersion = require('rapid-fuzzy-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-openharmony-x64')
         const bindingPackageVersion = require('rapid-fuzzy-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('rapid-fuzzy-openharmony-arm')
         const bindingPackageVersion = require('rapid-fuzzy-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.4.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.4.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -591,6 +591,7 @@ module.exports.jaroWinklerMany = nativeBinding.jaroWinklerMany
 module.exports.levenshtein = nativeBinding.levenshtein
 module.exports.levenshteinBatch = nativeBinding.levenshteinBatch
 module.exports.levenshteinMany = nativeBinding.levenshteinMany
+module.exports.MatchType = nativeBinding.MatchType
 module.exports.normalizedLevenshtein = nativeBinding.normalizedLevenshtein
 module.exports.normalizedLevenshteinBatch = nativeBinding.normalizedLevenshteinBatch
 module.exports.normalizedLevenshteinMany = nativeBinding.normalizedLevenshteinMany

--- a/index.mjs
+++ b/index.mjs
@@ -5,6 +5,7 @@ const binding = require('./index.js');
 
 export const {
   FuzzyIndex,
+  MatchType,
   closest,
   searchKeys,
   damerauLevenshtein,


### PR DESCRIPTION
## Summary

- Add optional `matchType` field to `SearchResult` that classifies how a query matched each item
- Classification values: `Exact`, `Prefix`, `Contains`, `Fuzzy`
- Only populated when `includePositions: true` — **zero performance impact** for default usage
- Derived from already-computed positions at no additional cost

### Design decision

The original issue proposed always populating `matchType`, but benchmarking revealed that computing match classification without positions requires either expensive string comparisons (-15% on small datasets) or an inaccurate heuristic. By tying `matchType` to `includePositions`, we get:

- **Zero overhead** for users who don't need it (the default)
- **100% accuracy** via position-based classification (no heuristic)
- **Zero additional cost** when positions are requested (classification is O(k), essentially free)

### Classification logic

| Type | Condition |
|------|-----------|
| **Exact** | All positions consecutive from index 0, covering every character |
| **Prefix** | All positions consecutive from index 0, item is longer |
| **Contains** | All positions consecutive (substring match), not at start |
| **Fuzzy** | Positions have gaps (character-level fuzzy match) |

### Usage example

```typescript
const results = search('apple', items, { includePositions: true });
// Filter to show only direct matches
const directMatches = results.filter(r => r.matchType !== 'Fuzzy');
// Without includePositions, matchType is undefined (zero cost)
const fast = search('apple', items);
// fast[0].matchType === undefined
```

Closes #244

## Checklist

- [x] Rust: `MatchType` enum + `classify_match()` function
- [x] Rust: `match_type: Option<MatchType>` field in `SearchResult`
- [x] Both search paths updated (`search_over_items` + `search_over_precomputed`)
- [x] TypeScript types auto-generated via napi-rs build (`matchType?: MatchType`)
- [x] Rust tests (7 tests for matchType)
- [x] JS tests (9 tests: standalone search + FuzzyIndex parity)
- [x] Benchmark verified: zero performance regression vs develop
- [x] `cargo test` / `cargo clippy` / `pnpm test` / `pnpm typecheck` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now include a matchType indicating Exact, Prefix, Contains, or Fuzzy.
  * FuzzyIndex can be serialized and deserialized for saving/loading indexes.

* **Tests**
  * Added comprehensive tests to validate match-type classification and consistency across search paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->