### PR TITLE
chore: update Cargo.toml version to 1.1.0

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapid-fuzzy"
-version = "1.0.0"
+version = "1.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

Sync Cargo.toml version with package.json after changeset release bump. The changeset action only updates package.json; Cargo.toml requires a manual version update.

## Checklist

- [x] Version matches package.json (1.1.0)
- [x] No changeset needed (version sync only)