### PR TITLE
docs(readme): add WASM bundle size information

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pnpm add rapid-fuzzy
 ### Runtime-specific notes
 
 - **Node.js** (>=20): Uses native bindings via napi-rs for best performance.
-- **Browser / Deno / Bun**: Falls back to a WASM build automatically.
+- **Browser / Deno / Bun**: Falls back to a WASM build automatically. The WASM binary is ~607 KB raw (~204 KB gzipped).
 
 > **Note**: rapid-fuzzy is pre-1.0 — the API is stable but minor versions may include additions.
 
@@ -351,7 +351,7 @@ cargo bench           # Rust internal benchmarks
 | **Highlight utility** | ✅ | — | — | ✅ | ✅ |
 | **Batch API** | ✅ | — | — | — | — |
 | **Node.js native** | ✅ napi-rs | — | — | — | — |
-| **Browser** | ✅ WASM | ✅ | ✅ | ✅ | ✅ |
+| **Browser** | ✅ WASM (~204 KB gzip) | ✅ | ✅ | ✅ | ✅ |
 | **TypeScript** | ✅ full | ✅ full | ✅ | ✅ | ✅ |
 
 ## Migration Guides

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pnpm add rapid-fuzzy
 ### Runtime-specific notes
 
 - **Node.js** (>=20): Uses native bindings via napi-rs for best performance.
-- **Browser / Deno / Bun**: Falls back to a WASM build automatically. The WASM binary is ~607 KB raw (~204 KB gzipped).
+- **Browser / Deno / Bun**: Falls back to a WASM build automatically. The WASM binary is ~607 KB raw (~200 KB gzipped).
 
 > **Note**: rapid-fuzzy is pre-1.0 — the API is stable but minor versions may include additions.
 
@@ -351,7 +351,7 @@ cargo bench           # Rust internal benchmarks
 | **Highlight utility** | ✅ | — | — | ✅ | ✅ |
 | **Batch API** | ✅ | — | — | — | — |
 | **Node.js native** | ✅ napi-rs | — | — | — | — |
-| **Browser** | ✅ WASM (~204 KB gzip) | ✅ | ✅ | ✅ | ✅ |
+| **Browser** | ✅ WASM (~200 KB gzipped) | ✅ | ✅ | ✅ | ✅ |
 | **TypeScript** | ✅ full | ✅ full | ✅ | ✅ | ✅ |
 
 ## Migration Guides


### PR DESCRIPTION
## Summary

- Add WASM bundle size (~607 KB raw, ~204 KB gzipped) to the "Runtime-specific notes" section
- Include gzipped size in the "Browser" row of the feature comparison table

Sizes measured from the published `rapid-fuzzy-wasm32-wasi@0.6.0` npm package.

Closes #261

## Checklist

- [x] Measured WASM bundle size from published npm package
- [x] Added size info to README in two relevant locations
- [x] All pre-push hooks pass (lint, typecheck, test, clippy, cargo test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation with WASM binary size specifications to improve transparency on runtime requirements. Added size annotations (~204 KB gzipped, ~607 KB raw) for WASM fallback support across Browser/Deno/Bun runtime documentation and feature comparison table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->