### PR TITLE
perf(core): migrate Jaro/Jaro-Winkler to rapidfuzz bit-parallel

### DIFF
--- a/.changeset/jaro-rapidfuzz.md
+++ b/.changeset/jaro-rapidfuzz.md
@@ -1,0 +1,5 @@
+---
+"rapid-fuzzy": patch
+---
+
+Migrate Jaro and Jaro-Winkler from strsim to rapidfuzz bit-parallel implementation for ~2.7x faster single-pair and ~1.9x faster batch comparisons

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,6 +885,7 @@ version = "0.0.0"
 dependencies = [
  "codspeed-criterion-compat",
  "nucleo-matcher",
+ "rapidfuzz",
  "strsim",
 ]
 

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dev-dependencies]
 criterion = { version = "4.4.1", package = "codspeed-criterion-compat" }
 strsim = { workspace = true }
+rapidfuzz = { workspace = true }
 nucleo-matcher = { workspace = true }
 
 [[bench]]

--- a/crates/bench/benches/distance.rs
+++ b/crates/bench/benches/distance.rs
@@ -38,23 +38,103 @@ fn bench_damerau_levenshtein(c: &mut Criterion) {
 }
 
 fn bench_jaro(c: &mut Criterion) {
-    c.bench_function("jaro", |b| {
+    let mut group = c.benchmark_group("jaro");
+    group.bench_function("strsim", |b| {
         b.iter(|| {
             for (a, s) in PAIRS {
                 black_box(strsim::jaro(a, s));
             }
         });
     });
+    group.bench_function("rapidfuzz", |b| {
+        b.iter(|| {
+            for (a, s) in PAIRS {
+                black_box(rapidfuzz::distance::jaro::similarity(a.chars(), s.chars()));
+            }
+        });
+    });
+    group.finish();
 }
 
 fn bench_jaro_winkler(c: &mut Criterion) {
-    c.bench_function("jaro_winkler", |b| {
+    let mut group = c.benchmark_group("jaro_winkler");
+    group.bench_function("strsim", |b| {
         b.iter(|| {
             for (a, s) in PAIRS {
                 black_box(strsim::jaro_winkler(a, s));
             }
         });
     });
+    group.bench_function("rapidfuzz", |b| {
+        b.iter(|| {
+            for (a, s) in PAIRS {
+                black_box(rapidfuzz::distance::jaro_winkler::similarity(
+                    a.chars(),
+                    s.chars(),
+                ));
+            }
+        });
+    });
+    group.finish();
+}
+
+fn bench_jaro_many(c: &mut Criterion) {
+    // Generate 1000 candidate strings for 1:N comparison
+    let candidates: Vec<String> = (0..1000)
+        .map(|i| format!("candidate_string_number_{}", i))
+        .collect();
+    let reference = "candidate_string";
+
+    let mut group = c.benchmark_group("jaro_many_1k");
+    group.bench_function("strsim_loop", |b| {
+        b.iter(|| {
+            let results: Vec<f64> = candidates
+                .iter()
+                .map(|c| strsim::jaro(reference, c))
+                .collect();
+            black_box(results);
+        });
+    });
+    group.bench_function("rapidfuzz_batch_comparator", |b| {
+        b.iter(|| {
+            let scorer = rapidfuzz::distance::jaro::BatchComparator::new(reference.chars());
+            let results: Vec<f64> = candidates
+                .iter()
+                .map(|c| scorer.similarity(c.chars()))
+                .collect();
+            black_box(results);
+        });
+    });
+    group.finish();
+}
+
+fn bench_jaro_winkler_many(c: &mut Criterion) {
+    let candidates: Vec<String> = (0..1000)
+        .map(|i| format!("candidate_string_number_{}", i))
+        .collect();
+    let reference = "candidate_string";
+
+    let mut group = c.benchmark_group("jaro_winkler_many_1k");
+    group.bench_function("strsim_loop", |b| {
+        b.iter(|| {
+            let results: Vec<f64> = candidates
+                .iter()
+                .map(|c| strsim::jaro_winkler(reference, c))
+                .collect();
+            black_box(results);
+        });
+    });
+    group.bench_function("rapidfuzz_batch_comparator", |b| {
+        b.iter(|| {
+            let scorer = rapidfuzz::distance::jaro_winkler::BatchComparator::new(reference.chars());
+            let results: Vec<f64> = candidates
+                .iter()
+                .map(|c| scorer.similarity(c.chars()))
+                .collect();
+            black_box(results);
+        });
+    });
+    group.finish();
 }
 
 fn bench_sorensen_dice(c: &mut Criterion) {
@@ -83,6 +163,8 @@ criterion_group!(
     bench_damerau_levenshtein,
     bench_jaro,
     bench_jaro_winkler,
+    bench_jaro_many,
+    bench_jaro_winkler_many,
     bench_sorensen_dice,
     bench_normalized_levenshtein,
 );

--- a/crates/core/src/distance/mod.rs
+++ b/crates/core/src/distance/mod.rs
@@ -510,6 +510,45 @@ mod tests {
     }
 
     #[test]
+    fn test_jaro_regression_vectors() {
+        let vectors: Vec<(&str, &str, f64)> = vec![
+            ("MARTHA", "MARHTA", 0.9444444444444445),
+            ("DWAYNE", "DUANE", 0.8222222222222223),
+            ("DIXON", "DICKSONX", 0.7666666666666666),
+            ("a jke", "jane a k", 0.6),
+            ("", "", 1.0),
+            ("a", "", 0.0),
+            ("a", "a", 1.0),
+        ];
+        for (a, b, expected) in vectors {
+            let score = jaro(a.into(), b.into());
+            assert!(
+                (score - expected).abs() <= f64::EPSILON,
+                "jaro({a:?}, {b:?}) = {score}, expected {expected}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_jaro_winkler_regression_vectors() {
+        let vectors: Vec<(&str, &str, f64)> = vec![
+            ("MARTHA", "MARHTA", 0.9611111111111111),
+            ("DWAYNE", "DUANE", 0.84),
+            ("DIXON", "DICKSONX", 0.8133333333333332),
+            ("", "", 1.0),
+            ("a", "", 0.0),
+            ("a", "a", 1.0),
+        ];
+        for (a, b, expected) in vectors {
+            let score = jaro_winkler(a.into(), b.into());
+            assert!(
+                (score - expected).abs() <= f64::EPSILON,
+                "jaro_winkler({a:?}, {b:?}) = {score}, expected {expected}",
+            );
+        }
+    }
+
+    #[test]
     fn test_sorensen_dice() {
         let score = sorensen_dice("night".into(), "nacht".into());
         assert!(score > 0.0 && score < 1.0);

--- a/crates/core/src/distance/mod.rs
+++ b/crates/core/src/distance/mod.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeSet;
 
 use napi_derive::napi;
 use rapidfuzz::distance::damerau_levenshtein as rapid_damerau;
+use rapidfuzz::distance::jaro as rapid_jaro;
+use rapidfuzz::distance::jaro_winkler as rapid_jw;
 use rapidfuzz::distance::levenshtein as rapid_lev;
 
 /// Apply a distance/similarity function to each pair in a batch.
@@ -92,7 +94,7 @@ pub fn damerau_levenshtein_many(reference: String, candidates: Vec<String>) -> V
 /// Returns a value between 0.0 (completely different) and 1.0 (identical).
 #[napi]
 pub fn jaro(a: String, b: String) -> f64 {
-    strsim::jaro(&a, &b)
+    rapid_jaro::similarity(a.chars(), b.chars())
 }
 
 /// Compute the Jaro similarity for multiple pairs of strings in a single call.
@@ -100,7 +102,7 @@ pub fn jaro(a: String, b: String) -> f64 {
 /// Returns an array of similarity scores in the same order as the input pairs.
 #[napi]
 pub fn jaro_batch(pairs: Vec<Vec<String>>) -> Vec<f64> {
-    batch_apply(&pairs, strsim::jaro)
+    batch_apply(&pairs, |a, b| rapid_jaro::similarity(a.chars(), b.chars()))
 }
 
 /// Compute the Jaro similarity from one reference string to many candidates.
@@ -108,7 +110,11 @@ pub fn jaro_batch(pairs: Vec<Vec<String>>) -> Vec<f64> {
 /// Returns an array of similarity scores, one per candidate, in the same order as the input.
 #[napi]
 pub fn jaro_many(reference: String, candidates: Vec<String>) -> Vec<f64> {
-    many_apply(&reference, &candidates, strsim::jaro)
+    let scorer = rapid_jaro::BatchComparator::new(reference.chars());
+    candidates
+        .iter()
+        .map(|c| scorer.similarity(c.chars()))
+        .collect()
 }
 
 /// Compute the Jaro-Winkler similarity between two strings.
@@ -117,7 +123,7 @@ pub fn jaro_many(reference: String, candidates: Vec<String>) -> Vec<f64> {
 /// Returns a value between 0.0 and 1.0.
 #[napi]
 pub fn jaro_winkler(a: String, b: String) -> f64 {
-    strsim::jaro_winkler(&a, &b)
+    rapid_jw::similarity(a.chars(), b.chars())
 }
 
 /// Compute the Jaro-Winkler similarity for multiple pairs of strings in a single call.
@@ -125,7 +131,7 @@ pub fn jaro_winkler(a: String, b: String) -> f64 {
 /// Returns an array of similarity scores in the same order as the input pairs.
 #[napi]
 pub fn jaro_winkler_batch(pairs: Vec<Vec<String>>) -> Vec<f64> {
-    batch_apply(&pairs, strsim::jaro_winkler)
+    batch_apply(&pairs, |a, b| rapid_jw::similarity(a.chars(), b.chars()))
 }
 
 /// Compute the Jaro-Winkler similarity from one reference string to many candidates.
@@ -133,7 +139,11 @@ pub fn jaro_winkler_batch(pairs: Vec<Vec<String>>) -> Vec<f64> {
 /// Returns an array of similarity scores, one per candidate, in the same order as the input.
 #[napi]
 pub fn jaro_winkler_many(reference: String, candidates: Vec<String>) -> Vec<f64> {
-    many_apply(&reference, &candidates, strsim::jaro_winkler)
+    let scorer = rapid_jw::BatchComparator::new(reference.chars());
+    candidates
+        .iter()
+        .map(|c| scorer.similarity(c.chars()))
+        .collect()
 }
 
 /// Compute the Sorensen-Dice coefficient between two strings.


### PR DESCRIPTION
## Summary

- Migrate Jaro and Jaro-Winkler implementations from strsim (classic DP) to rapidfuzz-rs (bit-parallel algorithm)
- Use `BatchComparator` for `_many` variants to pre-compute reference string characteristics
- Add comparison benchmarks to `crates/bench/benches/distance.rs`

## Benchmark results (Apple Silicon)

| Operation | strsim | rapidfuzz | Speedup |
|-----------|--------|-----------|---------|
| Jaro (single pair × 6) | 2.61 µs | 0.91 µs | **2.9x** |
| Jaro-Winkler (single pair × 6) | 2.62 µs | 0.99 µs | **2.6x** |
| Jaro many (1K candidates) | 199.6 µs | 97.3 µs | **2.1x** |
| Jaro-Winkler many (1K candidates) | 193.2 µs | 112.9 µs | **1.7x** |

## Precision validation

Cross-validated 21 test pairs (standard, edge cases, Unicode, length-asymmetric, transposition fix from strsim #56). All pairs produce identical f64 output (diff = 0.00, within f64::EPSILON).

## Scope

- Sorensen-Dice remains on strsim (not available in rapidfuzz-rs)
- rapidfuzz 0.5 was already a dependency (used for Levenshtein since #200)

Closes #251

## Checklist

- [x] Biome lint
- [x] TypeScript typecheck
- [x] Vitest tests (219 passed)
- [x] Rust tests (185 passed, including proptest)
- [x] Cargo clippy
- [x] napi-rs build
- [x] Changeset added
- [x] Benchmark comparison completed
- [x] Precision cross-validation completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized Jaro and Jaro-Winkler distance calculations, delivering ~2.7x speed improvements for single-pair comparisons and ~1.9x faster batch operations.

* **Tests**
  * Enhanced benchmarking suite to evaluate performance across additional comparison scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->