### PR TITLE
chore(wasm): add wasm-opt post-processing to build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,12 @@ jobs:
         if: matrix.settings.target == 'wasm32-wasip1-threads'
         run: pnpm run build --target wasm32-wasip1-threads
 
+      - name: Optimize WASM with wasm-opt
+        if: matrix.settings.target == 'wasm32-wasip1-threads'
+        run: |
+          sudo apt-get update && sudo apt-get install -y binaryen
+          pnpm run optimize:wasm
+
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,12 @@ jobs:
           ${{ matrix.settings.use-cross && '--use-napi-cross' || '' }}
           ${{ matrix.settings.use-zig && '--cross-compile' || '' }}
 
+      - name: Optimize WASM with wasm-opt
+        if: matrix.settings.target == 'wasm32-wasip1-threads'
+        run: |
+          sudo apt-get update && sudo apt-get install -y binaryen
+          pnpm run optimize:wasm
+
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:

--- a/package.json
+++ b/package.json
@@ -101,6 +101,8 @@
     "postbuild": "node scripts/patch-binding.js",
     "build:debug": "napi build --manifest-path crates/core/Cargo.toml --platform --js index.js --dts index.d.ts --output-dir .",
     "build:wasm": "napi build --manifest-path crates/core/Cargo.toml --platform --release --js index.js --dts index.d.ts --output-dir . --target wasm32-wasip1-threads",
+    "postbuild:wasm": "node scripts/optimize-wasm.js",
+    "optimize:wasm": "node scripts/optimize-wasm.js",
     "artifacts": "napi artifacts",
     "prepublishOnly": "napi prepublish -t npm",
     "version": "napi version",

--- a/scripts/optimize-wasm.js
+++ b/scripts/optimize-wasm.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Post-process WASM binaries with wasm-opt for size and speed optimization.
+ *
+ * Looks for *.wasm files in the project root and runs `wasm-opt -O3` on each.
+ * Skips gracefully if wasm-opt is not installed (non-blocking).
+ *
+ * Usage:
+ *   node scripts/optimize-wasm.js
+ *   node scripts/optimize-wasm.js --size   # Use -Oz instead of -O3
+ */
+
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// Parse CLI flags
+const optimizeForSize = process.argv.includes('--size');
+const optLevel = optimizeForSize ? '-Oz' : '-O3';
+
+// Check if wasm-opt is available
+function findWasmOpt() {
+  try {
+    execFileSync('wasm-opt', ['--version'], { stdio: 'pipe' });
+    return 'wasm-opt';
+  } catch {
+    return null;
+  }
+}
+
+// Find all .wasm files in the project root (not in subdirectories)
+function findWasmFiles() {
+  return fs
+    .readdirSync(ROOT)
+    .filter((f) => f.endsWith('.wasm'))
+    .map((f) => path.join(ROOT, f));
+}
+
+const wasmOpt = findWasmOpt();
+if (!wasmOpt) {
+  console.log('wasm-opt not found in PATH, skipping WASM optimization.');
+  console.log('Install binaryen to enable: https://github.com/WebAssembly/binaryen');
+  process.exit(0);
+}
+
+const wasmFiles = findWasmFiles();
+if (wasmFiles.length === 0) {
+  console.log('No .wasm files found in project root, nothing to optimize.');
+  process.exit(0);
+}
+
+console.log(`Optimizing ${wasmFiles.length} WASM file(s) with wasm-opt ${optLevel}...`);
+
+for (const wasmFile of wasmFiles) {
+  const basename = path.basename(wasmFile);
+  const originalSize = fs.statSync(wasmFile).size;
+
+  try {
+    // wasm-opt in-place: write to temp then rename
+    const tmpFile = `${wasmFile}.opt`;
+    execFileSync(wasmOpt, [optLevel, '-o', tmpFile, wasmFile], {
+      stdio: 'pipe',
+      timeout: 120_000,
+    });
+    fs.renameSync(tmpFile, wasmFile);
+
+    const optimizedSize = fs.statSync(wasmFile).size;
+    const reduction = (((originalSize - optimizedSize) / originalSize) * 100).toFixed(1);
+    console.log(
+      `  ${basename}: ${formatBytes(originalSize)} -> ${formatBytes(optimizedSize)} (${reduction}% smaller)`,
+    );
+  } catch (err) {
+    // Clean up temp file on failure
+    const tmpFile = `${wasmFile}.opt`;
+    if (fs.existsSync(tmpFile)) {
+      fs.unlinkSync(tmpFile);
+    }
+    console.error(`  ${basename}: optimization failed — ${err.message}`);
+    process.exit(1);
+  }
+}
+
+console.log('WASM optimization complete.');
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(2)} MB`;
+}

--- a/scripts/optimize-wasm.js
+++ b/scripts/optimize-wasm.js
@@ -62,7 +62,7 @@ for (const wasmFile of wasmFiles) {
   try {
     // wasm-opt in-place: write to temp then rename
     const tmpFile = `${wasmFile}.opt`;
-    execFileSync(wasmOpt, [optLevel, '-o', tmpFile, wasmFile], {
+    execFileSync(wasmOpt, [optLevel, '--all-features', '-o', tmpFile, wasmFile], {
       stdio: 'pipe',
       timeout: 120_000,
     });


### PR DESCRIPTION
## Summary

Add `wasm-opt -O3` post-processing step to optimize WASM binaries for both size and speed.

### Changes

- **`scripts/optimize-wasm.js`**: Node.js script that finds `*.wasm` files in the project root and runs `wasm-opt` on each. Gracefully skips if `wasm-opt` is not in PATH. Supports `--size` flag for `-Oz` optimization. Reports before/after sizes.
- **`package.json`**: Added `postbuild:wasm` (runs automatically after `build:wasm`) and `optimize:wasm` (standalone for CI)
- **CI workflow**: Installs `binaryen` via apt and runs `pnpm run optimize:wasm` after WASM build
- **Release workflow**: Same wasm-opt step added to ensure published WASM binaries are optimized

### Design

- Local dev: `wasm-opt` is optional — script exits gracefully if not installed
- CI/Release: `binaryen` installed via `apt-get`, ensuring optimization always runs in pipeline
- Uses temp file strategy to avoid corrupting the original `.wasm` on failure

## Related issue

Closes #320

## Checklist

- [x] All pre-push hooks pass (lint, test, typecheck, clippy, cargo-test, cargo-deny)
- [x] Graceful fallback when wasm-opt is not installed
- [x] No changeset needed (build tooling, not library code)