### PR TITLE
chore(bench): split benchmarks by feature area and switch CodSpeed to walltime

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
         with:
-          mode: walltime
+          mode: simulation
           run: cargo codspeed run -p rapid-fuzzy-bench
 
   js-benchmarks:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
         with:
-          mode: simulation
+          mode: walltime
           run: cargo codspeed run -p rapid-fuzzy-bench
 
   js-benchmarks:
@@ -72,5 +72,5 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
         with:
-          mode: simulation
-          run: pnpm run bench
+          mode: walltime
+          run: pnpm run bench:ci

--- a/__test__/batch.bench.ts
+++ b/__test__/batch.bench.ts
@@ -1,0 +1,49 @@
+import { bench, describe } from 'vitest';
+import {
+  levenshtein,
+  levenshteinMany,
+  normalizedLevenshtein,
+  normalizedLevenshteinMany,
+} from '../index.js';
+
+// --- Many candidates (1-to-N comparison) ---
+
+const manyCandidates = Array.from({ length: 1_000 }, (_, i) => {
+  const words = [
+    'kitten',
+    'sitting',
+    'saturday',
+    'sunday',
+    'hello',
+    'world',
+    'fuzzy',
+    'search',
+    'match',
+    'distance',
+  ];
+  return `${words[i % words.length]}${i}`;
+});
+
+describe('Levenshtein Distance — Many (1K candidates)', () => {
+  bench('rapid-fuzzy (many)', () => {
+    levenshteinMany('kitten', manyCandidates);
+  });
+
+  bench('rapid-fuzzy (loop)', () => {
+    for (const c of manyCandidates) {
+      levenshtein('kitten', c);
+    }
+  });
+});
+
+describe('Normalized Levenshtein — Many (1K candidates)', () => {
+  bench('rapid-fuzzy (many)', () => {
+    normalizedLevenshteinMany('kitten', manyCandidates);
+  });
+
+  bench('rapid-fuzzy (loop)', () => {
+    for (const c of manyCandidates) {
+      normalizedLevenshtein('kitten', c);
+    }
+  });
+});

--- a/__test__/distance.bench.ts
+++ b/__test__/distance.bench.ts
@@ -1,24 +1,5 @@
-// Competitors
-import { distance as fastestLevenshteinDistance } from 'fastest-levenshtein';
-import * as fuzz from 'fuzzball';
-import leven from 'leven';
-import stringSimilarity from 'string-similarity';
 import { bench, describe } from 'vitest';
