### PR TITLE
fix(objects): add runtime input validation for keys parameter

### DIFF
--- a/__test__/objects.spec.ts
+++ b/__test__/objects.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-const { searchObjects } = require('../objects.js');
+const { searchObjects, FuzzyObjectIndex } = require('../objects.js');
 
 const users = [
   { name: 'John Smith', email: 'john@example.com', role: 'admin' },
@@ -156,9 +156,43 @@ describe('searchObjects', () => {
   });
 });
 
-describe('FuzzyObjectIndex', () => {
-  const { FuzzyObjectIndex } = require('../objects.js');
+describe('searchObjects input validation', () => {
+  it('throws on undefined options', () => {
+    expect(() => searchObjects('query', [], undefined as never)).toThrow(TypeError);
+  });
 
+  it('throws on null options', () => {
+    expect(() => searchObjects('query', [], null as never)).toThrow(TypeError);
+  });
+
+  it('throws on empty keys array', () => {
+    expect(() => searchObjects('query', [], { keys: [] })).toThrow(TypeError);
+  });
+
+  it('throws on missing keys property', () => {
+    expect(() => searchObjects('query', [], {} as never)).toThrow(TypeError);
+  });
+});
+
+describe('FuzzyObjectIndex input validation', () => {
+  it('throws on undefined options', () => {
+    expect(() => new FuzzyObjectIndex([], undefined as never)).toThrow(TypeError);
+  });
+
+  it('throws on null options', () => {
+    expect(() => new FuzzyObjectIndex([], null as never)).toThrow(TypeError);
+  });
+
+  it('throws on empty keys array', () => {
+    expect(() => new FuzzyObjectIndex([], { keys: [] })).toThrow(TypeError);
+  });
+
+  it('throws on missing keys property', () => {
+    expect(() => new FuzzyObjectIndex([], {} as never)).toThrow(TypeError);
+  });
+});
+
+describe('FuzzyObjectIndex', () => {
   const users = [
     { name: 'John Smith', email: 'john@example.com' },
     { name: 'Jane Doe', email: 'jane@example.com' },

--- a/objects.js
+++ b/objects.js
@@ -34,6 +34,9 @@ function getNestedValue(obj, path) {
  * @returns {Array<{ item: T; index: number; score: number; keyScores: number[]; positions: number[] }>}
  */
 function searchObjects(query, items, options) {
+  if (!options?.keys?.length) {
+    throw new TypeError('options.keys must be a non-empty array');
+  }
   const { keys, ...searchOpts } = options;
 
   const normalizedKeys = keys.map((k) =>
@@ -78,6 +81,9 @@ class FuzzyObjectIndex {
    * @param {Array<string | { name: string; weight?: number }>} options.keys - Keys to search.
    */
   constructor(items, options) {
+    if (!options?.keys?.length) {
+      throw new TypeError('options.keys must be a non-empty array');
+    }
     this.#keys = options.keys.map((k) =>
       typeof k === 'string' ? { name: k, weight: 1.0 } : { name: k.name, weight: k.weight ?? 1.0 },
     );


### PR DESCRIPTION
## Summary

- Add `TypeError` when `options.keys` is missing, null, or empty in `searchObjects()` and `FuzzyObjectIndex` constructor
- Replaces cryptic "Cannot destructure property 'keys' of undefined" with clear error message
- Add input validation tests

## Related issue

Closes #273

## Checklist

- [x] `searchObjects()` validates `options.keys`
- [x] `FuzzyObjectIndex` constructor validates `options.keys`
- [x] Added test coverage for validation
- [x] Tests pass
- [x] Biome lint passes