### PR TITLE
chore(ci): run Renovate daily and remove PR concurrency limit

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,7 +2,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: '0 19 * * 0' # Weekly Sunday 19:00 UTC (Monday 4:00 JST)
+    - cron: '0 19 * * *' # Daily 19:00 UTC (4:00 JST)
   workflow_dispatch:
 
 permissions:

--- a/renovate.json
+++ b/renovate.json
@@ -2,13 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "baseBranchPatterns": ["develop"],
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 0,
   "ignoreDeps": ["string-similarity", "@types/string-similarity"],
   "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true,
-    "recreateWhen": "always",
-    "rebaseWhen": "never"
+    "enabled": false
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

- Change Renovate workflow schedule from weekly (Sunday only) to daily (`0 19 * * *`)
- Remove `prConcurrentLimit` cap (set to `0` = unlimited)
- Disable `lockFileMaintenance` (has not been working reliably)

Closes #368

## Checklist

- [x] `.github/workflows/renovate.yml` cron updated
- [x] `renovate.json` `prConcurrentLimit` set to `0`
- [x] `renovate.json` `lockFileMaintenance` disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate workflow schedule to run daily instead of weekly for more frequent dependency checks.
  * Disabled automatic lockfile maintenance in Renovate configuration to reduce automatic updates.
  * Modified pull request concurrent limit to allow unlimited simultaneous dependency update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->