### PR TITLE
feat(search): add searchIndices() for index-only results

### DIFF
--- a/.changeset/search-indices-api.md
+++ b/.changeset/search-indices-api.md
@@ -1,0 +1,5 @@
+---
+"rapid-fuzzy": minor
+---
+
+Add `searchIndices()` method to FuzzyIndex that returns only indices and scores without cloning item strings, reducing GC pressure for large datasets.

--- a/crates/core/src/search/index.rs
+++ b/crates/core/src/search/index.rs
@@ -7,8 +7,8 @@ use nucleo_matcher::pattern::CaseMatching;
 use nucleo_matcher::{Config, Matcher, Utf32String};
 
 use super::{
-    PrecomputedSearch, SearchOptions, SearchResult, compute_char_mask, resolve_case_matching,
-    search_over_precomputed,
+    IndexSearchResult, PrecomputedSearch, SearchOptions, SearchResult, compute_char_mask,
+    resolve_case_matching, search_over_precomputed, search_over_precomputed_indices,
 };
 
 /// A persistent fuzzy search index backed by Rust-side data.
@@ -114,6 +114,52 @@ impl FuzzyIndex {
     pub fn closest(&self, query: String, min_score: Option<f64>) -> Option<String> {
         let results = self.search_impl(&query, Some(1), min_score, false, CaseMatching::Smart);
         results.into_iter().next().map(|r| r.item)
+    }
+
+    /// Search the index, returning only indices and scores (no item strings).
+    ///
+    /// This is more efficient than `search()` when you maintain your own data
+    /// array and only need the index to look up the original item. Avoids
+    /// String cloning overhead for each result.
+    #[napi]
+    pub fn search_indices(
+        &self,
+        query: String,
+        options: Option<Either<u32, SearchOptions>>,
+    ) -> Vec<IndexSearchResult> {
+        let (max_results, min_score, include_positions, case_matching, return_all_on_empty) =
+            match options {
+                Some(Either::A(max)) => (Some(max), None, false, CaseMatching::Smart, false),
+                Some(Either::B(opts)) => (
+                    opts.max_results,
+                    opts.min_score,
+                    opts.include_positions.unwrap_or(false),
+                    resolve_case_matching(opts.is_case_sensitive),
+                    opts.return_all_on_empty.unwrap_or(false),
+                ),
+                None => (None, None, false, CaseMatching::Smart, false),
+            };
+
+        if return_all_on_empty && query.trim().is_empty() {
+            let limit = max_results.unwrap_or(self.items.len() as u32) as usize;
+            return (0..self.items.len())
+                .take(limit)
+                .map(|i| IndexSearchResult {
+                    index: i as u32,
+                    score: 1.0,
+                    positions: Vec::new(),
+                    match_type: None,
+                })
+                .collect();
+        }
+
+        self.search_indices_impl(
+            &query,
+            max_results,
+            min_score,
+            include_positions,
+            case_matching,
+        )
     }
 
     /// Add a single item to the index.
@@ -297,6 +343,54 @@ impl FuzzyIndex {
         };
 
         let outcome = search_over_precomputed(
+            query,
+            &ctx,
+            max_results,
+            min_score,
+            include_positions,
+            case_matching,
+        );
+
+        // Update incremental cache.
+        *self.last_query.borrow_mut() = query.to_owned();
+        *self.last_matching_indices.borrow_mut() = outcome.all_matching_indices;
+
+        outcome.results
+    }
+
+    fn search_indices_impl(
+        &self,
+        query: &str,
+        max_results: Option<u32>,
+        min_score: Option<f64>,
+        include_positions: bool,
+        case_matching: CaseMatching,
+    ) -> Vec<IndexSearchResult> {
+        let candidates: Option<Vec<u32>> = {
+            let last_q = self.last_query.borrow();
+            let last_idx = self.last_matching_indices.borrow();
+            if !last_q.is_empty()
+                && !last_idx.is_empty()
+                && query.len() > last_q.len()
+                && query.starts_with(last_q.as_str())
+                && !query.contains('!')
+                && !last_q.contains('!')
+            {
+                Some(last_idx.clone())
+            } else {
+                None
+            }
+        };
+
+        let ctx = PrecomputedSearch {
+            items: &self.items,
+            utf32_items: &self.utf32_items,
+            char_masks: &self.char_masks,
+            candidate_indices: candidates.as_deref(),
+            matcher: &self.matcher,
+        };
+
+        let outcome = search_over_precomputed_indices(
             query,
             &ctx,
             max_results,
@@ -571,5 +665,76 @@ mod tests {
     fn test_deserialize_bad_version() {
         let data = b"RFZI\xFF\x00\x00\x00\x00\x00\x00\x00";
         assert!(FuzzyIndex::deserialize_impl(data).is_err());
+    }
+
+    #[test]
+    fn test_search_indices_basic() {
+        let index = FuzzyIndex::new(vec![
+            "TypeScript".into(),
+            "JavaScript".into(),
+            "Python".into(),
+        ]);
+        let results =
+            index.search_indices_impl("typscript", None, None, false, CaseMatching::Smart);
+        assert!(!results.is_empty());
+        assert_eq!(results[0].index, 0); // TypeScript
+    }
+
+    #[test]
+    fn test_search_indices_no_item_field() {
+        let index = FuzzyIndex::new(vec!["hello".into(), "world".into()]);
+        let results = index.search_indices_impl("hello", None, None, false, CaseMatching::Smart);
+        assert!(!results.is_empty());
+        // IndexSearchResult has index and score but no item field
+        assert_eq!(results[0].index, 0);
+        assert!((results[0].score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_search_indices_consistent_with_search() {
+        let items = vec![
+            "apple".into(),
+            "application".into(),
+            "banana".into(),
+            "grape".into(),
+        ];
+        let index = FuzzyIndex::new(items);
+        let full = index.search_impl("apple", None, None, false, CaseMatching::Smart);
+        let indices_only =
+            index.search_indices_impl("apple", None, None, false, CaseMatching::Smart);
+        assert_eq!(full.len(), indices_only.len());
+        for (f, i) in full.iter().zip(indices_only.iter()) {
+            assert_eq!(f.index, i.index);
+            assert!((f.score - i.score).abs() < f64::EPSILON);
+        }
+    }
+
+    #[test]
+    fn test_search_indices_with_positions() {
+        let index = FuzzyIndex::new(vec!["hello".into()]);
+        let results = index.search_indices_impl("hello", None, None, true, CaseMatching::Smart);
+        assert!(!results.is_empty());
+        assert_eq!(results[0].positions, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_search_indices_min_score() {
+        let index = FuzzyIndex::new(vec!["apple".into(), "xyz".into()]);
+        let results =
+            index.search_indices_impl("apple", None, Some(0.5), false, CaseMatching::Smart);
+        for r in &results {
+            assert!(r.score >= 0.5);
+        }
+    }
+
+    #[test]
+    fn test_search_indices_max_results() {
+        let index = FuzzyIndex::new(vec![
+            "apple".into(),
+            "application".into(),
+            "appetizer".into(),
+        ]);
+        let results = index.search_indices_impl("app", Some(2), None, false, CaseMatching::Smart);
+        assert!(results.len() <= 2);
     }
 }

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -68,6 +68,25 @@ pub struct SearchResult {
     pub match_type: Option<MatchType>,
 }
 
+/// A lightweight search result containing only index and score (no item string).
+///
+/// Use this when you maintain your own data array and only need the index
+/// to look up the original item. Avoids String cloning overhead.
+#[napi(object)]
+pub struct IndexSearchResult {
+    /// The index of the item in the original input array.
+    pub index: u32,
+    /// The match score normalized to 0.0-1.0 range (1.0 is a perfect match).
+    pub score: f64,
+    /// Indices of matched characters in the item string.
+    /// Empty unless `includePositions` is set to true in SearchOptions.
+    pub positions: Vec<u32>,
+    /// How the query matched this item (Exact, Prefix, Contains, or Fuzzy).
+    /// Only present when `includePositions` is set to true in SearchOptions.
+    /// Derived from positions at zero additional cost.
+    pub match_type: Option<MatchType>,
+}
+
 /// Options for the search function.
 #[napi(object)]
 pub struct SearchOptions {
@@ -260,6 +279,14 @@ pub(crate) struct PrecomputedSearchResult {
     pub all_matching_indices: Vec<u32>,
 }
 
+/// Lightweight result of `search_over_precomputed_indices`: index-only results.
+pub(crate) struct PrecomputedIndexSearchResult {
+    /// Top-k index-only results (sorted, truncated).
+    pub results: Vec<IndexSearchResult>,
+    /// Indices of ALL items that matched (before truncation), for incremental cache.
+    pub all_matching_indices: Vec<u32>,
+}
+
 /// Search over pre-computed Utf32String items with a reusable Matcher.
 ///
 /// Used by FuzzyIndex to avoid per-search string conversion and Matcher allocation.
@@ -376,6 +403,117 @@ pub(crate) fn search_over_precomputed(
         .collect();
 
     PrecomputedSearchResult {
+        results,
+        all_matching_indices,
+    }
+}
+
+/// Index-only variant of `search_over_precomputed`.
+///
+/// Reuses the same Pass 1 (scoring, filtering, top-k selection) but builds
+/// lightweight `IndexSearchResult` objects in Pass 2 — no String cloning.
+pub(crate) fn search_over_precomputed_indices(
+    query: &str,
+    ctx: &PrecomputedSearch<'_>,
+    max_results: Option<u32>,
+    min_score: Option<f64>,
+    include_positions: bool,
+    case_matching: CaseMatching,
+) -> PrecomputedIndexSearchResult {
+    let items = ctx.items;
+    let utf32_items = ctx.utf32_items;
+    let matcher_cell = ctx.matcher;
+    if query.is_empty() || items.is_empty() {
+        return PrecomputedIndexSearchResult {
+            results: Vec::new(),
+            all_matching_indices: Vec::new(),
+        };
+    }
+
+    let mut matcher = matcher_cell.borrow_mut();
+    let pattern = Pattern::parse(query, case_matching, Normalization::Smart);
+    let max_score = compute_max_score(query, &pattern, &mut matcher);
+    let threshold = min_score.unwrap_or(0.0);
+    let query_mask = compute_query_mask(query);
+    let char_masks = ctx.char_masks;
+
+    let mut score_item = |index: u32| -> Option<(u32, f64)> {
+        let idx = index as usize;
+        if query_mask != 0 && (char_masks[idx] & query_mask) != query_mask {
+            return None;
+        }
+        let atoms = utf32_items[idx].slice(..);
+        let raw_score = pattern.score(atoms, &mut matcher)?;
+        let normalized = (raw_score as f64 / max_score).min(1.0);
+        if normalized >= threshold {
+            Some((index, normalized))
+        } else {
+            None
+        }
+    };
+
+    let mut scored: Vec<(u32, f64)> = match ctx.candidate_indices {
+        Some(candidates) => candidates.iter().filter_map(|&i| score_item(i)).collect(),
+        None => (0..utf32_items.len() as u32)
+            .filter_map(&mut score_item)
+            .collect(),
+    };
+
+    let total = utf32_items.len();
+    let all_matching_indices: Vec<u32> = if total > 0 && scored.len() < total / 2 {
+        scored.iter().map(|&(index, _)| index).collect()
+    } else {
+        Vec::new()
+    };
+
+    let cmp = |a: &(u32, f64), b: &(u32, f64)| {
+        let score_ord = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
+        if score_ord != std::cmp::Ordering::Equal {
+            return score_ord;
+        }
+        let len_ord = items[a.0 as usize].len().cmp(&items[b.0 as usize].len());
+        if len_ord != std::cmp::Ordering::Equal {
+            return len_ord;
+        }
+        a.0.cmp(&b.0)
+    };
+
+    if let Some(max) = max_results {
+        let k = max as usize;
+        if scored.len() > k {
+            scored.select_nth_unstable_by(k, cmp);
+            scored.truncate(k);
+        }
+    }
+    scored.sort_unstable_by(cmp);
+
+    // Pass 2: Build IndexSearchResult without String cloning.
+    let results = scored
+        .into_iter()
+        .map(|(index, score)| {
+            let (positions, match_type) = if include_positions {
+                let atoms = utf32_items[index as usize].slice(..);
+                let mut indices = Vec::new();
+                pattern.indices(atoms, &mut matcher, &mut indices);
+                indices.sort_unstable();
+                indices.dedup();
+                let item_char_count = items[index as usize].chars().count();
+                let mt = classify_match(&indices, item_char_count);
+                (indices, Some(mt))
+            } else {
+                (Vec::new(), None)
+            };
+
+            IndexSearchResult {
+                index,
+                score,
+                positions,
+                match_type,
+            }
+        })
+        .collect();
+
+    PrecomputedIndexSearchResult {
         results,
         all_matching_indices,
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,14 @@ export declare class FuzzyIndex {
    * If minScore is provided, returns null when the best match scores below the threshold.
    */
   closest(query: string, minScore?: number | undefined | null): string | null
+  /**
+   * Search the index, returning only indices and scores (no item strings).
+   *
+   * This is more efficient than `search()` when you maintain your own data
+   * array and only need the index to look up the original item. Avoids
+   * String cloning overhead for each result.
+   */
+  searchIndices(query: string, options?: number | SearchOptions | undefined | null): Array<IndexSearchResult>
   /** Add a single item to the index. */
   add(item: string): void
   /** Add multiple items to the index at once. */
@@ -141,6 +149,30 @@ export declare function damerauLevenshteinBatch(pairs: Array<Array<string>>): Ar
  * will return `max_distance + 1` (enabling early termination for better performance).
  */
 export declare function damerauLevenshteinMany(reference: string, candidates: Array<string>, maxDistance?: number | undefined | null): Array<number>
+
+/**
+ * A lightweight search result containing only index and score (no item string).
+ *
+ * Use this when you maintain your own data array and only need the index
+ * to look up the original item. Avoids String cloning overhead.
+ */
+export interface IndexSearchResult {
+  /** The index of the item in the original input array. */
+  index: number
+  /** The match score normalized to 0.0-1.0 range (1.0 is a perfect match). */
+  score: number
+  /**
+   * Indices of matched characters in the item string.
+   * Empty unless `includePositions` is set to true in SearchOptions.
+   */
+  positions: Array<number>
+  /**
+   * How the query matched this item (Exact, Prefix, Contains, or Fuzzy).
+   * Only present when `includePositions` is set to true in SearchOptions.
+   * Derived from positions at zero additional cost.
+   */
+  matchType?: MatchType
+}
 
 /**
  * Compute the Jaro similarity between two strings.


### PR DESCRIPTION
## Summary

Add `searchIndices()` method to FuzzyIndex that returns lightweight results containing only index, score, positions, and matchType — without cloning item strings. This reduces GC pressure for applications that maintain their own data array and only need the index to look up original items.

New types:
- `IndexSearchResult`: like `SearchResult` but without the `item` field
- `FuzzyIndex.searchIndices()`: same options as `search()`, returns `IndexSearchResult[]`

## Related issue

Closes #318

## Checklist

- [x] `cargo test` — 206 tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — formatted
- [x] New tests: basic, consistency with search(), positions, min_score, max_results
- [x] Changeset added (minor: new API)
- [x] KeyedFuzzyIndex not modified (already returns index-only results)