### PR TITLE
Update version references for v1.0.0

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapid-fuzzy"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "rapid-fuzzy": "^0.6.0"
+    "rapid-fuzzy": "^1.0.0"
   },
   "devDependencies": {
     "vite": "^6.4.1"


### PR DESCRIPTION
## Summary

Update stale version references found during v1.0.0 release pre-flight check:

- `playground/package.json`: rapid-fuzzy dependency `^0.6.0` → `^1.0.0`
- `crates/core/Cargo.toml`: version `0.1.0` → `1.0.0` (consistency with npm package)

These changes will be included in the release PR #301 (develop → main).