### PR TITLE
fix(ci): use workflow_run trigger for playground deployment

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -5,8 +5,11 @@ on:
     branches: [main]
     paths:
       - 'playground/**'
-      - 'crates/core/**'
       - '.github/workflows/playground.yml'
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -21,6 +24,9 @@ concurrency:
 jobs:
   deploy:
     name: Deploy Playground
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary

- Remove `crates/core/**` from the push trigger paths — core changes alone don't require a playground rebuild
- Add `workflow_run` trigger to rebuild the playground after the Release workflow completes successfully, ensuring npm packages are published before `npm install` runs
- Add a condition to skip the deploy job when the triggering Release workflow failed

## Related issue

Closes #304

## Checklist

- [x] Removed `crates/core/**` from push paths
- [x] Added `workflow_run` trigger for the Release workflow
- [x] Added `if` condition to skip deploy on failed release
- [x] YAML validated successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment automation: the playground now automatically updates when release workflows complete successfully on the main branch.
  * Refined path monitoring to detect core module changes and trigger corresponding playground deployments.
  * Improved deployment job execution logic based on workflow outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->