### PR TITLE
ci: verify napi-rs generated binding files are in sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run check
       - run: pnpm run build
+      - name: Verify generated binding files are up to date
+        run: git diff --exit-code index.js index.d.ts browser.js
       - run: pnpm run typecheck
       - run: pnpm run publint
 


### PR DESCRIPTION
## Summary

- Add a CI check in the lint job that verifies committed binding files (`index.js`, `index.d.ts`, `browser.js`) match the Rust source after build
- Runs `git diff --exit-code` on the generated files immediately after `pnpm run build`
- Prevents PRs from being merged with stale generated files

Closes #265

## Related issue

Same pattern used by protobuf / `go generate` projects to enforce codegen freshness.

## Checklist

- [x] All pre-push hooks passed (lint, typecheck, test, clippy, cargo-test, cargo-deny)
- [x] Change is minimal (2 lines added to ci.yml)