### PR TITLE
fix(types): remove always-empty positions from ObjectSearchResult

### DIFF
--- a/__test__/objects.spec.ts
+++ b/__test__/objects.spec.ts
@@ -133,13 +133,13 @@ describe('searchObjects', () => {
     expect(results.length).toBe(0);
   });
 
-  it('should return empty positions when includePositions is not set', () => {
+  it('should not include positions in results', () => {
     const results = searchObjects('john', users, {
       keys: ['name'],
     });
     expect(results.length).toBeGreaterThan(0);
     for (const r of results) {
-      expect(r.positions).toEqual([]);
+      expect(r).not.toHaveProperty('positions');
     }
   });
 

--- a/objects.d.ts
+++ b/objects.d.ts
@@ -5,6 +5,10 @@ export interface KeyConfig {
   weight?: number;
 }
 
+/**
+ * Options for searchObjects(). Extends SearchOptions with key configuration.
+ * Note: `includePositions` has no effect for multi-key search.
+ */
 export interface ObjectSearchOptions extends SearchOptions {
   keys: Array<string | KeyConfig>;
 }
@@ -14,11 +18,6 @@ export interface ObjectSearchResult<T> {
   index: number;
   score: number;
   keyScores: Array<number>;
-  /**
-   * Indices of matched characters in the best-matching key string.
-   * Empty unless `includePositions` is set to true in ObjectSearchOptions.
-   */
-  positions: Array<number>;
 }
 
 /**
@@ -86,7 +85,7 @@ export declare class FuzzyObjectIndex<T> {
   search(
     query: string,
     options?: ObjectIndexSearchOptions,
-  ): Array<Omit<ObjectSearchResult<T>, 'positions'>>;
+  ): Array<ObjectSearchResult<T>>;
 
   /** Find the closest matching object, or null if no match. */
   closest(query: string, minScore?: number): T | null;

--- a/objects.js
+++ b/objects.js
@@ -31,7 +31,7 @@ function getNestedValue(obj, path) {
  * @param {number} [options.maxResults] - Maximum results to return.
  * @param {number} [options.minScore] - Minimum score threshold.
  * @param {boolean} [options.isCaseSensitive] - Enable case-sensitive matching.
- * @returns {Array<{ item: T; index: number; score: number; keyScores: number[]; positions: number[] }>}
+ * @returns {Array<{ item: T; index: number; score: number; keyScores: number[] }>}
  */
 function searchObjects(query, items, options) {
   const { keys, ...searchOpts } = options;
@@ -52,7 +52,6 @@ function searchObjects(query, items, options) {
     index: r.index,
     score: r.score,
     keyScores: r.keyScores,
-    positions: r.positions ?? [],
   }));
 }
 


### PR DESCRIPTION
## Summary

- Remove the `positions` field from `ObjectSearchResult<T>` which was always an empty array
- The underlying `KeySearchResult` Rust struct has no positions field, so `positions` was always `[]`
- Document that `includePositions` has no effect for multi-key search in `ObjectSearchOptions`
- Simplify `FuzzyObjectIndex.search()` return type (remove unnecessary `Omit`)
- Update test to verify `positions` is absent rather than empty

## Related issue

Closes #276

## Checklist

- [x] Removed `positions` from `ObjectSearchResult<T>` type
- [x] Removed `positions` from `searchObjects` result mapping
- [x] Simplified `FuzzyObjectIndex.search()` return type
- [x] Added note about `includePositions` limitation
- [x] Updated test
- [x] All checks pass (build, typecheck, test, cargo test, clippy)