### PR TITLE
fix(test): improve WASM test skip logic and add Hamming coverage

### DIFF
--- a/__test__/wasm.spec.ts
+++ b/__test__/wasm.spec.ts
@@ -8,7 +8,8 @@ let wasm: Record<string, any> = {};
 try {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mod = require('../rapid-fuzzy.wasi.cjs');
-  wasmAvailable = typeof mod.levenshtein === 'function';
+  // Check for a recently-added export to detect stale binaries
+  wasmAvailable = typeof mod.levenshtein === 'function' && typeof mod.hamming === 'function';
   if (wasmAvailable) wasm = mod;
 } catch {
   wasmAvailable = false;
@@ -24,6 +25,9 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
         'damerauLevenshtein',
         'damerauLevenshteinBatch',
         'damerauLevenshteinMany',
+        'hamming',
+        'hammingBatch',
+        'hammingMany',
         'jaro',
         'jaroBatch',
         'jaroMany',
@@ -101,6 +105,14 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
       const score = wasm.sorensenDice('hello', 'world');
       expect(score).toBeGreaterThanOrEqual(0);
       expect(score).toBeLessThanOrEqual(1);
+    });
+
+    it('hamming', () => {
+      expect(wasm.hamming('hello', 'hello')).toBe(0);
+      expect(wasm.hamming('karolin', 'kathrin')).toBe(3);
+      expect(wasm.hamming('hello', 'world')).toBe(4);
+      expect(wasm.hamming('hello', 'hi')).toBeNull();
+      expect(wasm.hamming('', '')).toBe(0);
     });
 
     it('tokenSortRatio', () => {
@@ -189,6 +201,18 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
       expect(result).toEqual([0, 1]);
     });
 
+    it('hammingBatch', () => {
+      const result = wasm.hammingBatch([
+        ['hello', 'hello'],
+        ['hello', 'world'],
+        ['hello', 'hi'],
+      ]);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toBe(0);
+      expect(result[1]).toBe(4);
+      expect(result[2]).toBeNull();
+    });
+
     it('tokenSortRatioBatch', () => {
       const result = wasm.tokenSortRatioBatch([
         ['hello world', 'hello world'],
@@ -261,6 +285,14 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
       const result = wasm.damerauLevenshteinMany('hello', ['hello', 'ehllo']);
       expect(result).toHaveLength(2);
       expect(result[0]).toBe(0);
+    });
+
+    it('hammingMany', () => {
+      const result = wasm.hammingMany('hello', ['hello', 'world', 'hi']);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toBe(0);
+      expect(result[1]).toBe(4);
+      expect(result[2]).toBeNull();
     });
 
     it('tokenSortRatioMany', () => {
@@ -368,6 +400,12 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
     it('damerauLevenshtein results should match native', () => {
       for (const [a, b] of testPairs) {
         expect(wasm.damerauLevenshtein(a, b)).toBe(native.damerauLevenshtein(a, b));
+      }
+    });
+
+    it('hamming results should match native', () => {
+      for (const [a, b] of testPairs) {
+        expect(wasm.hamming(a, b)).toBe(native.hamming(a, b));
       }
     });
 


### PR DESCRIPTION
## Summary

- Improve WASM binary staleness detection by checking for both `levenshtein` and `hamming` exports (previously only checked `levenshtein`, causing 18 failures with outdated binaries)
- Add Hamming distance test coverage: single-pair, batch, many, and native parity tests
- Add `hamming`, `hammingBatch`, `hammingMany` to expected WASM exports list

## Related issue

Closes #352

## Checklist

- [x] All pre-push hooks pass (lint, test, typecheck, clippy, cargo-test, cargo-deny)
- [x] WASM tests correctly skip when binary is stale (52 tests skipped)
- [x] No changeset needed (test-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Hamming distance calculation capabilities to the WASM module, including single, batch, and many operation variants.

* **Tests**
  * Expanded test coverage to validate Hamming distance functionality and ensure compatibility with native implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->