-import {
-  damerauLevenshtein,
-  hamming,
-  jaro,
-  jaroWinkler,
-  levenshtein,
-  levenshteinBatch,
-  levenshteinMany,
-  normalizedLevenshtein,
-  normalizedLevenshteinMany,
-  sorensenDice,
-  tokenSetRatio,
-  tokenSortRatio,
-  weightedRatio,
-} from '../index.js';
+import { damerauLevenshtein, hamming, levenshtein, levenshteinBatch } from '../index.js';
 
 // Test data — realistic string pairs of varying length and similarity
 const pairs: [string, string][] = [
@@ -39,102 +20,6 @@ describe('Levenshtein Distance', () => {
 
   bench('rapid-fuzzy (batch)', () => {
     levenshteinBatch(pairs);
-  });
-
-  bench('fastest-levenshtein', () => {
-    for (const [a, b] of pairs) {
-      fastestLevenshteinDistance(a, b);
-    }
-  });
-
-  bench('leven', () => {
-    for (const [a, b] of pairs) {
-      leven(a, b);
-    }
-  });
-
-  bench('fuzzball', () => {
-    for (const [a, b] of pairs) {
-      fuzz.distance(a, b);
-    }
-  });
-});
-
-describe('Normalized Similarity', () => {
-  bench('rapid-fuzzy (normalizedLevenshtein)', () => {
-    for (const [a, b] of pairs) {
-      normalizedLevenshtein(a, b);
-    }
-  });
-
-  bench('string-similarity (compareTwoStrings / Dice)', () => {
-    for (const [a, b] of pairs) {
-      stringSimilarity.compareTwoStrings(a, b);
-    }
-  });
-
-  bench('rapid-fuzzy (sorensenDice)', () => {
-    for (const [a, b] of pairs) {
-      sorensenDice(a, b);
-    }
-  });
-
-  bench('fuzzball (ratio)', () => {
-    for (const [a, b] of pairs) {
-      fuzz.ratio(a, b);
-    }
-  });
-});
-
-describe('Token-Based Ratio', () => {
-  bench('rapid-fuzzy (tokenSetRatio)', () => {
-    for (const [a, b] of pairs) {
-      tokenSetRatio(a, b);
-    }
-  });
-
-  bench('rapid-fuzzy (tokenSortRatio)', () => {
-    for (const [a, b] of pairs) {
-      tokenSortRatio(a, b);
-    }
-  });
-
-  bench('rapid-fuzzy (weightedRatio)', () => {
-    for (const [a, b] of pairs) {
-      weightedRatio(a, b);
-    }
-  });
-
-  bench('fuzzball (token_set_ratio)', () => {
-    for (const [a, b] of pairs) {
-      fuzz.token_set_ratio(a, b);
-    }
-  });
-
-  bench('fuzzball (token_sort_ratio)', () => {
-    for (const [a, b] of pairs) {
-      fuzz.token_sort_ratio(a, b);
-    }
-  });
-
-  bench('fuzzball (WRatio)', () => {
-    for (const [a, b] of pairs) {
-      fuzz.WRatio(a, b);
-    }
-  });
-});
-
-describe('Jaro / Jaro-Winkler', () => {
-  bench('rapid-fuzzy (jaro)', () => {
-    for (const [a, b] of pairs) {
-      jaro(a, b);
-    }
-  });
-
-  bench('rapid-fuzzy (jaroWinkler)', () => {
-    for (const [a, b] of pairs) {
-      jaroWinkler(a, b);
-    }
   });
 });
 
@@ -160,58 +45,6 @@ describe('Hamming Distance', () => {
   bench('rapid-fuzzy', () => {
     for (const [a, b] of equalLengthPairs) {
       hamming(a, b);
-    }
-  });
-});
-
-// --- Many candidates (1-to-N comparison) ---
-
-const manyCandidates = Array.from({ length: 1_000 }, (_, i) => {
-  const words = [
-    'kitten',
-    'sitting',
-    'saturday',
-    'sunday',
-    'hello',
-    'world',
-    'fuzzy',
-    'search',
-    'match',
-    'distance',
-  ];
-  return `${words[i % words.length]}${i}`;
-});
-
-describe('Levenshtein Distance — Many (1K candidates)', () => {
-  bench('rapid-fuzzy (many)', () => {
-    levenshteinMany('kitten', manyCandidates);
-  });
-
-  bench('rapid-fuzzy (loop)', () => {
-    for (const c of manyCandidates) {
-      levenshtein('kitten', c);
-    }
-  });
-
-  bench('fastest-levenshtein (loop)', () => {
-    for (const c of manyCandidates) {
-      fastestLevenshteinDistance('kitten', c);
-    }
-  });
-
-  bench('fuzzball (extract)', () => {
-    fuzz.extract('kitten', manyCandidates, { scorer: fuzz.ratio, limit: manyCandidates.length });
-  });
-});
-
-describe('Normalized Levenshtein — Many (1K candidates)', () => {
-  bench('rapid-fuzzy (many)', () => {
-    normalizedLevenshteinMany('kitten', manyCandidates);
-  });
-
-  bench('rapid-fuzzy (loop)', () => {
-    for (const c of manyCandidates) {
-      normalizedLevenshtein('kitten', c);
     }
   });
 });

--- a/__test__/distance.compare.bench.ts
+++ b/__test__/distance.compare.bench.ts
@@ -1,0 +1,155 @@
+// Competitor comparison benchmarks (local use only, excluded from CodSpeed CI)
+import { distance as fastestLevenshteinDistance } from 'fastest-levenshtein';
+import * as fuzz from 'fuzzball';
+import leven from 'leven';
+import stringSimilarity from 'string-similarity';
+import { bench, describe } from 'vitest';
+import {
+  levenshtein,
+  levenshteinMany,
+  normalizedLevenshtein,
+  sorensenDice,
+  tokenSetRatio,
+  tokenSortRatio,
+  weightedRatio,
+} from '../index.js';
+
+// Test data — realistic string pairs of varying length and similarity
+const pairs: [string, string][] = [
+  ['kitten', 'sitting'],
+  ['saturday', 'sunday'],
+  ['rosettacode', 'raisethysword'],
+  ['pneumonoultramicroscopicsilicovolcanoconiosis', 'ultramicroscopically'],
+  ['the quick brown fox jumps over the lazy dog', 'the fast brown fox leaps over the lazy dog'],
+  ['abcdefghijklmnopqrstuvwxyz', 'zyxwvutsrqponmlkjihgfedcba'],
+];
+
+describe('Levenshtein Distance (vs competitors)', () => {
+  bench('rapid-fuzzy', () => {
+    for (const [a, b] of pairs) {
+      levenshtein(a, b);
+    }
+  });
+
+  bench('fastest-levenshtein', () => {
+    for (const [a, b] of pairs) {
+      fastestLevenshteinDistance(a, b);
+    }
+  });
+
+  bench('leven', () => {
+    for (const [a, b] of pairs) {
+      leven(a, b);
+    }
+  });
+
+  bench('fuzzball', () => {
+    for (const [a, b] of pairs) {
+      fuzz.distance(a, b);
+    }
+  });
+});
+
+describe('Normalized Similarity (vs competitors)', () => {
+  bench('rapid-fuzzy (normalizedLevenshtein)', () => {
+    for (const [a, b] of pairs) {
+      normalizedLevenshtein(a, b);
+    }
+  });
+
+  bench('string-similarity (compareTwoStrings / Dice)', () => {
+    for (const [a, b] of pairs) {
+      stringSimilarity.compareTwoStrings(a, b);
+    }
+  });
+
+  bench('rapid-fuzzy (sorensenDice)', () => {
+    for (const [a, b] of pairs) {
+      sorensenDice(a, b);
+    }
+  });
+
+  bench('fuzzball (ratio)', () => {
+    for (const [a, b] of pairs) {
+      fuzz.ratio(a, b);
+    }
+  });
+});
+
+describe('Token-Based Ratio (vs competitors)', () => {
+  bench('rapid-fuzzy (tokenSetRatio)', () => {
+    for (const [a, b] of pairs) {
+      tokenSetRatio(a, b);
+    }
+  });
+
+  bench('rapid-fuzzy (tokenSortRatio)', () => {
+    for (const [a, b] of pairs) {
+      tokenSortRatio(a, b);
+    }
+  });
+
+  bench('rapid-fuzzy (weightedRatio)', () => {
+    for (const [a, b] of pairs) {
+      weightedRatio(a, b);
+    }
+  });
+
+  bench('fuzzball (token_set_ratio)', () => {
+    for (const [a, b] of pairs) {
+      fuzz.token_set_ratio(a, b);
+    }
+  });
+
+  bench('fuzzball (token_sort_ratio)', () => {
+    for (const [a, b] of pairs) {
+      fuzz.token_sort_ratio(a, b);
+    }
+  });
+
+  bench('fuzzball (WRatio)', () => {
+    for (const [a, b] of pairs) {
+      fuzz.WRatio(a, b);
+    }
+  });
+});
+
+// --- Many candidates (1-to-N comparison) ---
+
+const manyCandidates = Array.from({ length: 1_000 }, (_, i) => {
+  const words = [
+    'kitten',
+    'sitting',
+    'saturday',
+    'sunday',
+    'hello',
+    'world',
+    'fuzzy',
+    'search',
+    'match',
+    'distance',
+  ];
+  return `${words[i % words.length]}${i}`;
+});
+
+describe('Levenshtein Distance — Many 1K (vs competitors)', () => {
+  bench('rapid-fuzzy (many)', () => {
+    levenshteinMany('kitten', manyCandidates);
+  });
+
+  bench('rapid-fuzzy (loop)', () => {
+    for (const c of manyCandidates) {
+      levenshtein('kitten', c);
+    }
+  });
+
+  bench('fastest-levenshtein (loop)', () => {
+    for (const c of manyCandidates) {
+      fastestLevenshteinDistance('kitten', c);
+    }
+  });
+
+  bench('fuzzball (extract)', () => {
+    fuzz.extract('kitten', manyCandidates, { scorer: fuzz.ratio, limit: manyCandidates.length });
+  });
+});

--- a/__test__/ratio.bench.ts
+++ b/__test__/ratio.bench.ts
@@ -1,0 +1,32 @@
+import { bench, describe } from 'vitest';
+import { tokenSetRatio, tokenSortRatio, weightedRatio } from '../index.js';
+
+// Test data — realistic string pairs of varying length and similarity
+const pairs: [string, string][] = [
+  ['kitten', 'sitting'],
+  ['saturday', 'sunday'],
+  ['rosettacode', 'raisethysword'],
+  ['pneumonoultramicroscopicsilicovolcanoconiosis', 'ultramicroscopically'],
+  ['the quick brown fox jumps over the lazy dog', 'the fast brown fox leaps over the lazy dog'],
+  ['abcdefghijklmnopqrstuvwxyz', 'zyxwvutsrqponmlkjihgfedcba'],
+];
+
+describe('Token-Based Ratio', () => {
+  bench('rapid-fuzzy (tokenSetRatio)', () => {
+    for (const [a, b] of pairs) {
+      tokenSetRatio(a, b);
+    }
+  });
+
+  bench('rapid-fuzzy (tokenSortRatio)', () => {
+    for (const [a, b] of pairs) {
+      tokenSortRatio(a, b);
+    }
+  });
+
+  bench('rapid-fuzzy (weightedRatio)', () => {
+    for (const [a, b] of pairs) {
+      weightedRatio(a, b);
+    }
+  });
+});

--- a/__test__/search.bench.ts
+++ b/__test__/search.bench.ts
@@ -1,9 +1,3 @@
-import uFuzzy from '@leeoniya/ufuzzy';
-import { closest as fastestLevenshteinClosest } from 'fastest-levenshtein';
-import { Index as FlexSearchIndex } from 'flexsearch';
-import Fuse from 'fuse.js';
-import fuzzysort from 'fuzzysort';
-import MiniSearch from 'minisearch';
 import { bench, describe } from 'vitest';
 
 import { closest, FuzzyIndex, search } from '../index.js';
@@ -139,46 +133,6 @@ const hugeItems = Array.from({ length: 100_000 }, (_, i) => {
 
 // --- Pre-initialize search instances ---
 
-// Fuse.js
-const fuseSmall = new Fuse(smallItems, { threshold: 0.4 });
-const fuseMedium = new Fuse(mediumItems, { threshold: 0.4 });
-const fuseLarge = new Fuse(largeItems, { threshold: 0.4 });
-
-// fuzzysort (prepared targets)
-const fuzzysortMediumPrepared = mediumItems.map((item) => fuzzysort.prepare(item));
-const fuzzysortLargePrepared = largeItems.map((item) => fuzzysort.prepare(item));
-const fuzzysortXlargePrepared = xlargeItems.map((item) => fuzzysort.prepare(item));
-const fuzzysortHugePrepared = hugeItems.map((item) => fuzzysort.prepare(item));
-
-// uFuzzy
-const uf = new uFuzzy();
-
-// FlexSearch (default strict tokenization — represents inverted-index search category,
-// intentionally not configured for fuzzy/typo-tolerant matching)
-const flexSmall = new FlexSearchIndex();
-for (let i = 0; i < smallItems.length; i++) flexSmall.add(i, smallItems[i]);
-const flexMedium = new FlexSearchIndex();
-for (let i = 0; i < mediumItems.length; i++) flexMedium.add(i, mediumItems[i]);
-const flexLarge = new FlexSearchIndex();
-for (let i = 0; i < largeItems.length; i++) flexLarge.add(i, largeItems[i]);
-const flexXlarge = new FlexSearchIndex();
-for (let i = 0; i < xlargeItems.length; i++) flexXlarge.add(i, xlargeItems[i]);
-const flexHuge = new FlexSearchIndex();
-for (let i = 0; i < hugeItems.length; i++) flexHuge.add(i, hugeItems[i]);
-
-// MiniSearch
-function createMiniSearch(items: string[]) {
-  const ms = new MiniSearch({ fields: ['text'], storeFields: ['text'] });
-  ms.addAll(items.map((text, id) => ({ id, text })));
-  return ms;
-}
-const miniSmall = createMiniSearch(smallItems);
-const miniMedium = createMiniSearch(mediumItems);
-const miniLarge = createMiniSearch(largeItems);
-const miniXlarge = createMiniSearch(xlargeItems);
-const miniHuge = createMiniSearch(hugeItems);
-
-// rapid-fuzzy FuzzyIndex
 const fuzzyIndexSmall = new FuzzyIndex(smallItems);
 const fuzzyIndexMedium = new FuzzyIndex(mediumItems);
 const fuzzyIndexLarge = new FuzzyIndex(largeItems);
@@ -195,26 +149,6 @@ describe('Fuzzy Search — Small (20 items)', () => {
   bench('rapid-fuzzy (FuzzyIndex)', () => {
     fuzzyIndexSmall.search('aple', { maxResults: 5 });
   });
-
-  bench('fuse.js', () => {
-    fuseSmall.search('aple', { limit: 5 });
-  });
-
-  bench('fuzzysort', () => {
-    fuzzysort.go('aple', smallItems, { limit: 5 });
-  });
-
-  bench('uFuzzy', () => {
-    uf.search(smallItems, 'aple');
-  });
-
-  bench('FlexSearch', () => {
-    flexSmall.search('aple', { limit: 5 });
-  });
-
-  bench('MiniSearch', () => {
-    miniSmall.search('aple', { fuzzy: 0.2, prefix: true });
-  });
 });
 
 describe('Fuzzy Search — Medium (1K items)', () => {
@@ -224,26 +158,6 @@ describe('Fuzzy Search — Medium (1K items)', () => {
 
   bench('rapid-fuzzy (FuzzyIndex)', () => {
     fuzzyIndexMedium.search('utils config', { maxResults: 10 });
-  });
-
-  bench('fuse.js', () => {
-    fuseMedium.search('utils config', { limit: 10 });
-  });
-
-  bench('fuzzysort', () => {
-    fuzzysort.go('utils config', fuzzysortMediumPrepared, { limit: 10 });
-  });
-
-  bench('uFuzzy', () => {
-    uf.search(mediumItems, 'utils config');
-  });
-
-  bench('FlexSearch', () => {
-    flexMedium.search('utils config', { limit: 10 });
-  });
-
-  bench('MiniSearch', () => {
-    miniMedium.search('utils config', { fuzzy: 0.2, prefix: true });
   });
 });
 
@@ -255,47 +169,11 @@ describe('Fuzzy Search — Large (10K items)', () => {
   bench('rapid-fuzzy (FuzzyIndex)', () => {
     fuzzyIndexLarge.search('handler middleware', { maxResults: 10 });
   });
-
-  bench('fuse.js', () => {
-    fuseLarge.search('handler middleware', { limit: 10 });
-  });
-
-  bench('fuzzysort', () => {
-    fuzzysort.go('handler middleware', fuzzysortLargePrepared, { limit: 10 });
-  });
-
-  bench('uFuzzy', () => {
-    uf.search(largeItems, 'handler middleware');
-  });
-
-  bench('FlexSearch', () => {
-    flexLarge.search('handler middleware', { limit: 10 });
-  });
-
-  bench('MiniSearch', () => {
-    miniLarge.search('handler middleware', { fuzzy: 0.2, prefix: true });
-  });
 });
 
 describe('Fuzzy Search — Extra Large (50K items)', () => {
   bench('rapid-fuzzy (FuzzyIndex)', () => {
     fuzzyIndexXlarge.search('handler middleware', { maxResults: 10 });
-  });
-
-  bench('fuzzysort', () => {
-    fuzzysort.go('handler middleware', fuzzysortXlargePrepared, { limit: 10 });
-  });
-
-  bench('uFuzzy', () => {
-    uf.search(xlargeItems, 'handler middleware');
-  });
-
-  bench('FlexSearch', () => {
-    flexXlarge.search('handler middleware', { limit: 10 });
-  });
-
-  bench('MiniSearch', () => {
-    miniXlarge.search('handler middleware', { fuzzy: 0.2, prefix: true });
   });
 });
 
@@ -303,67 +181,17 @@ describe('Fuzzy Search — Huge (100K items)', () => {
   bench('rapid-fuzzy (FuzzyIndex)', () => {
     fuzzyIndexHuge.search('handler middleware', { maxResults: 10 });
   });
-
-  bench('fuzzysort', () => {
-    fuzzysort.go('handler middleware', fuzzysortHugePrepared, { limit: 10 });
-  });
-
-  bench('uFuzzy', () => {
-    uf.search(hugeItems, 'handler middleware');
-  });
-
-  bench('FlexSearch', () => {
-    flexHuge.search('handler middleware', { limit: 10 });
-  });
-
-  bench('MiniSearch', () => {
-    miniHuge.search('handler middleware', { fuzzy: 0.2, prefix: true });
-  });
 });
 
 describe('Index Construction — Medium (1K items)', () => {
   bench('rapid-fuzzy (FuzzyIndex)', () => {
     new FuzzyIndex(mediumItems);
   });
-
-  bench('fuse.js', () => {
-    new Fuse(mediumItems, { threshold: 0.4 });
-  });
-
-  bench('fuzzysort (prepare)', () => {
-    mediumItems.map((item) => fuzzysort.prepare(item));
-  });
-
-  bench('FlexSearch', () => {
-    const idx = new FlexSearchIndex();
-    for (let i = 0; i < mediumItems.length; i++) idx.add(i, mediumItems[i]);
-  });
-
-  bench('MiniSearch', () => {
-    createMiniSearch(mediumItems);
-  });
 });
 
 describe('Index Construction — Large (10K items)', () => {
   bench('rapid-fuzzy (FuzzyIndex)', () => {
     new FuzzyIndex(largeItems);
-  });
-
-  bench('fuse.js', () => {
-    new Fuse(largeItems, { threshold: 0.4 });
-  });
-
-  bench('fuzzysort (prepare)', () => {
-    largeItems.map((item) => fuzzysort.prepare(item));
-  });
-
-  bench('FlexSearch', () => {
-    const idx = new FlexSearchIndex();
-    for (let i = 0; i < largeItems.length; i++) idx.add(i, largeItems[i]);
-  });
-
-  bench('MiniSearch', () => {
-    createMiniSearch(largeItems);
   });
 });
 
@@ -375,10 +203,6 @@ describe('Closest Match — Medium (1K items)', () => {
   bench('rapid-fuzzy (FuzzyIndex)', () => {
     fuzzyIndexClosestMedium.closest('src/utils42.ts');
   });
-
-  bench('fastest-levenshtein', () => {
-    fastestLevenshteinClosest('src/utils42.ts', mediumItems);
-  });
 });
 
 describe('Closest Match — Large (10K items)', () => {
@@ -388,9 +212,5 @@ describe('Closest Match — Large (10K items)', () => {
 
   bench('rapid-fuzzy (FuzzyIndex)', () => {
     fuzzyIndexClosestLarge.closest('handler_middleware_500');
-  });
-
-  bench('fastest-levenshtein', () => {
-    fastestLevenshteinClosest('handler_middleware_500', largeItems);
   });
 });

--- a/__test__/search.compare.bench.ts
+++ b/__test__/search.compare.bench.ts
@@ -1,0 +1,386 @@
+// Competitor comparison benchmarks (local use only, excluded from CodSpeed CI)
+import uFuzzy from '@leeoniya/ufuzzy';
+import { closest as fastestLevenshteinClosest } from 'fastest-levenshtein';
+import { Index as FlexSearchIndex } from 'flexsearch';
+import Fuse from 'fuse.js';
+import fuzzysort from 'fuzzysort';
+import MiniSearch from 'minisearch';
+import { bench, describe } from 'vitest';
+
+import { closest, FuzzyIndex, search } from '../index.js';
+
+// --- Test data ---
+
+// Small dataset (typical autocomplete)
+const smallItems = [
+  'apple',
+  'banana',
+  'grape',
+  'orange',
+  'pineapple',
+  'mango',
+  'strawberry',
+  'blueberry',
+  'raspberry',
+  'watermelon',
+  'kiwi',
+  'peach',
+  'plum',
+  'cherry',
+  'lemon',
+  'lime',
+  'coconut',
+  'avocado',
+  'papaya',
+  'guava',
+];
+
+// Medium dataset (file finder, ~1K items)
+const mediumItems = Array.from({ length: 1_000 }, (_, i) => {
+  const dirs = ['src', 'lib', 'test', 'docs', 'utils', 'components', 'hooks', 'services'];
+  const exts = ['.ts', '.js', '.tsx', '.jsx', '.json', '.md'];
+  const names = [
+    'index',
+    'main',
+    'utils',
+    'helper',
+    'config',
+    'types',
+    'schema',
+    'handler',
+    'service',
+    'controller',
+  ];
+  const dir = dirs[i % dirs.length];
+  const name = names[i % names.length];
+  const ext = exts[i % exts.length];
+  return `${dir}/${name}${Math.floor(i / 10)}${ext}`;
+});
+
+// Large dataset (~10K items)
+const largeItems = Array.from({ length: 10_000 }, (_, i) => {
+  const words = [
+    'async',
+    'await',
+    'function',
+    'class',
+    'interface',
+    'type',
+    'export',
+    'import',
+    'const',
+    'let',
+    'return',
+    'promise',
+    'observable',
+    'subscriber',
+    'handler',
+    'middleware',
+    'controller',
+    'service',
+    'repository',
+    'factory',
+  ];
+  return `${words[i % words.length]}_${words[(i * 7) % words.length]}_${i}`;
+});
+
+// Extra-large dataset (~50K items)
+const xlargeItems = Array.from({ length: 50_000 }, (_, i) => {
+  const words = [
+    'async',
+    'await',
+    'function',
+    'class',
+    'interface',
+    'type',
+    'export',
+    'import',
+    'const',
+    'let',
+    'return',
+    'promise',
+    'observable',
+    'subscriber',
+    'handler',
+    'middleware',
+    'controller',
+    'service',
+    'repository',
+    'factory',
+  ];
+  return `${words[i % words.length]}_${words[(i * 7) % words.length]}_${i}`;
+});
+
+// 100K dataset (scaling benchmark)
+const hugeItems = Array.from({ length: 100_000 }, (_, i) => {
+  const words = [
+    'async',
+    'await',
+    'function',
+    'class',
+    'interface',
+    'type',
+    'export',
+    'import',
+    'const',
+    'let',
+    'return',
+    'promise',
+    'observable',
+    'subscriber',
+    'handler',
+    'middleware',
+    'controller',
+    'service',
+    'repository',
+    'factory',
+  ];
+  return `${words[i % words.length]}_${words[(i * 7) % words.length]}_${i}`;
+});
+
+// --- Pre-initialize search instances ---
+
+// Fuse.js
+const fuseSmall = new Fuse(smallItems, { threshold: 0.4 });
+const fuseMedium = new Fuse(mediumItems, { threshold: 0.4 });
+const fuseLarge = new Fuse(largeItems, { threshold: 0.4 });
+
+// fuzzysort (prepared targets)
+const fuzzysortMediumPrepared = mediumItems.map((item) => fuzzysort.prepare(item));
+const fuzzysortLargePrepared = largeItems.map((item) => fuzzysort.prepare(item));
+const fuzzysortXlargePrepared = xlargeItems.map((item) => fuzzysort.prepare(item));
+const fuzzysortHugePrepared = hugeItems.map((item) => fuzzysort.prepare(item));
+
+// uFuzzy
+const uf = new uFuzzy();
+
+// FlexSearch
+const flexSmall = new FlexSearchIndex();
+for (let i = 0; i < smallItems.length; i++) flexSmall.add(i, smallItems[i]);
+const flexMedium = new FlexSearchIndex();
+for (let i = 0; i < mediumItems.length; i++) flexMedium.add(i, mediumItems[i]);
+const flexLarge = new FlexSearchIndex();
+for (let i = 0; i < largeItems.length; i++) flexLarge.add(i, largeItems[i]);
+const flexXlarge = new FlexSearchIndex();
+for (let i = 0; i < xlargeItems.length; i++) flexXlarge.add(i, xlargeItems[i]);
+const flexHuge = new FlexSearchIndex();
+for (let i = 0; i < hugeItems.length; i++) flexHuge.add(i, hugeItems[i]);
+
+// MiniSearch
+function createMiniSearch(items: string[]) {
+  const ms = new MiniSearch({ fields: ['text'], storeFields: ['text'] });
+  ms.addAll(items.map((text, id) => ({ id, text })));
+  return ms;
+}
+const miniSmall = createMiniSearch(smallItems);
+const miniMedium = createMiniSearch(mediumItems);
+const miniLarge = createMiniSearch(largeItems);
+const miniXlarge = createMiniSearch(xlargeItems);
+const miniHuge = createMiniSearch(hugeItems);
+
+// rapid-fuzzy FuzzyIndex
+const fuzzyIndexSmall = new FuzzyIndex(smallItems);
+const fuzzyIndexMedium = new FuzzyIndex(mediumItems);
+const fuzzyIndexLarge = new FuzzyIndex(largeItems);
+const fuzzyIndexClosestMedium = new FuzzyIndex(mediumItems);
+const fuzzyIndexClosestLarge = new FuzzyIndex(largeItems);
+
+describe('Fuzzy Search — Small 20 (vs competitors)', () => {
+  bench('rapid-fuzzy', () => {
+    search('aple', smallItems, 5);
+  });
+
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    fuzzyIndexSmall.search('aple', { maxResults: 5 });
+  });
+
+  bench('fuse.js', () => {
+    fuseSmall.search('aple', { limit: 5 });
+  });
+
+  bench('fuzzysort', () => {
+    fuzzysort.go('aple', smallItems, { limit: 5 });
+  });
+
+  bench('uFuzzy', () => {
+    uf.search(smallItems, 'aple');
+  });
+
+  bench('FlexSearch', () => {
+    flexSmall.search('aple', { limit: 5 });
+  });
+
+  bench('MiniSearch', () => {
+    miniSmall.search('aple', { fuzzy: 0.2, prefix: true });
+  });
+});
+
+describe('Fuzzy Search — Medium 1K (vs competitors)', () => {
+  bench('rapid-fuzzy', () => {
+    search('utils config', mediumItems, 10);
+  });
+
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    fuzzyIndexMedium.search('utils config', { maxResults: 10 });
+  });
+
+  bench('fuse.js', () => {
+    fuseMedium.search('utils config', { limit: 10 });
+  });
+
+  bench('fuzzysort', () => {
+    fuzzysort.go('utils config', fuzzysortMediumPrepared, { limit: 10 });
+  });
+
+  bench('uFuzzy', () => {
+    uf.search(mediumItems, 'utils config');
+  });
+
+  bench('FlexSearch', () => {
+    flexMedium.search('utils config', { limit: 10 });
+  });
+
+  bench('MiniSearch', () => {
+    miniMedium.search('utils config', { fuzzy: 0.2, prefix: true });
+  });
+});
+
+describe('Fuzzy Search — Large 10K (vs competitors)', () => {
+  bench('rapid-fuzzy', () => {
+    search('handler middleware', largeItems, 10);
+  });
+
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    fuzzyIndexLarge.search('handler middleware', { maxResults: 10 });
+  });
+
+  bench('fuse.js', () => {
+    fuseLarge.search('handler middleware', { limit: 10 });
+  });
+
+  bench('fuzzysort', () => {
+    fuzzysort.go('handler middleware', fuzzysortLargePrepared, { limit: 10 });
+  });
+
+  bench('uFuzzy', () => {
+    uf.search(largeItems, 'handler middleware');
+  });
+
+  bench('FlexSearch', () => {
+    flexLarge.search('handler middleware', { limit: 10 });
+  });
+
+  bench('MiniSearch', () => {
+    miniLarge.search('handler middleware', { fuzzy: 0.2, prefix: true });
+  });
+});
+
+describe('Fuzzy Search — Extra Large 50K (vs competitors)', () => {
+  bench('fuzzysort', () => {
+    fuzzysort.go('handler middleware', fuzzysortXlargePrepared, { limit: 10 });
+  });
+
+  bench('uFuzzy', () => {
+    uf.search(xlargeItems, 'handler middleware');
+  });
+
+  bench('FlexSearch', () => {
+    flexXlarge.search('handler middleware', { limit: 10 });
+  });
+
+  bench('MiniSearch', () => {
+    miniXlarge.search('handler middleware', { fuzzy: 0.2, prefix: true });
+  });
+});
+
+describe('Fuzzy Search — Huge 100K (vs competitors)', () => {
+  bench('fuzzysort', () => {
+    fuzzysort.go('handler middleware', fuzzysortHugePrepared, { limit: 10 });
+  });
+
+  bench('uFuzzy', () => {
+    uf.search(hugeItems, 'handler middleware');
+  });
+
+  bench('FlexSearch', () => {
+    flexHuge.search('handler middleware', { limit: 10 });
+  });
+
+  bench('MiniSearch', () => {
+    miniHuge.search('handler middleware', { fuzzy: 0.2, prefix: true });
+  });
+});
+
+describe('Index Construction — Medium 1K (vs competitors)', () => {
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    new FuzzyIndex(mediumItems);
+  });
+
+  bench('fuse.js', () => {
+    new Fuse(mediumItems, { threshold: 0.4 });
+  });
+
+  bench('fuzzysort (prepare)', () => {
+    mediumItems.map((item) => fuzzysort.prepare(item));
+  });
+
+  bench('FlexSearch', () => {
+    const idx = new FlexSearchIndex();
+    for (let i = 0; i < mediumItems.length; i++) idx.add(i, mediumItems[i]);
+  });
+
+  bench('MiniSearch', () => {
+    createMiniSearch(mediumItems);
+  });
+});
+
+describe('Index Construction — Large 10K (vs competitors)', () => {
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    new FuzzyIndex(largeItems);
+  });
+
+  bench('fuse.js', () => {
+    new Fuse(largeItems, { threshold: 0.4 });
+  });
+
+  bench('fuzzysort (prepare)', () => {
+    largeItems.map((item) => fuzzysort.prepare(item));
+  });
+
+  bench('FlexSearch', () => {
+    const idx = new FlexSearchIndex();
+    for (let i = 0; i < largeItems.length; i++) idx.add(i, largeItems[i]);
+  });
+
+  bench('MiniSearch', () => {
+    createMiniSearch(largeItems);
+  });
+});
+
+describe('Closest Match — Medium 1K (vs competitors)', () => {
+  bench('rapid-fuzzy', () => {
+    closest('src/utils42.ts', mediumItems);
+  });
+
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    fuzzyIndexClosestMedium.closest('src/utils42.ts');
+  });
+
+  bench('fastest-levenshtein', () => {
+    fastestLevenshteinClosest('src/utils42.ts', mediumItems);
+  });
+});
+
+describe('Closest Match — Large 10K (vs competitors)', () => {
+  bench('rapid-fuzzy', () => {
+    closest('handler_middleware_500', largeItems);
+  });
+
+  bench('rapid-fuzzy (FuzzyIndex)', () => {
+    fuzzyIndexClosestLarge.closest('handler_middleware_500');
+  });
+
+  bench('fastest-levenshtein', () => {
+    fastestLevenshteinClosest('handler_middleware_500', largeItems);
+  });
+});

