### PR TITLE
chore: declare minimum supported Rust version (1.85)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 
 ## Prerequisites
 
-- [Rust](https://rustup.rs/) (stable toolchain)
+- [Rust](https://rustup.rs/) ≥ 1.85 (stable toolchain)
 - [Node.js](https://nodejs.org/) ≥ 20
 - [pnpm](https://pnpm.io/) ≥ 10
 - [Git](https://git-scm.com/)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "rapid-fuzzy"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.85"
 license = "MIT"
 repository = "https://github.com/derodero24/rapid-fuzzy"
 


### PR DESCRIPTION
## Summary

- Add `rust-version = "1.85"` to `[workspace.package]` in `Cargo.toml` to formally declare the MSRV
- Update `CONTRIBUTING.md` prerequisites to specify the minimum Rust version requirement

## Related issue

Closes #306

## Checklist

- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes (200 tests)
- [x] `pnpm run build` succeeds
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (252 tests)
- [x] Commit follows Conventional Commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minimum Rust version requirement updated to 1.85 (stable toolchain).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->