### PR TITLE
feat(search): add returnAllOnEmpty option

### DIFF
--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -519,6 +519,59 @@ describe('search', () => {
       }
     });
   });
+
+  describe('returnAllOnEmpty', () => {
+    const items = ['apple', 'banana', 'grape'];
+
+    it('should return all items when query is empty', () => {
+      const results = search('', items, { returnAllOnEmpty: true });
+      expect(results.length).toBe(3);
+      expect(results.map((r) => r.item)).toEqual(items);
+    });
+
+    it('should return items in original index order', () => {
+      const results = search('', items, { returnAllOnEmpty: true });
+      for (let i = 0; i < results.length; i++) {
+        expect(results[i]?.index).toBe(i);
+      }
+    });
+
+    it('should set score to 1.0 for all results', () => {
+      const results = search('', items, { returnAllOnEmpty: true });
+      for (const r of results) {
+        expect(r.score).toBe(1.0);
+      }
+    });
+
+    it('should return empty positions and no matchType', () => {
+      const results = search('', items, { returnAllOnEmpty: true });
+      for (const r of results) {
+        expect(r.positions).toEqual([]);
+        expect(r.matchType).toBeUndefined();
+      }
+    });
+
+    it('should respect maxResults', () => {
+      const results = search('', items, { returnAllOnEmpty: true, maxResults: 2 });
+      expect(results.length).toBe(2);
+    });
+
+    it('should treat whitespace-only query as empty', () => {
+      const results = search('  ', items, { returnAllOnEmpty: true });
+      expect(results.length).toBe(3);
+    });
+
+    it('should return empty when returnAllOnEmpty is false (default)', () => {
+      expect(search('', items)).toEqual([]);
+      expect(search('', items, { returnAllOnEmpty: false })).toEqual([]);
+    });
+
+    it('should perform normal search when query is non-empty', () => {
+      const results = search('apple', items, { returnAllOnEmpty: true });
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.length).toBeLessThan(items.length);
+    });
+  });
 });
 
 describe('closest', () => {
@@ -1203,6 +1256,26 @@ describe('FuzzyIndex', () => {
     it('should respect minScore', () => {
       const index = new FuzzyIndex(['xyz']);
       expect(index.closest('hello', 0.99)).toBeNull();
+    });
+  });
+
+  describe('returnAllOnEmpty', () => {
+    it('should return all items when query is empty', () => {
+      const index = new FuzzyIndex(['apple', 'banana', 'grape']);
+      const results = index.search('', { returnAllOnEmpty: true });
+      expect(results.length).toBe(3);
+      expect(results.map((r) => r.item)).toEqual(['apple', 'banana', 'grape']);
+    });
+
+    it('should respect maxResults', () => {
+      const index = new FuzzyIndex(['apple', 'banana', 'grape']);
+      const results = index.search('', { returnAllOnEmpty: true, maxResults: 1 });
+      expect(results.length).toBe(1);
+    });
+
+    it('should return empty when option is not set', () => {
+      const index = new FuzzyIndex(['apple']);
+      expect(index.search('')).toEqual([]);
     });
   });
 

--- a/crates/core/src/search/index.rs
+++ b/crates/core/src/search/index.rs
@@ -67,16 +67,36 @@ impl FuzzyIndex {
         query: String,
         options: Option<Either<u32, SearchOptions>>,
     ) -> Vec<SearchResult> {
-        let (max_results, min_score, include_positions, case_matching) = match options {
-            Some(Either::A(max)) => (Some(max), None, false, CaseMatching::Smart),
-            Some(Either::B(opts)) => (
-                opts.max_results,
-                opts.min_score,
-                opts.include_positions.unwrap_or(false),
-                resolve_case_matching(opts.is_case_sensitive),
-            ),
-            None => (None, None, false, CaseMatching::Smart),
-        };
+        let (max_results, min_score, include_positions, case_matching, return_all_on_empty) =
+            match options {
+                Some(Either::A(max)) => (Some(max), None, false, CaseMatching::Smart, false),
+                Some(Either::B(opts)) => (
+                    opts.max_results,
+                    opts.min_score,
+                    opts.include_positions.unwrap_or(false),
+                    resolve_case_matching(opts.is_case_sensitive),
+                    opts.return_all_on_empty.unwrap_or(false),
+                ),
+                None => (None, None, false, CaseMatching::Smart, false),
+            };
+
+        if return_all_on_empty && query.trim().is_empty() {
+            let limit = max_results.unwrap_or(self.items.len() as u32) as usize;
+            return self
+                .items
+                .iter()
+                .enumerate()
+                .take(limit)
+                .map(|(i, item)| SearchResult {
+                    item: item.clone(),
+                    score: 1.0,
+                    index: i as u32,
+                    positions: Vec::new(),
+                    match_type: None,
+                })
+                .collect();
+        }
+
         self.search_impl(
             &query,
             max_results,

--- a/crates/core/src/search/keyed_index.rs
+++ b/crates/core/src/search/keyed_index.rs
@@ -65,12 +65,34 @@ impl KeyedFuzzyIndex {
     pub fn search(&self, query: String, options: Option<SearchOptions>) -> Vec<KeySearchResult> {
         let num_keys = self.key_texts.len();
 
-        if query.is_empty() || num_keys == 0 {
+        if num_keys == 0 {
             return Vec::new();
         }
 
         let num_items = self.size() as usize;
         if num_items == 0 {
+            return Vec::new();
+        }
+
+        let return_all_on_empty = options
+            .as_ref()
+            .and_then(|o| o.return_all_on_empty)
+            .unwrap_or(false);
+
+        if return_all_on_empty && query.trim().is_empty() {
+            let max_results = options.as_ref().and_then(|o| o.max_results);
+            let limit = max_results.unwrap_or(num_items as u32) as usize;
+            return (0..num_items)
+                .take(limit)
+                .map(|i| KeySearchResult {
+                    index: i as u32,
+                    score: 1.0,
+                    key_scores: vec![1.0; num_keys],
+                })
+                .collect();
+        }
+
+        if query.is_empty() {
             return Vec::new();
         }
 
@@ -332,6 +354,7 @@ mod tests {
                 min_score: Some(0.9),
                 include_positions: None,
                 is_case_sensitive: None,
+                return_all_on_empty: None,
             }),
         );
         for r in &results {
@@ -349,6 +372,7 @@ mod tests {
                 min_score: None,
                 include_positions: None,
                 is_case_sensitive: None,
+                return_all_on_empty: None,
             }),
         );
         assert!(results.len() <= 1);

--- a/crates/core/src/search/keys.rs
+++ b/crates/core/src/search/keys.rs
@@ -32,7 +32,7 @@ pub fn search_keys(
 ) -> Vec<KeySearchResult> {
     let num_keys = key_texts.len();
 
-    if query.is_empty() || num_keys == 0 || weights.len() != num_keys {
+    if num_keys == 0 || weights.len() != num_keys {
         return Vec::new();
     }
 
@@ -46,6 +46,28 @@ pub fn search_keys(
         if texts.len() != num_items {
             return Vec::new();
         }
+    }
+
+    let return_all_on_empty = options
+        .as_ref()
+        .and_then(|o| o.return_all_on_empty)
+        .unwrap_or(false);
+
+    if return_all_on_empty && query.trim().is_empty() {
+        let max_results = options.as_ref().and_then(|o| o.max_results);
+        let limit = max_results.unwrap_or(num_items as u32) as usize;
+        return (0..num_items)
+            .take(limit)
+            .map(|i| KeySearchResult {
+                index: i as u32,
+                score: 1.0,
+                key_scores: vec![1.0; num_keys],
+            })
+            .collect();
+    }
+
+    if query.is_empty() {
+        return Vec::new();
     }
 
     let (max_results, min_score, case_matching) = match &options {
@@ -256,6 +278,7 @@ mod tests {
                 min_score: None,
                 include_positions: None,
                 is_case_sensitive: None,
+                return_all_on_empty: None,
             }),
         );
         assert!(results.len() <= 2);
@@ -279,6 +302,7 @@ mod tests {
                 min_score: Some(0.5),
                 include_positions: None,
                 is_case_sensitive: None,
+                return_all_on_empty: None,
             }),
         );
         for r in &results {
@@ -351,6 +375,7 @@ mod tests {
                 min_score: Some(1.0),
                 include_positions: None,
                 is_case_sensitive: Some(true),
+                return_all_on_empty: None,
             }),
         );
         assert_eq!(results.len(), 1);
@@ -389,5 +414,93 @@ mod tests {
                 sr.score
             );
         }
+    }
+
+    #[test]
+    fn test_return_all_on_empty() {
+        let key_texts = vec![vec![
+            "apple".to_string(),
+            "banana".to_string(),
+            "grape".to_string(),
+        ]];
+        let weights = vec![1.0];
+
+        let results = search_keys(
+            "".to_string(),
+            key_texts,
+            weights,
+            Some(SearchOptions {
+                max_results: None,
+                min_score: None,
+                include_positions: None,
+                is_case_sensitive: None,
+                return_all_on_empty: Some(true),
+            }),
+        );
+        assert_eq!(results.len(), 3);
+        for (i, r) in results.iter().enumerate() {
+            assert_eq!(r.index, i as u32);
+            assert!((r.score - 1.0).abs() < f64::EPSILON);
+        }
+    }
+
+    #[test]
+    fn test_return_all_on_empty_respects_max_results() {
+        let key_texts = vec![vec!["a".to_string(), "b".to_string(), "c".to_string()]];
+        let weights = vec![1.0];
+
+        let results = search_keys(
+            "".to_string(),
+            key_texts,
+            weights,
+            Some(SearchOptions {
+                max_results: Some(2),
+                min_score: None,
+                include_positions: None,
+                is_case_sensitive: None,
+                return_all_on_empty: Some(true),
+            }),
+        );
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_return_all_on_empty_false_returns_empty() {
+        let key_texts = vec![vec!["apple".to_string()]];
+        let weights = vec![1.0];
+
+        let results = search_keys(
+            "".to_string(),
+            key_texts,
+            weights,
+            Some(SearchOptions {
+                max_results: None,
+                min_score: None,
+                include_positions: None,
+                is_case_sensitive: None,
+                return_all_on_empty: Some(false),
+            }),
+        );
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_return_all_on_empty_whitespace_query() {
+        let key_texts = vec![vec!["apple".to_string(), "banana".to_string()]];
+        let weights = vec![1.0];
+
+        let results = search_keys(
+            "  ".to_string(),
+            key_texts,
+            weights,
+            Some(SearchOptions {
+                max_results: None,
+                min_score: None,
+                include_positions: None,
+                is_case_sensitive: None,
+                return_all_on_empty: Some(true),
+            }),
+        );
+        assert_eq!(results.len(), 2);
     }
 }

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -80,6 +80,10 @@ pub struct SearchOptions {
     /// If true, matching is case-sensitive. Default is smart case
     /// (case-insensitive unless the query contains uppercase characters).
     pub is_case_sensitive: Option<bool>,
+    /// If true, return all items when the query is empty (or whitespace-only).
+    /// Useful for filter-as-you-type UIs where the full list should appear
+    /// before the user starts typing. Default is false.
+    pub return_all_on_empty: Option<bool>,
 }
 
 /// Compute the maximum possible score for a given pattern by scoring
@@ -414,16 +418,35 @@ pub fn search(
     items: Vec<String>,
     options: Option<Either<u32, SearchOptions>>,
 ) -> Vec<SearchResult> {
-    let (max_results, min_score, include_positions, case_matching) = match options {
-        Some(Either::A(max)) => (Some(max), None, false, CaseMatching::Smart),
-        Some(Either::B(opts)) => (
-            opts.max_results,
-            opts.min_score,
-            opts.include_positions.unwrap_or(false),
-            resolve_case_matching(opts.is_case_sensitive),
-        ),
-        None => (None, None, false, CaseMatching::Smart),
-    };
+    let (max_results, min_score, include_positions, case_matching, return_all_on_empty) =
+        match options {
+            Some(Either::A(max)) => (Some(max), None, false, CaseMatching::Smart, false),
+            Some(Either::B(opts)) => (
+                opts.max_results,
+                opts.min_score,
+                opts.include_positions.unwrap_or(false),
+                resolve_case_matching(opts.is_case_sensitive),
+                opts.return_all_on_empty.unwrap_or(false),
+            ),
+            None => (None, None, false, CaseMatching::Smart, false),
+        };
+
+    if return_all_on_empty && query.trim().is_empty() {
+        let limit = max_results.unwrap_or(items.len() as u32) as usize;
+        return items
+            .iter()
+            .enumerate()
+            .take(limit)
+            .map(|(i, item)| SearchResult {
+                item: item.clone(),
+                score: 1.0,
+                index: i as u32,
+                positions: Vec::new(),
+                match_type: None,
+            })
+            .collect();
+    }
+
     search_impl(
         query,
         items,

--- a/index.d.ts
+++ b/index.d.ts
@@ -318,6 +318,12 @@ export interface SearchOptions {
    * (case-insensitive unless the query contains uppercase characters).
    */
   isCaseSensitive?: boolean
+  /**
+   * If true, return all items when the query is empty (or whitespace-only).
+   * Useful for filter-as-you-type UIs where the full list should appear
+   * before the user starts typing. Default is false.
+   */
+  returnAllOnEmpty?: boolean
 }
 
 /** A single fuzzy search result with the matched item and its score. */

--- a/objects.d.ts
+++ b/objects.d.ts
@@ -54,6 +54,7 @@ export interface ObjectIndexSearchOptions {
   maxResults?: number;
   minScore?: number;
   isCaseSensitive?: boolean;
+  returnAllOnEmpty?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `returnAllOnEmpty` option to `SearchOptions` for filter-as-you-type UIs
- When `true` and query is empty (or whitespace-only), returns all items in original index order with `score: 1.0`
- Default is `false` (backward compatible, no behavior change)

### Problem

Search-as-you-type UIs need to show the full list before the user starts typing, requiring two code paths:

```typescript
// Before: two code paths needed
const results = query
  ? search(query, items)
  : items.map((item, index) => ({ item, score: 1, index, positions: [] }))

// After: single code path
const results = search(query, items, { returnAllOnEmpty: true })
```

This is [one of the most requested features](https://github.com/krisk/Fuse/issues/229) in the fuzzy search ecosystem (29 upvotes, 78 comments on fuse.js).

### Scope

| Function | Behavior |
|----------|----------|
| `search()` | Returns all items as SearchResult |
| `FuzzyIndex.search()` | Returns all indexed items |
| `searchKeys()` | Returns all items with per-key scores of 1.0 |
| `KeyedFuzzyIndex.search()` | Same |
| `searchObjects()` / `FuzzyObjectIndex.search()` | Passes through via Rust wrappers |
| `closest()` | Not affected (does not accept SearchOptions) |

- `maxResults` is respected (allows pagination)
- `positions: []` and `matchType: undefined` (no match occurred)
- Zero performance impact on non-empty queries (early return before scoring)

Closes #245

## Checklist

- [x] `SearchOptions.returnAllOnEmpty` added in Rust
- [x] Early return in 4 napi entry points (search, FuzzyIndex, searchKeys, KeyedFuzzyIndex)
- [x] `ObjectIndexSearchOptions.returnAllOnEmpty` added in objects.d.ts
- [x] Rust tests (4 new tests in keys.rs)
- [x] JS tests (11 new tests for search + FuzzyIndex)
- [x] `cargo test` / `cargo clippy` / `pnpm test` / `pnpm typecheck` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `returnAllOnEmpty` option to search configuration that returns all items when queries are empty or whitespace-only, with uniform scores of 1.0. Respects max-results limits to optimize filter-as-you-type interfaces.

* **Tests**
  * Added comprehensive test coverage for the new empty-query behavior, including whitespace handling, result truncation, and verification of parity between standalone and index-based search implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->