--- a/__test__/similarity.bench.ts
+++ b/__test__/similarity.bench.ts
@@ -1,0 +1,40 @@
+import { bench, describe } from 'vitest';
+import { jaro, jaroWinkler, normalizedLevenshtein, sorensenDice } from '../index.js';
+
+// Test data — realistic string pairs of varying length and similarity
+const pairs: [string, string][] = [
+  ['kitten', 'sitting'],
+  ['saturday', 'sunday'],
+  ['rosettacode', 'raisethysword'],
+  ['pneumonoultramicroscopicsilicovolcanoconiosis', 'ultramicroscopically'],
+  ['the quick brown fox jumps over the lazy dog', 'the fast brown fox leaps over the lazy dog'],
+  ['abcdefghijklmnopqrstuvwxyz', 'zyxwvutsrqponmlkjihgfedcba'],
+];
+
+describe('Normalized Similarity', () => {
+  bench('rapid-fuzzy (normalizedLevenshtein)', () => {
+    for (const [a, b] of pairs) {
+      normalizedLevenshtein(a, b);
+    }
+  });
+
+  bench('rapid-fuzzy (sorensenDice)', () => {
+    for (const [a, b] of pairs) {
+      sorensenDice(a, b);
+    }
+  });
+});
+
+describe('Jaro / Jaro-Winkler', () => {
+  bench('rapid-fuzzy (jaro)', () => {
+    for (const [a, b] of pairs) {
+      jaro(a, b);
+    }
+  });
+
+  bench('rapid-fuzzy (jaroWinkler)', () => {
+    for (const [a, b] of pairs) {
+      jaroWinkler(a, b);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "test:deno": "deno test --allow-read --allow-env --allow-net --node-modules-dir=auto e2e/wasm-deno.test.ts",
     "test:watch": "vitest watch",
     "bench": "vitest bench",
+    "bench:ci": "vitest bench --exclude '**/*.compare.bench.ts'",
     "bench:readme": "npx tsx scripts/update-bench-readme.ts",
     "bench:charts": "npx tsx scripts/generate-bench-charts.ts",
     "publint": "publint",


### PR DESCRIPTION
## Summary

- Split JS benchmarks into 5 focused files by feature area for clearer CodSpeed regression tracking
- Move competitor benchmarks (fuse.js, leven, fuzzball, etc.) to `*.compare.bench.ts` files excluded from CodSpeed CI
- Switch CodSpeed from `simulation` to `walltime` mode

### Benchmark file structure

| File | Feature area | Benchmarks |
|------|-------------|-----------|
| `distance.bench.ts` | Edit distance | levenshtein, levenshteinBatch, damerauLevenshtein, hamming |
| `similarity.bench.ts` | Similarity scores | normalizedLevenshtein, sorensenDice, jaro, jaroWinkler |
| `ratio.bench.ts` | Token-based ratios | tokenSetRatio, tokenSortRatio, weightedRatio |
| `batch.bench.ts` | 1:N operations | levenshteinMany, normalizedLevenshteinMany |
| `search.bench.ts` | Fuzzy search | search, closest, FuzzyIndex, index construction |
| `*.compare.bench.ts` | Competitor comparison | Local use only, excluded from CodSpeed |

### CodSpeed changes

- `mode: simulation` → `mode: walltime` for more realistic performance tracking
- `pnpm run bench` → `pnpm run bench:ci` to exclude competitor benchmarks

All `describe` + `bench` names are preserved to maintain CodSpeed benchmark history.

Closes #371

## Checklist

- [x] Benchmark names unchanged (CodSpeed history preserved)
- [x] `bench:ci` script excludes `*.compare.bench.ts`
- [x] `pnpm run bench` still runs all benchmarks locally (including competitors)
- [x] All checks pass (lint, typecheck, test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added multiple new benchmark suites covering batch, distance, similarity, ratio, and search scenarios.
  * Consolidated and focused benchmarks to prioritize core implementations and 1→N performance.
  * Removed many third‑party competitor integrations from primary benchmark runs to simplify comparisons.
  * Added a CI-friendly benchmark run that excludes extended comparison suites.

* **Chores**
  * Benchmark workflow updated to use walltime measurement mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->