### PR TITLE
docs: update README and migration guides for post-v1.0.0 changes

### DIFF
--- a/.github/assets/bench-distance.svg
+++ b/.github/assets/bench-distance.svg
@@ -15,18 +15,18 @@
 <text x="20" y="66" class="group-label">Levenshtein</text>
 <text x="172" y="91" class="bar-label" text-anchor="end">fastest-levenshtein</text>
 <rect x="180" y="74" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="632" y="91" class="bar-value" text-anchor="end">758,533 ops/s</text>
+<text x="632" y="91" class="bar-value" text-anchor="end">741,195 ops/s</text>
 <text x="172" y="122" class="bar-label" text-anchor="end">rapid-fuzzy</text>
-<rect x="180" y="105" width="342.39551871836824" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="514.3955187183683" y="122" class="bar-value" text-anchor="end" fill="#ffffff">564,605 ops/s</text>
+<rect x="180" y="105" width="338.44734516557725" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="510.4473451655772" y="122" class="bar-value" text-anchor="end" fill="#ffffff">545,338 ops/s</text>
 <text x="172" y="153" class="bar-label" text-anchor="end">leven</text>
-<rect x="180" y="136" width="129.90113811791974" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="317.90113811791974" y="153" class="bar-value" text-anchor="start">214,205 ops/s</text>
+<rect x="180" y="136" width="139.92298922685663" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="327.92298922685666" y="153" class="bar-value" text-anchor="start">225,457 ops/s</text>
 <text x="20" y="200" class="group-label">Sorensen-Dice</text>
 <text x="172" y="225" class="bar-label" text-anchor="end">rapid-fuzzy</text>
 <rect x="180" y="208" width="460" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="632" y="225" class="bar-value" text-anchor="end" fill="#ffffff">152,317 ops/s</text>
+<text x="632" y="225" class="bar-value" text-anchor="end" fill="#ffffff">142,180 ops/s</text>
 <text x="172" y="256" class="bar-label" text-anchor="end">string-similarity</text>
-<rect x="180" y="239" width="260.9264888357833" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="432.9264888357833" y="256" class="bar-value" text-anchor="end">86,399 ops/s</text>
+<rect x="180" y="239" width="183.53734702489803" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="371.53734702489805" y="256" class="bar-value" text-anchor="start">56,729 ops/s</text>
 </svg>

--- a/.github/assets/bench-search.svg
+++ b/.github/assets/bench-search.svg
@@ -15,49 +15,49 @@
 <text x="20" y="66" class="group-label">Small</text>
 <text x="172" y="91" class="bar-label" text-anchor="end">fuzzysort</text>
 <rect x="180" y="74" width="460" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="632" y="91" class="bar-value" text-anchor="end">2,655,421 ops/s</text>
+<text x="632" y="91" class="bar-value" text-anchor="end">1,661,273 ops/s</text>
 <text x="172" y="122" class="bar-label" text-anchor="end">uFuzzy</text>
-<rect x="180" y="105" width="160.61467465987502" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="348.61467465987505" y="122" class="bar-value" text-anchor="start">927,173 ops/s</text>
+<rect x="180" y="105" width="116.85901113182483" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="304.85901113182484" y="122" class="bar-value" text-anchor="start">422,032 ops/s</text>
 <text x="172" y="153" class="bar-label" text-anchor="end">rapid-fuzzy (indexed)</text>
-<rect x="180" y="136" width="70.03208154187227" height="26" rx="4" fill="#60a5fa" opacity="1" />
-<text x="258.0320815418723" y="153" class="bar-value" text-anchor="start">404,271 ops/s — 2x vs fuse.js</text>
+<rect x="180" y="136" width="109.6320231533288" height="26" rx="4" fill="#60a5fa" opacity="1" />
+<text x="297.6320231533288" y="153" class="bar-value" text-anchor="start">395,932 ops/s — 2x vs fuse.js</text>
 <text x="172" y="184" class="bar-label" text-anchor="end">rapid-fuzzy</text>
-<rect x="180" y="167" width="49.835306717842485" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="237.83530671784249" y="184" class="bar-value" text-anchor="start">287,682 ops/s — 2x vs fuse.js</text>
+<rect x="180" y="167" width="77.39494953568739" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="265.3949495356874" y="184" class="bar-value" text-anchor="start">279,509 ops/s — 2x vs fuse.js</text>
 <text x="172" y="215" class="bar-label" text-anchor="end">fuse.js</text>
