### PR TITLE
fix(esm): add KeyedFuzzyIndex to ESM wrapper exports

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -5,6 +5,7 @@ const binding = require('./index.js');
 
 export const {
   FuzzyIndex,
+  KeyedFuzzyIndex,
   MatchType,
   closest,
   searchKeys,


### PR DESCRIPTION
## Summary

- Add `KeyedFuzzyIndex` to the destructured exports in `index.mjs`
- ESM users importing `KeyedFuzzyIndex` were getting `undefined` at runtime despite TypeScript showing no errors, because the class was missing from the ESM re-export list

## Related issue

Closes #271

## Checklist

- [x] `KeyedFuzzyIndex` added to `index.mjs` exports
- [x] Biome lint passes
- [x] TypeScript type check passes
- [x] All tests pass (Vitest + cargo test)
- [x] Clippy clean