### PR TITLE
fix(distance): token_set_ratio returns 0.0 for empty input

### DIFF
--- a/.changeset/fix-token-set-ratio-empty.md
+++ b/.changeset/fix-token-set-ratio-empty.md
@@ -1,0 +1,5 @@
+---
+"rapid-fuzzy": patch
+---
+
+Fix `tokenSetRatio` returning 1.0 (perfect match) when comparing an empty string against a non-empty string. Now correctly returns 0.0.

--- a/crates/core/src/distance/mod.rs
+++ b/crates/core/src/distance/mod.rs
@@ -330,8 +330,12 @@ fn token_set_ratio_impl(a: &str, b: &str) -> f64 {
 
 /// Token set ratio from pre-normalized strings (already lowercased and whitespace-collapsed).
 fn token_set_ratio_from_normalized(norm_a: &str, norm_b: &str) -> f64 {
-    if norm_a.is_empty() && norm_b.is_empty() {
-        return 1.0;
+    if norm_a.is_empty() || norm_b.is_empty() {
+        return if norm_a.is_empty() && norm_b.is_empty() {
+            1.0
+        } else {
+            0.0
+        };
     }
 
     let tokens_a: BTreeSet<&str> = norm_a.split_whitespace().collect();
@@ -518,8 +522,12 @@ pub fn token_set_ratio_many(reference: String, candidates: Vec<String>) -> Vec<f
         .map(|c| {
             let norm_c = normalize_str(c);
 
-            if norm_ref.is_empty() && norm_c.is_empty() {
-                return 1.0;
+            if norm_ref.is_empty() || norm_c.is_empty() {
+                return if norm_ref.is_empty() && norm_c.is_empty() {
+                    1.0
+                } else {
+                    0.0
+                };
             }
 
             let tokens_c: BTreeSet<&str> = norm_c.split_whitespace().collect();
@@ -690,8 +698,12 @@ pub fn weighted_ratio_many(reference: String, candidates: Vec<String>) -> Vec<f6
 
             // Token set ratio (reuse pre-computed norm_ref and tokens_ref)
             let set = {
-                if norm_ref.is_empty() && norm_c.is_empty() {
-                    1.0
+                if norm_ref.is_empty() || norm_c.is_empty() {
+                    if norm_ref.is_empty() && norm_c.is_empty() {
+                        1.0
+                    } else {
+                        0.0
+                    }
                 } else {
                     let tokens_c: BTreeSet<&str> = norm_c.split_whitespace().collect();
                     let tokens_ref_borrowed: BTreeSet<&str> =
@@ -1325,6 +1337,14 @@ mod tests {
         #[test]
         fn test_empty_strings() {
             assert_eq!(token_set_ratio("".into(), "".into()), 1.0);
+        }
+
+        #[test]
+        fn test_one_empty_returns_zero() {
+            assert_eq!(token_set_ratio("".into(), "foo".into()), 0.0);
+            assert_eq!(token_set_ratio("foo".into(), "".into()), 0.0);
+            assert_eq!(token_set_ratio("  ".into(), "foo".into()), 0.0);
+            assert_eq!(token_set_ratio("foo".into(), "  ".into()), 0.0);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Fix `tokenSetRatio("", "foo")` returning `1.0` (perfect match) instead of `0.0`. The empty input produced an empty token set, making `diff_a` empty and triggering the `score_a=1.0` shortcut incorrectly.

The fix adds an early return when only one input is empty (after normalization), returning `0.0`. This is consistent with other distance functions (`normalizedLevenshtein`, `jaro`, `partialRatio` all return `0.0` for empty vs non-empty).

Applied to three locations:
- `token_set_ratio_from_normalized` (used by `tokenSetRatio` and `weightedRatio`)
- `token_set_ratio_many` optimized variant
- `weighted_ratio_many` inline token set logic

## Related issue

Closes #333

## Checklist

- [x] `cargo test` — 228 tests pass (1 new regression test)
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — formatted
- [x] Changeset added (patch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token set ratio calculation to correctly handle empty string comparisons. When comparing an empty string against a non-empty string, the function now returns 0.0 instead of incorrectly returning 1.0 (perfect match).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->