### PR TITLE
perf(distance): add early return to weighted_ratio for exact matches

### DIFF
--- a/crates/core/src/distance/mod.rs
+++ b/crates/core/src/distance/mod.rs
@@ -330,6 +330,9 @@ fn partial_ratio_impl(a: &str, b: &str) -> f64 {
 /// Internal implementation of weighted_ratio.
 fn weighted_ratio_impl(a: &str, b: &str) -> f64 {
     let raw = rapid_lev::normalized_similarity(a.chars(), b.chars());
+    if raw == 1.0 {
+        return 1.0;
+    }
     let sort = token_sort_ratio_impl(a, b);
     let set = token_set_ratio_impl(a, b);
     let partial = partial_ratio_impl(a, b);


### PR DESCRIPTION
## Summary

- Add early return in `weighted_ratio_impl` when `normalized_levenshtein` returns 1.0 (exact match)
- Avoids three unnecessary algorithm computations (token sort ratio, token set ratio, partial ratio) for identical strings
- Meaningful speedup for batch operations with datasets containing duplicates or exact matches

## Related issue

Closes #272

## Checklist

- [x] Early return added when `raw == 1.0`
- [x] Existing property tests cover correctness
- [x] `cargo test` passes
- [x] `cargo clippy` passes