### PR TITLE
Update benchmarks and regenerate charts for v1.0.0

### DIFF
--- a/.github/assets/bench-distance.svg
+++ b/.github/assets/bench-distance.svg
@@ -15,18 +15,18 @@
 <text x="20" y="66" class="group-label">Levenshtein</text>
 <text x="172" y="91" class="bar-label" text-anchor="end">fastest-levenshtein</text>
 <rect x="180" y="74" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="632" y="91" class="bar-value" text-anchor="end">794,298 ops/s</text>
+<text x="632" y="91" class="bar-value" text-anchor="end">758,533 ops/s</text>
 <text x="172" y="122" class="bar-label" text-anchor="end">rapid-fuzzy</text>
-<rect x="180" y="105" width="325.50627094616885" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="497.50627094616885" y="122" class="bar-value" text-anchor="end" fill="#ffffff">562,063 ops/s</text>
+<rect x="180" y="105" width="342.39551871836824" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="514.3955187183683" y="122" class="bar-value" text-anchor="end" fill="#ffffff">564,605 ops/s</text>
 <text x="172" y="153" class="bar-label" text-anchor="end">leven</text>
-<rect x="180" y="136" width="132.43956298517685" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="320.43956298517685" y="153" class="bar-value" text-anchor="start">228,688 ops/s</text>
+<rect x="180" y="136" width="129.90113811791974" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="317.90113811791974" y="153" class="bar-value" text-anchor="start">214,205 ops/s</text>
 <text x="20" y="200" class="group-label">Sorensen-Dice</text>
 <text x="172" y="225" class="bar-label" text-anchor="end">rapid-fuzzy</text>
 <rect x="180" y="208" width="460" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="632" y="225" class="bar-value" text-anchor="end" fill="#ffffff">147,850 ops/s</text>
+<text x="632" y="225" class="bar-value" text-anchor="end" fill="#ffffff">152,317 ops/s</text>
 <text x="172" y="256" class="bar-label" text-anchor="end">string-similarity</text>
-<rect x="180" y="239" width="262.3042272573554" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="434.3042272573554" y="256" class="bar-value" text-anchor="end">84,308 ops/s</text>
+<rect x="180" y="239" width="260.9264888357833" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="432.9264888357833" y="256" class="bar-value" text-anchor="end">86,399 ops/s</text>
 </svg>