-<rect x="180" y="198" width="21.929426633290916" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="209.92942663329092" y="215" class="bar-value" text-anchor="start">126,591 ops/s</text>
+<rect x="180" y="198" width="32.79640372172424" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="220.79640372172423" y="215" class="bar-value" text-anchor="start">118,443 ops/s</text>
 <text x="20" y="262" class="group-label">Medium</text>
 <text x="172" y="287" class="bar-label" text-anchor="end">rapid-fuzzy (indexed)</text>
 <rect x="180" y="270" width="460" height="26" rx="4" fill="#60a5fa" opacity="1" />
-<text x="632" y="287" class="bar-value" text-anchor="end" fill="#ffffff">79,616 ops/s — 19x vs fuse.js</text>
+<text x="632" y="287" class="bar-value" text-anchor="end" fill="#ffffff">77,271 ops/s — 18x vs fuse.js</text>
 <text x="172" y="318" class="bar-label" text-anchor="end">fuzzysort</text>
-<rect x="180" y="301" width="368.7984827170418" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="540.7984827170418" y="318" class="bar-value" text-anchor="end">63,831 ops/s</text>
+<rect x="180" y="301" width="346.0105343531208" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="518.0105343531209" y="318" class="bar-value" text-anchor="end">58,123 ops/s</text>
 <text x="172" y="349" class="bar-label" text-anchor="end">uFuzzy</text>
-<rect x="180" y="332" width="173.90398914790998" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="361.90398914791" y="349" class="bar-value" text-anchor="start">30,099 ops/s</text>
+<rect x="180" y="332" width="155.0894902356641" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="343.08949023566413" y="349" class="bar-value" text-anchor="start">26,052 ops/s</text>
 <text x="172" y="380" class="bar-label" text-anchor="end">rapid-fuzzy</text>
-<rect x="180" y="363" width="39.44458400321543" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="227.44458400321543" y="380" class="bar-value" text-anchor="start">6,827 ops/s — 19x vs fuse.js</text>
+<rect x="180" y="363" width="37.349587814315846" height="26" rx="4" fill="#3b82f6" opacity="1" />
+<text x="225.34958781431584" y="380" class="bar-value" text-anchor="start">6,274 ops/s — 18x vs fuse.js</text>
 <text x="172" y="411" class="bar-label" text-anchor="end">fuse.js</text>
 <rect x="180" y="394" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="192" y="411" class="bar-value" text-anchor="start">366 ops/s</text>
+<text x="192" y="411" class="bar-value" text-anchor="start">358 ops/s</text>
 <text x="20" y="458" class="group-label">Large</text>
 <text x="172" y="483" class="bar-label" text-anchor="end">rapid-fuzzy (indexed)</text>
 <rect x="180" y="466" width="460" height="26" rx="4" fill="#60a5fa" opacity="1" />
-<text x="632" y="483" class="bar-value" text-anchor="end" fill="#ffffff">136,294 ops/s — 46x vs fuse.js</text>
+<text x="632" y="483" class="bar-value" text-anchor="end" fill="#ffffff">230,848 ops/s — 52x vs fuse.js</text>
 <text x="172" y="514" class="bar-label" text-anchor="end">fuzzysort</text>
-<rect x="180" y="497" width="94.1539612895652" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="282.1539612895652" y="514" class="bar-value" text-anchor="start">27,897 ops/s</text>
+<rect x="180" y="497" width="50.44401510950929" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="238.44401510950928" y="514" class="bar-value" text-anchor="start">25,315 ops/s</text>
 <text x="172" y="545" class="bar-label" text-anchor="end">uFuzzy</text>
-<rect x="180" y="528" width="21.806242387779356" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="209.80624238777935" y="545" class="bar-value" text-anchor="start">6,461 ops/s</text>
+<rect x="180" y="528" width="9.2917417521486" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
+<text x="197.2917417521486" y="545" class="bar-value" text-anchor="start">4,663 ops/s</text>
 <text x="172" y="576" class="bar-label" text-anchor="end">rapid-fuzzy</text>
 <rect x="180" y="559" width="4" height="26" rx="4" fill="#3b82f6" opacity="1" />
-<text x="192" y="576" class="bar-value" text-anchor="start">827 ops/s — 46x vs fuse.js</text>
+<text x="192" y="576" class="bar-value" text-anchor="start">777 ops/s — 52x vs fuse.js</text>
 <text x="172" y="607" class="bar-label" text-anchor="end">fuse.js</text>
 <rect x="180" y="590" width="4" height="26" rx="4" fill="#94a3b8" opacity="0.6" />
