### PR TITLE
feat(playground): add interactive playground

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -126,6 +126,26 @@
           }
         }
       }
+    },
+    {
+      "includes": ["playground/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noDefaultExport": "off"
+          },
+          "performance": {
+            "noBarrelFile": "off",
+            "noReExportAll": "off"
+          },
+          "correctness": {
+            "noUndeclaredDependencies": "off"
+          },
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/playground/index.html
+++ b/playground/index.html
@@ -20,6 +20,7 @@
         <input
           type="text"
           id="search-input"
+          aria-label="Search query"
           placeholder="Type to search…"
           autocomplete="off"
           spellcheck="false"
@@ -35,7 +36,7 @@
       <div class="results" id="search-results">
         <p class="placeholder">Results will appear here as you type.</p>
       </div>
-      <details class="syntax-help">
+      <details class="syntax-help" open>
         <summary>Extended query syntax (always active)</summary>
         <ul>
           <li><code>^prefix</code> — starts with</li>
@@ -51,8 +52,8 @@
     <section class="card" id="distance-section">
       <h2>String Distance / Similarity</h2>
       <div class="distance-inputs">
-        <input type="text" id="dist-a" placeholder="String A" value="kitten">
-        <input type="text" id="dist-b" placeholder="String B" value="sitting">
+        <input type="text" id="dist-a" aria-label="Distance input A" placeholder="String A" value="kitten">
+        <input type="text" id="dist-b" aria-label="Distance input B" placeholder="String B" value="sitting">
       </div>
       <div class="algorithm-select">
         <label for="algorithm">Algorithm:</label>

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>rapid-fuzzy Playground</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <header>
+    <h1>rapid-fuzzy <span class="badge">Playground</span></h1>
+    <p class="subtitle">Rust-powered fuzzy search for JavaScript — try it live.</p>
+  </header>
+
+  <main>
+    <!-- Search Demo -->
+    <section class="card" id="search-section">
+      <h2>Fuzzy Search</h2>
+      <div class="search-controls">
+        <input
+          type="text"
+          id="search-input"
+          placeholder="Type to search…"
+          autocomplete="off"
+          spellcheck="false"
+        >
+        <div class="options-row">
+          <label>
+            <input type="checkbox" id="opt-positions" checked>
+            Highlight matches
+          </label>
+        </div>
+      </div>
+      <div class="timing" id="search-timing"></div>
+      <div class="results" id="search-results">
+        <p class="placeholder">Results will appear here as you type.</p>
+      </div>
+      <details class="syntax-help">
+        <summary>Extended query syntax (always active)</summary>
+        <ul>
+          <li><code>^prefix</code> — starts with</li>
+          <li><code>suffix$</code> — ends with</li>
+          <li><code>'literal</code> — exact substring</li>
+          <li><code>!exclude</code> — exclude matches</li>
+          <li>Combine with spaces: <code>^type script !java</code></li>
+        </ul>
+      </details>
+    </section>
+
+    <!-- Distance Calculator -->
+    <section class="card" id="distance-section">
+      <h2>String Distance / Similarity</h2>
+      <div class="distance-inputs">
+        <input type="text" id="dist-a" placeholder="String A" value="kitten">
+        <input type="text" id="dist-b" placeholder="String B" value="sitting">
+      </div>
+      <div class="algorithm-select">
+        <label for="algorithm">Algorithm:</label>
+        <select id="algorithm">
+          <option value="levenshtein">Levenshtein</option>
+          <option value="normalizedLevenshtein">Normalized Levenshtein</option>
+          <option value="damerauLevenshtein">Damerau-Levenshtein</option>
+          <option value="jaro">Jaro</option>
+          <option value="jaroWinkler" selected>Jaro-Winkler</option>
+          <option value="sorensenDice">Sørensen-Dice</option>
+          <option value="tokenSortRatio">Token Sort Ratio</option>
+          <option value="tokenSetRatio">Token Set Ratio</option>
+          <option value="partialRatio">Partial Ratio</option>
+          <option value="weightedRatio">Weighted Ratio</option>
+        </select>
+      </div>
+      <div class="distance-result" id="distance-result"></div>
+    </section>
+  </main>
+
+  <footer>
+    <p>
+      <a href="https://github.com/derodero24/rapid-fuzzy" target="_blank" rel="noopener">GitHub</a>
+      ·
+      <a href="https://www.npmjs.com/package/rapid-fuzzy" target="_blank" rel="noopener">npm</a>
+    </p>
+  </footer>
+
+  <div id="loading-overlay">
+    <div class="spinner"></div>
+    <p>Loading WASM module…</p>
+  </div>
+
+  <script type="module" src="/main.js"></script>
+</body>
+</html>

--- a/playground/index.html
+++ b/playground/index.html
@@ -36,7 +36,7 @@
       <div class="results" id="search-results">
         <p class="placeholder">Results will appear here as you type.</p>
       </div>
-      <details class="syntax-help" open>
+      <details class="syntax-help">
         <summary>Extended query syntax (always active)</summary>
         <ul>
           <li><code>^prefix</code> — starts with</li>

--- a/playground/main.js
+++ b/playground/main.js
@@ -1,0 +1,184 @@
+import * as distance from 'rapid-fuzzy';
+import { highlight, search } from 'rapid-fuzzy';
+
+// --- Sample data ---
+const sampleItems = [
+  'TypeScript',
+  'JavaScript',
+  'Python',
+  'Rust',
+  'Go',
+  'Ruby',
+  'Swift',
+  'Kotlin',
+  'Scala',
+  'Haskell',
+  'Clojure',
+  'Elixir',
+  'Erlang',
+  'Lua',
+  'Perl',
+  'PHP',
+  'Java',
+  'C#',
+  'C++',
+  'C',
+  'Zig',
+  'Nim',
+  'Dart',
+  'Julia',
+  'R',
+  'MATLAB',
+  'Fortran',
+  'COBOL',
+  'Assembly',
+  'Objective-C',
+  'Visual Basic',
+  'F#',
+  'OCaml',
+  'Racket',
+  'Scheme',
+  'Common Lisp',
+  'Crystal',
+  'V',
+  'Odin',
+  'Mojo',
+  'Gleam',
+  'Roc',
+  'Unison',
+  'Bend',
+];
+
+// --- Distance algorithms ---
+const distanceFunctions = {
+  levenshtein: { fn: distance.levenshtein, type: 'distance' },
+  normalizedLevenshtein: { fn: distance.normalizedLevenshtein, type: 'similarity' },
+  damerauLevenshtein: { fn: distance.damerauLevenshtein, type: 'distance' },
+  jaro: { fn: distance.jaro, type: 'similarity' },
+  jaroWinkler: { fn: distance.jaroWinkler, type: 'similarity' },
+  sorensenDice: { fn: distance.sorensenDice, type: 'similarity' },
+  tokenSortRatio: { fn: distance.tokenSortRatio, type: 'similarity' },
+  tokenSetRatio: { fn: distance.tokenSetRatio, type: 'similarity' },
+  partialRatio: { fn: distance.partialRatio, type: 'similarity' },
+  weightedRatio: { fn: distance.weightedRatio, type: 'similarity' },
+};
+
+// --- DOM refs ---
+const searchInput = document.getElementById('search-input');
+const searchResults = document.getElementById('search-results');
+const searchTiming = document.getElementById('search-timing');
+const optPositions = document.getElementById('opt-positions');
+const distA = document.getElementById('dist-a');
+const distB = document.getElementById('dist-b');
+const algorithmSelect = document.getElementById('algorithm');
+const distanceResult = document.getElementById('distance-result');
+const loadingOverlay = document.getElementById('loading-overlay');
+
+// --- Search ---
+function runSearch() {
+  const query = searchInput.value;
+
+  if (!query.trim()) {
+    searchResults.innerHTML = '<p class="placeholder">Results will appear here as you type.</p>';
+    searchTiming.textContent = '';
+    return;
+  }
+
+  const usePositions = optPositions.checked;
+
+  const start = performance.now();
+  const results = search(query, sampleItems, {
+    includePositions: usePositions,
+    maxResults: 20,
+  });
+  const elapsed = performance.now() - start;
+
+  const noun = results.length === 1 ? 'result' : 'results';
+  searchTiming.textContent = `${results.length} ${noun} in ${elapsed.toFixed(2)} ms`;
+
+  if (results.length === 0) {
+    searchResults.innerHTML = '<p class="placeholder">No matches found.</p>';
+    return;
+  }
+
+  searchResults.innerHTML = results
+    .map((r) => {
+      const text =
+        usePositions && r.positions
+          ? highlight(r.item, r.positions, '<mark>', '</mark>')
+          : escapeHtml(r.item);
+
+      const scoreClass = r.score >= 0.8 ? 'score-high' : r.score >= 0.5 ? 'score-mid' : 'score-low';
+
+      const matchType = r.matchType
+        ? `<span class="match-type match-type-${r.matchType.toLowerCase()}">${r.matchType}</span>`
+        : '';
+
+      return `<div class="result-item">
+        <span class="text">${text}</span>
+        ${matchType}
+        <span class="score ${scoreClass}">${r.score.toFixed(3)}</span>
+      </div>`;
+    })
+    .join('');
+}
+
+// --- Distance ---
+function runDistance() {
+  const a = distA.value;
+  const b = distB.value;
+  const algo = algorithmSelect.value;
+  const config = distanceFunctions[algo];
+
+  if (!a && !b) {
+    distanceResult.innerHTML = '';
+    return;
+  }
+
+  const result = config.fn(a, b);
+  const label = config.type === 'distance' ? 'Distance' : 'Similarity';
+
+  let display;
+  if (config.type === 'distance') {
+    display = result;
+  } else {
+    display = result.toFixed(4);
+  }
+
+  distanceResult.innerHTML = `
+    <span class="distance-label">${label}</span>
+    ${display}
+  `;
+}
+
+// --- Utils ---
+function escapeHtml(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// --- Init ---
+function init() {
+  // Verify WASM is loaded by calling a simple function
+  try {
+    distance.levenshtein('a', 'b');
+  } catch {
+    loadingOverlay.querySelector('p').textContent =
+      'Failed to load WASM module. Ensure CORS headers are set.';
+    return;
+  }
+
+  loadingOverlay.classList.add('hidden');
+
+  // Event listeners
+  searchInput.addEventListener('input', runSearch);
+  optPositions.addEventListener('change', runSearch);
+  distA.addEventListener('input', runDistance);
+  distB.addEventListener('input', runDistance);
+  algorithmSelect.addEventListener('change', runDistance);
+
+  // Initial state
+  runDistance();
+  searchInput.focus();
+}
+
+init();

--- a/playground/main.js
+++ b/playground/main.js
@@ -128,7 +128,7 @@ function runDistance() {
   const a = distA.value;
   const b = distB.value;
   const algo = algorithmSelect.value;
-  const config = distanceFunctions[algo] ?? distanceFunctions.jaroWinkler;
+  const config = distanceFunctions[algo];
 
   if (!a && !b) {
     distanceResult.innerHTML = '';

--- a/playground/main.js
+++ b/playground/main.js
@@ -128,7 +128,7 @@ function runDistance() {
   const a = distA.value;
   const b = distB.value;
   const algo = algorithmSelect.value;
-  const config = distanceFunctions[algo];
+  const config = distanceFunctions[algo] ?? distanceFunctions.jaroWinkler;
 
   if (!a && !b) {
     distanceResult.innerHTML = '';

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "rapid-fuzzy": "latest"
+    "rapid-fuzzy": "^0.6.0"
   },
   "devDependencies": {
     "vite": "^6.4.1"

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rapid-fuzzy-playground",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "rapid-fuzzy": "latest"
+  },
+  "devDependencies": {
+    "vite": "^6.4.1"
+  }
+}

--- a/playground/rapid-fuzzy-local.js
+++ b/playground/rapid-fuzzy-local.js
@@ -1,0 +1,38 @@
+// Local development shim — re-exports WASM loader + highlight utilities.
+// In production (StackBlitz / npm), imports resolve to the `rapid-fuzzy` package directly.
+export * from 'rapid-fuzzy-wasm32-wasi';
+
+// Inline highlight utilities (same as ../highlight.js but as ESM).
+// Needed because Vite can't CJS-transform files served via /@fs/.
+export function highlightRanges(item, positions) {
+  if (!item) return [];
+  if (!positions || positions.length === 0) {
+    return [{ start: 0, end: item.length, matched: false }];
+  }
+  const set = new Set(positions);
+  const ranges = [];
+  let i = 0;
+  while (i < item.length) {
+    const matched = set.has(i);
+    const start = i;
+    while (i < item.length && set.has(i) === matched) i++;
+    ranges.push({ start, end: i, matched });
+  }
+  return ranges;
+}
+
+export function highlight(item, positions, openOrCallback, close) {
+  if (!positions || positions.length === 0) return item;
+  const ranges = highlightRanges(item, positions);
+  const useCallback = typeof openOrCallback === 'function';
+  const parts = [];
+  for (const range of ranges) {
+    const segment = item.slice(range.start, range.end);
+    if (range.matched) {
+      parts.push(useCallback ? openOrCallback(segment) : openOrCallback + segment + (close ?? ''));
+    } else {
+      parts.push(segment);
+    }
+  }
+  return parts.join('');
+}

--- a/playground/style.css
+++ b/playground/style.css
@@ -1,0 +1,358 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg: #0f1117;
+  --surface: #1a1d27;
+  --border: #2a2d3a;
+  --text: #e4e4e7;
+  --text-muted: #71717a;
+  --accent: #3b82f6;
+  --accent-dim: #1e3a5f;
+  --match-bg: #3b82f622;
+  --match-text: #60a5fa;
+  --green: #22c55e;
+  --yellow: #eab308;
+  --red: #ef4444;
+  --radius: 8px;
+  --font-mono: "SF Mono", "Cascadia Code", "Fira Code", monospace;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+  padding: 2rem 1rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+header h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.badge {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15em 0.5em;
+  border-radius: 4px;
+  vertical-align: middle;
+  margin-left: 0.25rem;
+  text-transform: uppercase;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  margin-top: 0.25rem;
+}
+
+main {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+}
+
+.card h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: var(--text);
+}
+
+input[type="text"],
+select {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.95rem;
+  font-family: var(--font-mono);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+input[type="text"]:focus,
+select:focus {
+  border-color: var(--accent);
+}
+
+.options-row {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.options-row label {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+}
+
+.timing {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-top: 0.5rem;
+  min-height: 1.2em;
+}
+
+.results {
+  margin-top: 0.75rem;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.placeholder {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 1.5rem 0;
+}
+
+.result-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+
+.result-item:hover {
+  background: var(--bg);
+}
+
+.result-item .text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.result-item .score {
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.result-item .match-type {
+  font-size: 0.7rem;
+  padding: 0.1em 0.4em;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.match-type-exact {
+  background: #22c55e22;
+  color: var(--green);
+}
+
+.match-type-prefix {
+  background: #3b82f622;
+  color: var(--accent);
+}
+
+.match-type-contains {
+  background: #eab30822;
+  color: var(--yellow);
+}
+
+.match-type-fuzzy {
+  background: #71717a22;
+  color: var(--text-muted);
+}
+
+mark {
+  background: var(--match-bg);
+  color: var(--match-text);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.score-high {
+  color: var(--green);
+}
+
+.score-mid {
+  color: var(--yellow);
+}
+
+.score-low {
+  color: var(--red);
+}
+
+/* Distance section */
+.distance-inputs {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.algorithm-select {
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.algorithm-select label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.algorithm-select select {
+  flex: 1;
+}
+
+.distance-result {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: var(--bg);
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 1.25rem;
+  text-align: center;
+  min-height: 2.5rem;
+}
+
+.distance-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+/* Syntax help */
+.syntax-help {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.syntax-help summary {
+  cursor: pointer;
+}
+
+.syntax-help ul {
+  margin-top: 0.5rem;
+  padding-left: 1.25rem;
+}
+
+.syntax-help li {
+  margin-bottom: 0.25rem;
+}
+
+.syntax-help code {
+  background: var(--bg);
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+
+/* Loading overlay */
+#loading-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  z-index: 1000;
+  transition: opacity 0.3s;
+}
+
+#loading-overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Footer */
+footer {
+  text-align: center;
+  margin-top: 2rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+footer a:hover {
+  text-decoration: underline;
+}
+
+/* Scrollbar */
+.results::-webkit-scrollbar {
+  width: 6px;
+}
+
+.results::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.results::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  body {
+    padding: 1rem 0.5rem;
+  }
+
+  .distance-inputs {
+    flex-direction: column;
+  }
+}

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -1,0 +1,23 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+
+// When running locally from the repo (after `pnpm run build:wasm`),
+// aliases resolve to the local WASM build + highlight utilities.
+// On StackBlitz, remove the `resolve.alias` block — imports resolve
+// to the `rapid-fuzzy` npm package directly.
+const root = resolve(__dirname, '..');
+
+export default defineConfig({
+  server: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  },
+  resolve: {
+    alias: {
+      'rapid-fuzzy': resolve(__dirname, 'rapid-fuzzy-local.js'),
+      'rapid-fuzzy-wasm32-wasi': resolve(root, 'rapid-fuzzy.wasi-browser.js'),
+    },
+  },
+});

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -1,11 +1,14 @@
+import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
 // When running locally from the repo (after `pnpm run build:wasm`),
 // aliases resolve to the local WASM build + highlight utilities.
-// On StackBlitz, remove the `resolve.alias` block — imports resolve
-// to the `rapid-fuzzy` npm package directly.
+// On StackBlitz or clean checkouts, aliases are skipped and imports
+// resolve to the `rapid-fuzzy` npm package directly.
 const root = resolve(__dirname, '..');
+const localWasmEntry = resolve(root, 'rapid-fuzzy.wasi-browser.js');
+const useLocalAliases = existsSync(localWasmEntry);
 
 export default defineConfig({
   server: {
@@ -15,9 +18,11 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: {
-      'rapid-fuzzy': resolve(__dirname, 'rapid-fuzzy-local.js'),
-      'rapid-fuzzy-wasm32-wasi': resolve(root, 'rapid-fuzzy.wasi-browser.js'),
-    },
+    alias: useLocalAliases
+      ? {
+          'rapid-fuzzy': resolve(__dirname, 'rapid-fuzzy-local.js'),
+          'rapid-fuzzy-wasm32-wasi': localWasmEntry,
+        }
+      : {},
   },
 });


### PR DESCRIPTION
## Summary

- Add self-contained Vite project under `playground/` for trying rapid-fuzzy live
- Fuzzy search demo with real-time results, scores, highlights, and match type badges
- All 10 string distance/similarity algorithms with interactive calculator
- Extended query syntax documentation (always active)
- Add Biome overrides for playground directory

## How to run locally

```bash
pnpm run build:wasm   # or pnpm run build for native
cd playground
npm install
npm run dev           # opens http://localhost:5173
```

Closes #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive playground page with fuzzy search UI, highlighting, timing, and result scoring.
  * Distance/similarity calculator supporting multiple algorithms and live results.
  * Local playground loader for WASM-based fuzzy matching and highlighting utilities.

* **Style**
  * Dark-themed stylesheet and responsive layout for the playground UI.

* **Chores**
  * Playground project setup (dev/build config and package metadata).
  * Linter override added to relax strict rules for playground files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->