### PR TITLE
ci(playground): deploy from main branch

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -2,7 +2,7 @@ name: Playground
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
     paths:
       - 'playground/**'
       - 'crates/core/**'


### PR DESCRIPTION
## Summary

- Switch playground deployment trigger from `develop` to `main` for production stability
- Environment protection rules updated: `main` allowed, `develop` and `gh-pages` removed

Closes #292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to trigger from the main branch instead of the develop branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->