### PR TITLE
fix(ci): remove broken workflow_run trigger from playground workflow

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -6,10 +6,6 @@ on:
     paths:
       - 'playground/**'
       - '.github/workflows/playground.yml'
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -24,9 +20,6 @@ concurrency:
 jobs:
   deploy:
     name: Deploy Playground
-    if: >-
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary

- Remove the `workflow_run` trigger from the Playground workflow that caused deployment failures on `develop`
- Remove the associated `if` condition guard that was only needed for `workflow_run` events

The `workflow_run` trigger always executes on the default branch (`develop`), which is rejected by `github-pages` environment protection rules. The existing `push` trigger with path filter (`playground/**`) already correctly handles deploying when playground files change on `main`.

## Related issue

Closes #364

## Checklist

- [x] Verified the push trigger with path filter remains intact
- [x] Verified `workflow_dispatch` for manual re-deploys remains available
- [x] No functional changes to the deployment pipeline itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline configuration to streamline automated deployment triggers for the playground environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->