### PR TITLE
feat(exports): add subpath exports for highlight and objects

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -57,7 +57,7 @@
   },
   "overrides": [
     {
-      "includes": ["index.mjs", "highlight.mjs"],
+      "includes": ["index.mjs", "highlight.mjs", "objects.mjs"],
       "linter": {
         "rules": {
           "performance": {

--- a/objects.mjs
+++ b/objects.mjs
@@ -1,0 +1,2 @@
+// ESM re-export — single source of truth is objects.js (CJS).
+export { FuzzyObjectIndex, searchObjects } from './objects.js';

--- a/package.json
+++ b/package.json
@@ -43,6 +43,26 @@
         "default": "./index.js"
       },
       "browser": "./browser.js"
+    },
+    "./highlight": {
+      "import": {
+        "types": "./highlight.d.ts",
+        "default": "./highlight.mjs"
+      },
+      "require": {
+        "types": "./highlight.d.ts",
+        "default": "./highlight.js"
+      }
+    },
+    "./objects": {
+      "import": {
+        "types": "./objects.d.ts",
+        "default": "./objects.mjs"
+      },
+      "require": {
+        "types": "./objects.d.ts",
+        "default": "./objects.js"
+      }
     }
   },
   "files": [
@@ -51,6 +71,7 @@
     "index.d.ts",
     "index.d.mts",
     "objects.js",
+    "objects.mjs",
     "objects.d.ts",
     "browser.js",
     "highlight.js",


### PR DESCRIPTION
## Summary

- Add subpath exports `rapid-fuzzy/highlight` and `rapid-fuzzy/objects` to `package.json`
- Create `objects.mjs` ESM wrapper (matching existing `highlight.mjs` pattern)
- Add `objects.mjs` to Biome `noBarrelFile` override (matching `highlight.mjs` pattern)
- Enables importing pure-JS utilities via dedicated entry points:
  ```typescript
  import { highlight } from 'rapid-fuzzy/highlight';
  import { searchObjects } from 'rapid-fuzzy/objects';
  ```

## Related issue

Closes #277

## Checklist

- [x] `./highlight` subpath export added (ESM + CJS + types)
- [x] `./objects` subpath export added (ESM + CJS + types)
- [x] Created `objects.mjs` ESM wrapper
- [x] Added `objects.mjs` to `files` array
- [x] Added `objects.mjs` to Biome `noBarrelFile` override
- [x] `publint` passes
- [x] All tests pass
- [x] All pre-push hooks pass