### PR TITLE
perf(distance): reduce redundant normalize_str calls

### DIFF
--- a/.changeset/normalize-str-cache.md
+++ b/.changeset/normalize-str-cache.md
@@ -1,0 +1,5 @@
+---
+"rapid-fuzzy": patch
+---
+
+Reduce redundant string normalization in weighted_ratio by sharing pre-normalized strings across sub-algorithms.

--- a/crates/core/src/distance/mod.rs
+++ b/crates/core/src/distance/mod.rs
@@ -325,7 +325,11 @@ fn token_sort_ratio_impl(a: &str, b: &str) -> f64 {
 fn token_set_ratio_impl(a: &str, b: &str) -> f64 {
     let norm_a = normalize_str(a);
     let norm_b = normalize_str(b);
+    token_set_ratio_from_normalized(&norm_a, &norm_b)
+}
 
+/// Token set ratio from pre-normalized strings (already lowercased and whitespace-collapsed).
+fn token_set_ratio_from_normalized(norm_a: &str, norm_b: &str) -> f64 {
     if norm_a.is_empty() && norm_b.is_empty() {
         return 1.0;
     }
@@ -377,7 +381,11 @@ fn token_set_ratio_impl(a: &str, b: &str) -> f64 {
 fn partial_ratio_impl(a: &str, b: &str) -> f64 {
     let norm_a = normalize_str(a);
     let norm_b = normalize_str(b);
+    partial_ratio_from_normalized(&norm_a, &norm_b)
+}
 
+/// Partial ratio from pre-normalized strings (already lowercased and whitespace-collapsed).
+fn partial_ratio_from_normalized(norm_a: &str, norm_b: &str) -> f64 {
     if norm_a.is_empty() && norm_b.is_empty() {
         return 1.0;
     }
@@ -386,9 +394,9 @@ fn partial_ratio_impl(a: &str, b: &str) -> f64 {
     }
 
     let (shorter, longer) = if norm_a.chars().count() <= norm_b.chars().count() {
-        (&norm_a, &norm_b)
+        (norm_a, norm_b)
     } else {
-        (&norm_b, &norm_a)
+        (norm_b, norm_a)
     };
 
     let short_len = shorter.chars().count();
@@ -423,8 +431,12 @@ fn weighted_ratio_impl(a: &str, b: &str) -> f64 {
         return 1.0;
     }
     let sort = token_sort_ratio_impl(a, b);
-    let set = token_set_ratio_impl(a, b);
-    let partial = partial_ratio_impl(a, b);
+
+    // Pre-normalize once and share across token_set_ratio and partial_ratio.
+    let norm_a = normalize_str(a);
+    let norm_b = normalize_str(b);
+    let set = token_set_ratio_from_normalized(&norm_a, &norm_b);
+    let partial = partial_ratio_from_normalized(&norm_a, &norm_b);
 
     // Return the best score across all methods
     [raw, sort, set, partial]


### PR DESCRIPTION
## Summary

Reduce redundant string normalization in `weighted_ratio_impl` by normalizing both input strings once and sharing the result across `token_set_ratio` and `partial_ratio` sub-algorithms.

Previously, `weighted_ratio_impl` called `token_set_ratio_impl` and `partial_ratio_impl`, each of which independently called `normalize_str(a)` and `normalize_str(b)`. This resulted in 4 unnecessary normalize_str calls (2 per sub-function × 2 strings).

Now, `weighted_ratio_impl` normalizes once at the start and passes pre-normalized strings to new `_from_normalized` internal variants. The original `_impl` functions are unchanged for direct public API use.

## Related issue

Closes #322

## Checklist

- [x] `cargo test` — 212 tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — formatted
- [x] No API changes (internal optimization only)
- [x] Changeset added (patch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal distance calculation algorithms to eliminate redundant string processing, improving performance while maintaining all existing functionality.

* **Chores**
  * Added changelog entry for package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->