--- a/.github/assets/bench-search.svg
+++ b/.github/assets/bench-search.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 798" width="680" height="798">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 664" width="680" height="664">
 <style>
   text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
   .title { font-size: 16px; font-weight: 600; fill: #1f2937; }
@@ -8,66 +8,56 @@
   .bar-value { font-size: 12px; fill: #374151; font-weight: 500; }
   .multiplier { font-size: 11px; fill: #059669; font-weight: 600; }
 </style>
-<rect width="680" height="798" rx="8" fill="#ffffff" />
-<rect x="0.5" y="0.5" width="679" height="797" rx="8" fill="none" stroke="#e5e7eb" />
+<rect width="680" height="664" rx="8" fill="#ffffff" />
+<rect x="0.5" y="0.5" width="679" height="663" rx="8" fill="none" stroke="#e5e7eb" />
 <text x="20" y="28" class="title">Fuzzy Search Performance</text>
 <text x="20" y="44" class="subtitle">ops/s (higher is better)</text>
 <text x="20" y="66" class="group-label">Small</text>
 <text x="172" y="91" class="bar-label" text-anchor="end">fuzzysort</text>
 <rect x="180" y="74" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="632" y="91" class="bar-value" text-anchor="end">2,606,394 ops/s</text>
+<text x="632" y="91" class="bar-value" text-anchor="end">2,655,421 ops/s</text>
 <text x="172" y="122" class="bar-label" text-anchor="end">uFuzzy</text>
-<rect x="180" y="105" width="162.91157054535884" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="350.9115705453588" y="122" class="bar-value" text-anchor="start">923,069 ops/s</text>
+<rect x="180" y="105" width="160.61467465987502" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="348.61467465987505" y="122" class="bar-value" text-anchor="start">927,173 ops/s</text>
 <text x="172" y="153" class="bar-label" text-anchor="end">rapid-fuzzy (indexed)</text>
-<rect x="180" y="136" width="71.58466448280652" height="26" rx="4" fill="#60a5fa" opacity="1" />
-<text x="259.5846644828065" y="153" class="bar-value" text-anchor="start">405,604 ops/s — 3x vs fuse.js</text>
+<rect x="180" y="136" width="70.03208154187227" height="26" rx="4" fill="#60a5fa" opacity="1" />
+<text x="258.0320815418723" y="153" class="bar-value" text-anchor="start">404,271 ops/s — 2x vs fuse.js</text>
 <text x="172" y="184" class="bar-label" text-anchor="end">rapid-fuzzy</text>
-<rect x="180" y="167" width="53.64949428213847" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="241.64949428213848" y="184" class="bar-value" text-anchor="start">303,982 ops/s — 3x vs fuse.js</text>
+<rect x="180" y="167" width="49.835306717842485" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="237.83530671784249" y="184" class="bar-value" text-anchor="start">287,682 ops/s — 2x vs fuse.js</text>
 <text x="172" y="215" class="bar-label" text-anchor="end">fuse.js</text>
-<rect x="180" y="198" width="18.63159599047573" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="206.63159599047572" y="215" class="bar-value" text-anchor="start">105,568 ops/s</text>
+<rect x="180" y="198" width="21.929426633290916" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="209.92942663329092" y="215" class="bar-value" text-anchor="start">126,591 ops/s</text>
 <text x="20" y="262" class="group-label">Medium</text>
 <text x="172" y="287" class="bar-label" text-anchor="end">rapid-fuzzy (indexed)</text>
 <rect x="180" y="270" width="460" height="26" rx="4" fill="#60a5fa" opacity="1" />
-<text x="632" y="287" class="bar-value" text-anchor="end" fill="#ffffff">80,579 ops/s — 18x vs fuse.js</text>
+<text x="632" y="287" class="bar-value" text-anchor="end" fill="#ffffff">79,616 ops/s — 19x vs fuse.js</text>
 <text x="172" y="318" class="bar-label" text-anchor="end">fuzzysort</text>
-<rect x="180" y="301" width="367.47936807356757" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="539.4793680735676" y="318" class="bar-value" text-anchor="end">64,372 ops/s</text>
+<rect x="180" y="301" width="368.7984827170418" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="540.7984827170418" y="318" class="bar-value" text-anchor="end">63,831 ops/s</text>
 <text x="172" y="349" class="bar-label" text-anchor="end">uFuzzy</text>
-<rect x="180" y="332" width="165.28351059208975" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="353.2835105920898" y="349" class="bar-value" text-anchor="start">28,953 ops/s</text>
+<rect x="180" y="332" width="173.90398914790998" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="361.90398914791" y="349" class="bar-value" text-anchor="start">30,099 ops/s</text>
 <text x="172" y="380" class="bar-label" text-anchor="end">rapid-fuzzy</text>
-<rect x="180" y="363" width="38.74483426202857" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="226.74483426202858" y="380" class="bar-value" text-anchor="start">6,787 ops/s — 18x vs fuse.js</text>
+<rect x="180" y="363" width="39.44458400321543" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="227.44458400321543" y="380" class="bar-value" text-anchor="start">6,827 ops/s — 19x vs fuse.js</text>
 <text x="172" y="411" class="bar-label" text-anchor="end">fuse.js</text>
 <rect x="180" y="394" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="192" y="411" class="bar-value" text-anchor="start">367 ops/s</text>
+<text x="192" y="411" class="bar-value" text-anchor="start">366 ops/s</text>
 <text x="20" y="458" class="group-label">Large</text>
 <text x="172" y="483" class="bar-label" text-anchor="end">rapid-fuzzy (indexed)</text>
 <rect x="180" y="466" width="460" height="26" rx="4" fill="#60a5fa" opacity="1" />
-<text x="632" y="483" class="bar-value" text-anchor="end" fill="#ffffff">136,528 ops/s — 40x vs fuse.js</text>
+<text x="632" y="483" class="bar-value" text-anchor="end" fill="#ffffff">136,294 ops/s — 46x vs fuse.js</text>
 <text x="172" y="514" class="bar-label" text-anchor="end">fuzzysort</text>
-<rect x="180" y="497" width="87.97843665768194" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="275.9784366576819" y="514" class="bar-value" text-anchor="start">26,112 ops/s</text>
+<rect x="180" y="497" width="94.1539612895652" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="282.1539612895652" y="514" class="bar-value" text-anchor="start">27,897 ops/s</text>
 <text x="172" y="545" class="bar-label" text-anchor="end">uFuzzy</text>
-<rect x="180" y="528" width="21.539757412398924" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="209.53975741239893" y="545" class="bar-value" text-anchor="start">6,393 ops/s</text>
+<rect x="180" y="528" width="21.806242387779356" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="209.80624238777935" y="545" class="bar-value" text-anchor="start">6,461 ops/s</text>
 <text x="172" y="576" class="bar-label" text-anchor="end">rapid-fuzzy</text>
 <rect x="180" y="559" width="4" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="192" y="576" class="bar-value" text-anchor="start">751 ops/s — 40x vs fuse.js</text>
+<text x="192" y="576" class="bar-value" text-anchor="start">827 ops/s — 46x vs fuse.js</text>
 <text x="172" y="607" class="bar-label" text-anchor="end">fuse.js</text>
 <rect x="180" y="590" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="192" y="607" class="bar-value" text-anchor="start">19 ops/s</text>
-<text x="20" y="654" class="group-label">XL</text>
-<text x="172" y="679" class="bar-label" text-anchor="end">rapid-fuzzy (indexed)</text>
-<rect x="180" y="662" width="460" height="26" rx="4" fill="#60a5fa" opacity="1" />
-<text x="632" y="679" class="bar-value" text-anchor="end" fill="#ffffff">31,903 ops/s</text>
-<text x="172" y="710" class="bar-label" text-anchor="end">fuzzysort</text>
-<rect x="180" y="693" width="85.30106886499702" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="273.30106886499703" y="710" class="bar-value" text-anchor="start">5,916 ops/s</text>
-<text x="172" y="741" class="bar-label" text-anchor="end">uFuzzy</text>
-<rect x="180" y="724" width="18.628969062470613" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="206.62896906247062" y="741" class="bar-value" text-anchor="start">1,292 ops/s</text>
+<text x="192" y="607" class="bar-value" text-anchor="start">18 ops/s</text>
 </svg>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const results = search('typscript', ['TypeScript', 'JavaScript', 'Python']);
 // → [{ item: 'TypeScript', score: 0.85, index: 0 }, ...]
 ```
 
-For repeated searches, use `FuzzyIndex` for up to 182x faster lookups:
+For repeated searches, use `FuzzyIndex` for up to 165x faster lookups:
 
 ```typescript
 import { FuzzyIndex } from 'rapid-fuzzy';
@@ -183,7 +183,7 @@ For applications that search the same dataset repeatedly (autocomplete, file fin
 ```typescript
 import { FuzzyIndex, FuzzyObjectIndex } from 'rapid-fuzzy';
 
-// String search index — up to 182x faster than standalone search()
+// String search index — up to 165x faster than standalone search()
 const index = new FuzzyIndex(['TypeScript', 'JavaScript', 'Python', ...]);
 
 index.search('typscript', { maxResults: 5 });
@@ -291,7 +291,7 @@ levenshteinMany('kitten', ['sitting', 'kittens', 'kitchen']);
 | Substring / abbreviation matching | `partialRatio` | Finds best partial match within longer strings |
 | Best-effort similarity | `weightedRatio` | Picks the best score across all methods automatically |
 | Interactive fuzzy search | `search`, `closest` | Nucleo algorithm (same as Helix editor) |
-| Repeated search on same data | `FuzzyIndex`, `FuzzyObjectIndex` | Persistent Rust-side index with incremental cache, up to 182x faster |
+| Repeated search on same data | `FuzzyIndex`, `FuzzyObjectIndex` | Persistent Rust-side index with incremental cache, up to 165x faster |
 
 **Return types:**
 
@@ -313,11 +313,11 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 | Function | rapid-fuzzy | fastest-levenshtein | leven | string-similarity |
 |---|---:|---:|---:|---:|
-| Levenshtein | 562,063 ops/s | **794,298 ops/s** | 228,688 ops/s | — |
-| Normalized Levenshtein | **546,107 ops/s** | — | — | — |
-| Sorensen-Dice | **147,850 ops/s** | — | — | 84,308 ops/s |
-| Jaro-Winkler | **293,403 ops/s** | — | — | — |
-| Damerau-Levenshtein | **116,153 ops/s** | — | — | — |
+| Levenshtein | 564,605 ops/s | **758,533 ops/s** | 214,205 ops/s | — |
+| Normalized Levenshtein | **515,352 ops/s** | — | — | — |
+| Sorensen-Dice | **152,317 ops/s** | — | — | 86,399 ops/s |
+| Jaro-Winkler | **523,894 ops/s** | — | — | — |
+| Damerau-Levenshtein | **118,113 ops/s** | — | — | — |
 
 </details>
 
@@ -334,10 +334,9 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 | Dataset size | rapid-fuzzy | rapid-fuzzy (indexed) | fuse.js | fuzzysort | uFuzzy |
 |---|---:|---:|---:|---:|---:|
-| Small (20 items) | 303,982 ops/s | 405,604 ops/s | 105,568 ops/s | **2,606,394 ops/s** | 923,069 ops/s |
-| Medium (1K items) | 6,787 ops/s | **80,579 ops/s** | 367 ops/s | 64,372 ops/s | 28,953 ops/s |
-| Large (10K items) | 751 ops/s | **136,528 ops/s** | 19 ops/s | 26,112 ops/s | 6,393 ops/s |
-| XL (50K items) | — | **31,903 ops/s** | — | 5,916 ops/s | 1,292 ops/s |
+| Small (20 items) | 287,682 ops/s | 404,271 ops/s | 126,591 ops/s | **2,655,421 ops/s** | 927,173 ops/s |
+| Medium (1K items) | 6,827 ops/s | **79,616 ops/s** | 366 ops/s | 63,831 ops/s | 30,099 ops/s |
+| Large (10K items) | 827 ops/s | **136,294 ops/s** | 18 ops/s | 27,897 ops/s | 6,461 ops/s |
 
 </details>
 
@@ -345,18 +344,18 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 | Dataset size | rapid-fuzzy | rapid-fuzzy (indexed) | fastest-levenshtein |
 |---|---:|---:|---:|
-| Medium (1K items) | 8,611 ops/s | **989,095 ops/s** | 6,797 ops/s |
-| Large (10K items) | 924 ops/s | **156,014 ops/s** | 658 ops/s |
+| Medium (1K items) | 8,194 ops/s | **978,009 ops/s** | 6,869 ops/s |
+| Large (10K items) | 892 ops/s | **152,196 ops/s** | 679 ops/s |
 
-> In indexed mode (`FuzzyIndex`), rapid-fuzzy is up to **237x faster** than fastest-levenshtein for closest-match lookups.
+> In indexed mode (`FuzzyIndex`), rapid-fuzzy is up to **224x faster** than fastest-levenshtein for closest-match lookups.
 
 ### Why these numbers matter
 
-- **vs fuse.js**: `FuzzyIndex` is **219x faster** on medium datasets and **6,869x faster** on large datasets. Even standalone `search()` is 18x / 40x faster.
-- **Indexed mode**: `FuzzyIndex` keeps data on the Rust side with an incremental search cache, delivering sub-millisecond autocomplete. On large datasets this is **182x faster** than standalone `search()`.
-- **vs fuzzysort**: `FuzzyIndex` now **outperforms fuzzysort** on medium-and-above datasets — 1.25x faster at 1K, 5.2x at 10K, and 5.4x at 50K.
-- **vs uFuzzy**: `FuzzyIndex` is **2.8x faster** at medium and **21x faster** at large datasets.
-- **vs fastest-levenshtein**: With `FuzzyIndex`, closest-match is **145x faster** at 1K and **237x faster** at 10K.
+- **vs fuse.js**: `FuzzyIndex` is **218x faster** on medium datasets and **7,572x faster** on large datasets. Even standalone `search()` is 19x / 46x faster.
+- **Indexed mode**: `FuzzyIndex` keeps data on the Rust side with an incremental search cache, delivering sub-millisecond autocomplete. On large datasets this is **165x faster** than standalone `search()`.
+- **vs fuzzysort**: `FuzzyIndex` now **outperforms fuzzysort** on medium-and-above datasets — 1.2x faster at 1K and 4.9x at 10K.
+- **vs uFuzzy**: `FuzzyIndex` is **2.6x faster** at medium and **21x faster** at large datasets.
+- **vs fastest-levenshtein**: With `FuzzyIndex`, closest-match is **142x faster** at 1K and **224x faster** at 10K.
 
 Run benchmarks yourself:
 

--- a/scripts/update-bench-readme.ts
+++ b/scripts/update-bench-readme.ts
@@ -135,10 +135,12 @@ if (damerauSuite) {
   distLines.push(`| Damerau-Levenshtein | ${cell(dl, true)} | — | — | — |`);
 }
 
-// Search table (includes FuzzyIndex column)
+// Search table (includes FuzzyIndex column + uFuzzy)
 const searchLines: string[] = [];
-searchLines.push('| Dataset size | rapid-fuzzy | rapid-fuzzy (indexed) | fuse.js | fuzzysort |');
-searchLines.push('|---|---:|---:|---:|---:|');
+searchLines.push(
+  '| Dataset size | rapid-fuzzy | rapid-fuzzy (indexed) | fuse.js | fuzzysort | uFuzzy |',
+);
+searchLines.push('|---|---:|---:|---:|---:|---:|');
 
 for (const size of ['Small (20 items)', 'Medium (1K items)', 'Large (10K items)']) {
   const s = findSuite(`Fuzzy Search — ${size}`);
@@ -147,9 +149,10 @@ for (const size of ['Small (20 items)', 'Medium (1K items)', 'Large (10K items)'
   const fi = s.get('rapid-fuzzy (FuzzyIndex)') ?? null;
   const fj = s.get('fuse.js') ?? null;
   const fs = s.get('fuzzysort') ?? null;
-  const b = best([rf, fi, fj, fs]);
+  const uf = s.get('uFuzzy') ?? null;
+  const b = best([rf, fi, fj, fs, uf]);
   searchLines.push(
-    `| ${size.replace(/\s*\(/, ' (').replace(' items)', ' items)')} | ${cell(rf, rf === b)} | ${cell(fi, fi === b)} | ${cell(fj, fj === b)} | ${cell(fs, fs === b)} |`,
+    `| ${size} | ${cell(rf, rf === b)} | ${cell(fi, fi === b)} | ${cell(fj, fj === b)} | ${cell(fs, fs === b)} | ${cell(uf, uf === b)} |`,
   );
 }
 
@@ -203,12 +206,17 @@ function replaceSection(
   return `${content.slice(0, tableStart)}${table}\n\n${content.slice(tableEnd)}`;
 }
 
-readme = replaceSection(readme, '### Distance Functions', '> **Note**', distLines.join('\n'));
+readme = replaceSection(
+  readme,
+  '### Distance Functions',
+  '> **Note**',
+  `${distLines.join('\n')}\n\n</details>`,
+);
 readme = replaceSection(
   readme,
   '### Search Performance',
   '### Closest Match',
-  searchLines.join('\n'),
+  `${searchLines.join('\n')}\n\n</details>`,
 );
 readme = replaceSection(
   readme,


### PR DESCRIPTION
## Summary

- Re-run all JS benchmarks with latest optimizations (Jaro-Winkler rapidfuzz migration, weighted_ratio early return, quickselect)
- Add uFuzzy column to search performance table for complete 5-library comparison
- Remove XL (50K) dataset from search benchmark tables — S/M/L is sufficient for README
- Fix `bench:readme` script to include uFuzzy column and preserve `</details>` tags during table replacement
- Regenerate SVG charts (3 groups for search, 2 for distance)
- Update all multiplier claims to match fresh measurements

### Notable changes in numbers

- **Jaro-Winkler**: 293K → 524K ops/s (~1.8x improvement from rapidfuzz bit-parallel migration)
- **FuzzyIndex vs fuse.js (Large)**: 6,869x → 7,572x (improved)
- **FuzzyIndex vs standalone (Large)**: 182x → 165x (adjusted)
- **FuzzyIndex vs fastest-levenshtein closest (10K)**: 237x → 224x (adjusted)

Closes #295

## Checklist

- [x] Benchmark tables updated with fresh measurements
- [x] SVG charts regenerated (no XL group)
- [x] All multiplier claims verified and updated
- [x] `bench:readme` script fixed (uFuzzy column, `</details>` preservation)
- [x] Biome lint, TypeScript, Vitest, cargo test, clippy all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated performance benchmark figures and multiplier values across search scenarios and library comparisons based on latest test results.

* **Chores**
  * Enhanced benchmark tooling to include additional library metrics in performance comparison tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->