-<text x="192" y="607" class="bar-value" text-anchor="start">18 ops/s</text>
+<text x="192" y="607" class="bar-value" text-anchor="start">15 ops/s</text>
 </svg>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Blazing-fast fuzzy search for JavaScript — powered by Rust, works everywhere.
 
 ## Features
 
-- **Fast**: Up to 7,000x faster than fuse.js with FuzzyIndex (Rust + napi-rs)
+- **Fast**: Up to 15,000x faster than fuse.js with FuzzyIndex (Rust + napi-rs)
 - **Universal**: Works in Node.js (native), browsers (WASM), Deno, and Bun
 - **Zero JS dependencies**: Pure Rust core with napi-rs bindings
 - **Type-safe**: Full TypeScript support with auto-generated type definitions
@@ -31,7 +31,7 @@ const results = search('typscript', ['TypeScript', 'JavaScript', 'Python']);
 // → [{ item: 'TypeScript', score: 0.85, index: 0 }, ...]
 ```
 
-For repeated searches, use `FuzzyIndex` for up to 165x faster lookups:
+For repeated searches, use `FuzzyIndex` for up to 297x faster lookups:
 
 ```typescript
 import { FuzzyIndex } from 'rapid-fuzzy';
@@ -86,6 +86,9 @@ const [match] = search('hlo', ['hello world'], { includePositions: true });
 // Case-sensitive matching (default: smart case)
 search('Type', items, { isCaseSensitive: true });
 
+// Return all items when query is empty (useful for filter-as-you-type UIs)
+search('', items, { returnAllOnEmpty: true });
+
 // Find the single best match
 closest('tsc', ['TypeScript', 'JavaScript', 'Python']);
 // → 'TypeScript'
@@ -98,11 +101,12 @@ closest('xyz', items, 0.5);
 ### String Distance
 
 ```typescript
-import { levenshtein, jaroWinkler, sorensenDice } from 'rapid-fuzzy';
+import { levenshtein, jaroWinkler, sorensenDice, hamming } from 'rapid-fuzzy';
 
 levenshtein('kitten', 'sitting');     // 3
 jaroWinkler('MARTHA', 'MARHTA');      // 0.961
 sorensenDice('night', 'nacht');       // 0.25
+hamming('karolin', 'kathrin');        // 3 (null if lengths differ)
 ```
 
 ### Query Syntax
@@ -159,11 +163,15 @@ For applications that search the same dataset repeatedly (autocomplete, file fin
 ```typescript
 import { FuzzyIndex, FuzzyObjectIndex } from 'rapid-fuzzy';
 
-// String search index — up to 165x faster than standalone search()
+// String search index — up to 297x faster than standalone search()
 const index = new FuzzyIndex(['TypeScript', 'JavaScript', 'Python', ...]);
 
 index.search('typscript', { maxResults: 5 });
 index.closest('tsc');
+
+// Index-only results (no string cloning — less GC pressure)
+const hits = index.searchIndices('typscript', { maxResults: 5 });
+// → [{ index: 0, score: 0.85, positions: [] }, ...]
 
 // Mutate the index without rebuilding
 index.add('Rust');
@@ -255,6 +263,10 @@ levenshteinBatch([
 // Compare one string against many candidates
 levenshteinMany('kitten', ['sitting', 'kittens', 'kitchen']);
 // → [3, 1, 2]
+
+// With early-termination threshold (skip candidates that can't match)
+levenshteinMany('kitten', candidates, 3);        // maxDistance → returns 4 for exceeding
+jaroWinklerMany('MARTHA', candidates, 0.8);       // minSimilarity → returns 0.0 for below
 ```
 
 > **Tip**: Prefer batch/many variants over calling single-pair functions in a loop — they are significantly faster for multiple comparisons.
@@ -266,6 +278,7 @@ levenshteinMany('kitten', ['sitting', 'kittens', 'kitchen']);
 | Use case | Recommended | Why |
 |---|---|---|
 | Typo detection / spell check | `levenshtein`, `damerauLevenshtein` | Counts edits; Damerau adds transposition support |
+| Fixed-length comparison | `hamming` | Counts differing positions; only for equal-length strings |
 | Name / address matching | `jaroWinkler`, `tokenSortRatio` | Prefix-weighted or order-independent matching |
 | Document / text similarity | `sorensenDice` | Bigram-based; handles longer text well |
 | Normalized comparison (0–1) | `normalizedLevenshtein` | Length-independent similarity score |
@@ -273,11 +286,11 @@ levenshteinMany('kitten', ['sitting', 'kittens', 'kitchen']);
 | Substring / abbreviation matching | `partialRatio` | Finds best partial match within longer strings |
 | Best-effort similarity | `weightedRatio` | Picks the best score across all methods automatically |
 | Interactive fuzzy search | `search`, `closest` | Nucleo algorithm (same as Helix editor) |
-| Repeated search on same data | `FuzzyIndex`, `FuzzyObjectIndex` | Persistent Rust-side index with incremental cache, up to 165x faster |
+| Repeated search on same data | `FuzzyIndex`, `FuzzyObjectIndex` | Persistent Rust-side index with incremental cache, up to 297x faster |
 
 **Return types:**
 
-- `levenshtein`, `damerauLevenshtein` → integer (edit count)
+- `levenshtein`, `damerauLevenshtein`, `hamming` → integer (edit/difference count; `hamming` returns `null` if lengths differ)
 - `jaro`, `jaroWinkler`, `sorensenDice`, `normalizedLevenshtein` → float between 0.0 (no match) and 1.0 (identical)
 - `tokenSortRatio`, `tokenSetRatio`, `partialRatio`, `weightedRatio` → float between 0.0 and 1.0
 - `search` → array of `{ item, score, index, positions }` sorted by relevance (score: 0.0–1.0)
@@ -295,15 +308,16 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 | Function | rapid-fuzzy | fastest-levenshtein | leven | string-similarity |
 |---|---:|---:|---:|---:|
-| Levenshtein | 564,605 ops/s | **758,533 ops/s** | 214,205 ops/s | — |
-| Normalized Levenshtein | **515,352 ops/s** | — | — | — |
-| Sorensen-Dice | **152,317 ops/s** | — | — | 86,399 ops/s |
-| Jaro-Winkler | **523,894 ops/s** | — | — | — |
-| Damerau-Levenshtein | **118,113 ops/s** | — | — | — |
+| Levenshtein | 545,338 ops/s | **741,195 ops/s** | 225,457 ops/s | — |
+| Normalized Levenshtein | **514,446 ops/s** | — | — | — |
+| Sorensen-Dice | **142,180 ops/s** | — | — | 56,729 ops/s |
+| Jaro-Winkler | **505,762 ops/s** | — | — | — |
+| Damerau-Levenshtein | **116,186 ops/s** | — | — | — |
+| Hamming | **883,614 ops/s** | — | — | — |
 
 </details>
 
-> **Note**: For single-pair Levenshtein, fastest-levenshtein is ~1.4x faster due to its optimized pure-JS implementation that avoids FFI overhead. rapid-fuzzy is **2.5x faster** than leven, and provides broader algorithm coverage plus batch / search scenarios.
+> **Note**: For single-pair Levenshtein, fastest-levenshtein is ~1.4x faster due to its optimized pure-JS implementation that avoids FFI overhead. rapid-fuzzy is **2.4x faster** than leven, and provides broader algorithm coverage plus batch / search scenarios.
 
 ### Search Performance
 
@@ -316,9 +330,9 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 | Dataset size | rapid-fuzzy | rapid-fuzzy (indexed) | fuse.js | fuzzysort | uFuzzy |
 |---|---:|---:|---:|---:|---:|
-| Small (20 items) | 287,682 ops/s | 404,271 ops/s | 126,591 ops/s | **2,655,421 ops/s** | 927,173 ops/s |
-| Medium (1K items) | 6,827 ops/s | **79,616 ops/s** | 366 ops/s | 63,831 ops/s | 30,099 ops/s |
-| Large (10K items) | 827 ops/s | **136,294 ops/s** | 18 ops/s | 27,897 ops/s | 6,461 ops/s |
+| Small (20 items) | 279,509 ops/s | 395,932 ops/s | 118,443 ops/s | **1,661,273 ops/s** | 422,032 ops/s |
+| Medium (1K items) | 6,274 ops/s | **77,271 ops/s** | 358 ops/s | 58,123 ops/s | 26,052 ops/s |
+| Large (10K items) | 777 ops/s | **230,848 ops/s** | 15 ops/s | 25,315 ops/s | 4,663 ops/s |
 
 </details>
 
@@ -326,22 +340,22 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 
 | Dataset size | rapid-fuzzy | rapid-fuzzy (indexed) | fastest-levenshtein |
 |---|---:|---:|---:|
-| Medium (1K items) | 8,194 ops/s | **978,009 ops/s** | 6,869 ops/s |
-| Large (10K items) | 892 ops/s | **152,196 ops/s** | 679 ops/s |
+| Medium (1K items) | 7,690 ops/s | **906,274 ops/s** | 3,536 ops/s |
+| Large (10K items) | 611 ops/s | **352,688 ops/s** | 620 ops/s |
 
-> In indexed mode (`FuzzyIndex`), rapid-fuzzy is up to **224x faster** than fastest-levenshtein for closest-match lookups.
+> In indexed mode (`FuzzyIndex`), rapid-fuzzy is up to **569x faster** than fastest-levenshtein for closest-match lookups.
 
 ### Key takeaways
 
-- **vs fuse.js**: `FuzzyIndex` is **218x–7,572x faster** depending on dataset size. Even standalone `search()` is 19–46x faster.
-- **Indexed mode**: `FuzzyIndex` keeps data on the Rust side with incremental caching — **165x faster** than standalone `search()` on large datasets, delivering sub-millisecond autocomplete.
-- **vs fuzzysort / uFuzzy**: `FuzzyIndex` outperforms both on 1K+ datasets (up to 4.9x vs fuzzysort, 21x vs uFuzzy).
+- **vs fuse.js**: `FuzzyIndex` is **216x–15,390x faster** depending on dataset size. Even standalone `search()` is 18–52x faster.
+- **Indexed mode**: `FuzzyIndex` keeps data on the Rust side with incremental caching — **297x faster** than standalone `search()` on large datasets, delivering sub-millisecond autocomplete.
+- **vs fuzzysort / uFuzzy**: `FuzzyIndex` outperforms both on 1K+ datasets (up to 9.1x vs fuzzysort, 50x vs uFuzzy).
 
 ## Why rapid-fuzzy?
 
 | | rapid-fuzzy | fuse.js | fastest-levenshtein | fuzzysort | uFuzzy |
 |---|:---:|:---:|:---:|:---:|:---:|
-| **Algorithms** | 9 (Levenshtein, Jaro, Dice, …) | Bitap | Levenshtein | Substring | Regex-based |
+| **Algorithms** | 10 (Levenshtein, Hamming, Jaro, Dice, …) | Bitap | Levenshtein | Substring | Regex-based |
 | **Runtime** | Rust native + WASM | Pure JS | Pure JS | Pure JS | Pure JS |
 | **Object search** | ✅ weighted keys | ✅ | — | ✅ | — |
 | **Persistent index** | ✅ FuzzyIndex / FuzzyObjectIndex | — | — | ✅ prepared targets | — |
@@ -361,9 +375,9 @@ Measured on Apple M-series with Node.js v22 using [Vitest bench](https://vitest.
 Switching from another library? These guides provide API mapping tables, code examples, and performance comparisons:
 
 - [**From string-similarity**](docs/migration/from-string-similarity.md) — Same Dice coefficient algorithm, now maintained and faster
-- [**From fuse.js**](docs/migration/from-fuse-js.md) — Up to 7,000x faster fuzzy search with FuzzyIndex
+- [**From fuse.js**](docs/migration/from-fuse-js.md) — Up to 15,000x faster fuzzy search with FuzzyIndex
 - [**From leven / fastest-levenshtein**](docs/migration/from-leven.md) — Multi-algorithm upgrade with batch APIs
-- [**From fuzzysort**](docs/migration/from-fuzzysort.md) — Richer matching with query syntax and 9 distance algorithms
+- [**From fuzzysort**](docs/migration/from-fuzzysort.md) — Richer matching with query syntax and 10 distance algorithms
 - [**From uFuzzy**](docs/migration/from-ufuzzy.md) — Weighted object search, batch APIs, and persistent indexes
 
 ## License

--- a/__test__/distance.bench.ts
+++ b/__test__/distance.bench.ts
@@ -152,8 +152,8 @@ const equalLengthPairs: [string, string][] = [
   ['saturday', 'sunturdy'],
   ['abcdefgh', 'abcdefgz'],
   ['10101010', '01010101'],
-  ['the quick brown fox jump', 'the fast brown fox leap'],
-  ['abcdefghijklmnopqrstuvwx', 'zyxwvutsrqponmlkjihgfedcb'],
+  ['the quick brown fox jumps', 'the swift brown fox leaps'],
+  ['abcdefghijklmnopqrstuvwxyz', 'zyxwvutsrqponmlkjihgfedcba'],
 ];
 
 describe('Hamming Distance', () => {

--- a/__test__/distance.bench.ts
+++ b/__test__/distance.bench.ts
@@ -6,6 +6,7 @@ import stringSimilarity from 'string-similarity';
 import { bench, describe } from 'vitest';
 import {
   damerauLevenshtein,
+  hamming,
   jaro,
   jaroWinkler,
   levenshtein,
@@ -141,6 +142,24 @@ describe('Damerau-Levenshtein', () => {
   bench('rapid-fuzzy', () => {
     for (const [a, b] of pairs) {
       damerauLevenshtein(a, b);
+    }
+  });
+});
+
+// Equal-length pairs for Hamming distance
+const equalLengthPairs: [string, string][] = [
+  ['karolin', 'kathrin'],
+  ['saturday', 'sunturdy'],
+  ['abcdefgh', 'abcdefgz'],
+  ['10101010', '01010101'],
+  ['the quick brown fox jump', 'the fast brown fox leap'],
+  ['abcdefghijklmnopqrstuvwx', 'zyxwvutsrqponmlkjihgfedcb'],
+];
+
+describe('Hamming Distance', () => {
+  bench('rapid-fuzzy', () => {
+    for (const [a, b] of equalLengthPairs) {
+      hamming(a, b);
     }
   });
 });

--- a/docs/migration/from-fuse-js.md
+++ b/docs/migration/from-fuse-js.md
@@ -146,8 +146,8 @@ rapid-fuzzy is significantly faster than fuse.js for fuzzy search:
 
 | Dataset size | rapid-fuzzy | FuzzyIndex | fuse.js | Speedup |
 |---|---:|---:|---:|---:|
-| 1,000 items | 6,827 ops/s | 79,616 ops/s | 366 ops/s | **19x / 218x** |
-| 10,000 items | 827 ops/s | 136,294 ops/s | 18 ops/s | **46x / 7,572x** |
+| 1,000 items | 6,274 ops/s | 77,271 ops/s | 358 ops/s | **18x / 216x** |
+| 10,000 items | 777 ops/s | 230,848 ops/s | 15 ops/s | **52x / 15,390x** |
 
 The performance advantage grows with dataset size because rapid-fuzzy's Rust-based nucleo engine scales better than fuse.js's pure JavaScript implementation.
 

--- a/docs/migration/from-fuzzysort.md
+++ b/docs/migration/from-fuzzysort.md
@@ -1,6 +1,6 @@
 # Migrating from fuzzysort to rapid-fuzzy
 
-[fuzzysort](https://github.com/farzher/fuzzysort) is a fast fuzzy search library that uses substring matching and a custom scoring algorithm. rapid-fuzzy takes a different approach — it uses the nucleo fuzzy matching engine (same as the Helix editor) and adds 9 distance algorithms, query syntax, and batch APIs for broader use cases.
+[fuzzysort](https://github.com/farzher/fuzzysort) is a fast fuzzy search library that uses substring matching and a custom scoring algorithm. rapid-fuzzy takes a different approach — it uses the nucleo fuzzy matching engine (same as the Helix editor) and adds 10 distance algorithms, query syntax, and batch APIs for broader use cases.
 
 ## Installation
 
@@ -163,19 +163,19 @@ fuzzysort uses a substring-based matching algorithm that is extremely fast for r
 
 | Dataset size | rapid-fuzzy | FuzzyIndex | fuzzysort |
 |---|---:|---:|---:|
-| Small (20 items) | 287,682 ops/s | 404,271 ops/s | **2,655,421 ops/s** |
-| Medium (1K items) | 6,827 ops/s | **79,616 ops/s** | 63,831 ops/s |
-| Large (10K items) | 827 ops/s | **136,294 ops/s** | 27,897 ops/s |
+| Small (20 items) | 279,509 ops/s | 395,932 ops/s | **1,661,273 ops/s** |
+| Medium (1K items) | 6,274 ops/s | **77,271 ops/s** | 58,123 ops/s |
+| Large (10K items) | 777 ops/s | **230,848 ops/s** | 25,315 ops/s |
 
 Measured on Apple M-series with Node.js v22.
 
-fuzzysort is faster on small datasets because it uses optimized substring matching — a fundamentally simpler operation than fuzzy matching with out-of-order support. However, with `FuzzyIndex`, rapid-fuzzy outperforms fuzzysort on medium-and-above datasets (1.2x at 1K, 4.9x at 10K) thanks to Rust-side indexing with incremental caching.
+fuzzysort is faster on small datasets because it uses optimized substring matching — a fundamentally simpler operation than fuzzy matching with out-of-order support. However, with `FuzzyIndex`, rapid-fuzzy outperforms fuzzysort on medium-and-above datasets (1.3x at 1K, 9.1x at 10K) thanks to Rust-side indexing with incremental caching.
 
 ## Why Choose rapid-fuzzy Over fuzzysort?
 
 rapid-fuzzy with `FuzzyIndex` matches or exceeds fuzzysort's speed on real-world dataset sizes, while offering capabilities that fuzzysort does not:
 
-- **9 distance algorithms**: Levenshtein, Damerau-Levenshtein, Jaro, Jaro-Winkler, Sorensen-Dice, and more — useful beyond search
+- **10 distance algorithms**: Levenshtein, Damerau-Levenshtein, Hamming, Jaro, Jaro-Winkler, Sorensen-Dice, and more — useful beyond search
 - **Query syntax**: Exclude (`!term`), prefix (`^term`), suffix (`term$`), exact (`'term`) operators
 - **Diacritics handling**: `cafe` matches `café`, `uber` matches `über` automatically
 - **Batch APIs**: `levenshteinBatch`, `jaroWinklerMany`, etc. for bulk operations

--- a/docs/migration/from-leven.md
+++ b/docs/migration/from-leven.md
@@ -1,6 +1,6 @@
 # Migrating from leven / fastest-levenshtein to rapid-fuzzy
 
-[leven](https://www.npmjs.com/package/leven) and [fastest-levenshtein](https://www.npmjs.com/package/fastest-levenshtein) are single-purpose Levenshtein distance libraries. rapid-fuzzy provides the same Levenshtein distance plus five additional algorithms, batch APIs, and fuzzy search — all from a single package.
+[leven](https://www.npmjs.com/package/leven) and [fastest-levenshtein](https://www.npmjs.com/package/fastest-levenshtein) are single-purpose Levenshtein distance libraries. rapid-fuzzy provides the same Levenshtein distance plus six additional algorithms, batch APIs, and fuzzy search — all from a single package.
 
 ## Installation
 
@@ -62,6 +62,7 @@ import {
   levenshtein,           // Same as leven / fastest-levenshtein
   normalizedLevenshtein, // 0.0-1.0 similarity (length-independent)
   damerauLevenshtein,    // Handles transpositions (ab → ba = 1 edit)
+  hamming,               // Positional differences (equal-length strings)
   jaroWinkler,           // Prefix-weighted, great for names
   sorensenDice,          // Bigram-based text similarity
   jaro,                  // Base Jaro similarity
@@ -108,18 +109,18 @@ For single-pair Levenshtein distance, fastest-levenshtein is still faster due to
 
 | Operation | rapid-fuzzy | fastest-levenshtein | leven |
 |---|---:|---:|---:|
-| Single pair | 564,605 ops/s | **758,533 ops/s** | 214,205 ops/s |
+| Single pair | 545,338 ops/s | **741,195 ops/s** | 225,457 ops/s |
 
-rapid-fuzzy is 2.6x faster than leven and within 1.3x of fastest-levenshtein.
+rapid-fuzzy is 2.4x faster than leven and within 1.4x of fastest-levenshtein.
 
 For closest-match scenarios, rapid-fuzzy pulls ahead — especially with `FuzzyIndex` for repeated searches:
 
 | Closest match | rapid-fuzzy | FuzzyIndex | fastest-levenshtein |
 |---|---:|---:|---:|
-| 1,000 items | 8,194 ops/s | **978,009 ops/s** | 6,869 ops/s |
-| 10,000 items | 892 ops/s | **152,196 ops/s** | 679 ops/s |
+| 1,000 items | 7,690 ops/s | **906,274 ops/s** | 3,536 ops/s |
+| 10,000 items | 611 ops/s | **352,688 ops/s** | 620 ops/s |
 
-`FuzzyIndex` pre-computes internal data structures, making it **142x faster** than fastest-levenshtein for closest-match on 1K items. For repeated searches against the same dataset, always prefer `FuzzyIndex`:
+`FuzzyIndex` pre-computes internal data structures, making it **256x faster** than fastest-levenshtein for closest-match on 1K items. For repeated searches against the same dataset, always prefer `FuzzyIndex`:
 
 ```typescript
 import { FuzzyIndex } from 'rapid-fuzzy';
@@ -132,7 +133,7 @@ const best = index.closest('fast'); // 'faster' — uses pre-built index
 - You need more than just Levenshtein (similarity scores, other algorithms)
 - You process batches of string pairs
 - You need fuzzy search / closest match on medium-to-large datasets
-- You search the same dataset repeatedly (`FuzzyIndex` is 6.8x faster)
+- You search the same dataset repeatedly (`FuzzyIndex` is 256x faster for closest-match)
 - You want a single dependency for all string distance needs
 
 **When to keep fastest-levenshtein**:

--- a/docs/migration/from-string-similarity.md
+++ b/docs/migration/from-string-similarity.md
@@ -1,6 +1,6 @@
 # Migrating from string-similarity to rapid-fuzzy
 
-[string-similarity](https://www.npmjs.com/package/string-similarity) is no longer maintained. rapid-fuzzy provides the same Dice coefficient algorithm (`sorensenDice`) plus five additional algorithms, all powered by a high-performance Rust core.
+[string-similarity](https://www.npmjs.com/package/string-similarity) is no longer maintained. rapid-fuzzy provides the same Dice coefficient algorithm (`sorensenDice`) plus six additional algorithms, all powered by a high-performance Rust core.
 
 ## Installation
 

--- a/docs/migration/from-ufuzzy.md
+++ b/docs/migration/from-ufuzzy.md
@@ -188,19 +188,19 @@ uFuzzy is a highly optimized pure JavaScript library that uses regex-based match
 
 | Dataset size | rapid-fuzzy | FuzzyIndex | uFuzzy |
 |---|---:|---:|---:|
-| Small (20 items) | 287,682 ops/s | 404,271 ops/s | **927,173 ops/s** |
-| Medium (1K items) | 6,827 ops/s | **79,616 ops/s** | 30,099 ops/s |
-| Large (10K items) | 827 ops/s | **136,294 ops/s** | 6,461 ops/s |
+| Small (20 items) | 279,509 ops/s | 395,932 ops/s | **422,032 ops/s** |
+| Medium (1K items) | 6,274 ops/s | **77,271 ops/s** | 26,052 ops/s |
+| Large (10K items) | 777 ops/s | **230,848 ops/s** | 4,663 ops/s |
 
 Measured on Apple M-series with Node.js v22.
 
-uFuzzy is faster on small datasets because it uses optimized regex-based matching in pure JavaScript, avoiding FFI overhead entirely. However, with `FuzzyIndex`, rapid-fuzzy is **2.6x faster** at 1K items and **21x faster** at 10K items thanks to Rust-side indexing with incremental caching.
+uFuzzy is faster on small datasets because it uses optimized regex-based matching in pure JavaScript, avoiding FFI overhead entirely. However, with `FuzzyIndex`, rapid-fuzzy is **3.0x faster** at 1K items and **50x faster** at 10K items thanks to Rust-side indexing with incremental caching.
 
 ## Why Choose rapid-fuzzy Over uFuzzy?
 
 rapid-fuzzy with `FuzzyIndex` outperforms uFuzzy on real-world dataset sizes (1K+), while offering capabilities that uFuzzy does not:
 
-- **9 distance algorithms**: Levenshtein, Damerau-Levenshtein, Jaro, Jaro-Winkler, Sorensen-Dice, and more — useful beyond search
+- **10 distance algorithms**: Levenshtein, Damerau-Levenshtein, Hamming, Jaro, Jaro-Winkler, Sorensen-Dice, and more — useful beyond search
 - **Simpler API**: Returns ready-to-use sorted results instead of three arrays requiring manual assembly
 - **Batch APIs**: `levenshteinBatch`, `jaroWinklerMany`, etc. for bulk distance computations
 - **Weighted object search**: `searchObjects()` and `FuzzyObjectIndex` with per-key weights — no manual key extraction needed


### PR DESCRIPTION
## Summary

- Add Hamming distance documentation to all relevant README sections (String Distance, Choosing an Algorithm, Return types, comparison table)
- Document `searchIndices()` method, `_many` threshold parameters, and `returnAllOnEmpty` option
- Update algorithm count from 9 to 10 across README and all 5 migration guides
- Refresh benchmark numbers with latest measurements (FuzzyIndex 10K: 136K → 231K ops/s after bigram pre-filter)
- Add Hamming benchmark to `distance.bench.ts` and regenerate SVG charts

## Related issue

Closes #354

## Checklist

- [x] All pre-push hooks pass (lint, test, typecheck, clippy, cargo-test, cargo-deny)
- [x] Benchmark numbers verified with fresh `pnpm run bench` run
- [x] SVG charts regenerated from updated README data
- [x] No changeset needed (documentation and benchmark only, no library code changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Hamming distance algorithm to available distance functions.
  * Introduced `returnAllOnEmpty` option for empty search queries.
  * Added batch operation examples with early-termination thresholds.

* **Documentation**
  * Updated performance benchmarks and speedup metrics across guides.
  * Expanded API documentation with additional usage examples and algorithm descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->