### PR TITLE
feat(js): add serialize() and deserialize() to FuzzyObjectIndex

### DIFF
--- a/.changeset/object-index-serialize.md
+++ b/.changeset/object-index-serialize.md
@@ -1,0 +1,5 @@
+---
+"rapid-fuzzy": minor
+---
+
+Add `serialize()` and `static deserialize()` to `FuzzyObjectIndex`, enabling SSR/SSG pre-building patterns where the index is constructed at build time and shipped as a binary blob for fast client-side initialization.

--- a/__test__/objects.spec.ts
+++ b/__test__/objects.spec.ts
@@ -290,3 +290,46 @@ describe('FuzzyObjectIndex', () => {
     expect(results[0].item.user.name).toBe('Alice');
   });
 });
+
+describe('FuzzyObjectIndex.serialize / deserialize', () => {
+  const items = [
+    { name: 'John Smith', email: 'john@example.com' },
+    { name: 'Jane Doe', email: 'jane@example.com' },
+    { name: 'Bob Johnson', email: 'bob@test.com' },
+  ];
+  const options = { keys: [{ name: 'name', weight: 2.0 }, 'email'] };
+
+  it('should round-trip search results', () => {
+    const original = new FuzzyObjectIndex(items, options);
+    const buf = original.serialize();
+    const restored = FuzzyObjectIndex.deserialize(buf);
+
+    const originalResults = original.search('john');
+    const restoredResults = restored.search('john');
+
+    expect(restoredResults.length).toBe(originalResults.length);
+    for (let i = 0; i < originalResults.length; i++) {
+      expect(restoredResults[i].item).toEqual(originalResults[i].item);
+      expect(Math.abs(restoredResults[i].score - originalResults[i].score)).toBeLessThan(0.001);
+    }
+  });
+
+  it('should round-trip size and items', () => {
+    const original = new FuzzyObjectIndex(items, options);
+    const restored = FuzzyObjectIndex.deserialize(original.serialize());
+    expect(restored.size).toBe(items.length);
+    expect(restored.closest('jane')).toEqual(items[1]);
+  });
+
+  it('should serialize an empty index', () => {
+    const original = new FuzzyObjectIndex([], options);
+    const restored = FuzzyObjectIndex.deserialize(original.serialize());
+    expect(restored.size).toBe(0);
+    expect(restored.search('anything')).toEqual([]);
+  });
+
+  it('should return a Buffer', () => {
+    const index = new FuzzyObjectIndex(items, options);
+    expect(Buffer.isBuffer(index.serialize())).toBe(true);
+  });
+});

--- a/objects.d.ts
+++ b/objects.d.ts
@@ -98,4 +98,17 @@ export declare class FuzzyObjectIndex<T> {
 
   /** Free all internal data. */
   destroy(): void;
+
+  /**
+   * Serialize the index and its items to a Buffer.
+   *
+   * Items must be JSON-serializable. Pass the result to
+   * `FuzzyObjectIndex.deserialize()` to reconstruct the index.
+   */
+  serialize(): Buffer;
+
+  /**
+   * Reconstruct a `FuzzyObjectIndex` from a Buffer produced by `serialize()`.
+   */
+  static deserialize<T>(buffer: Buffer): FuzzyObjectIndex<T>;
 }

--- a/objects.js
+++ b/objects.js
@@ -74,12 +74,15 @@ class FuzzyObjectIndex {
   /** @type {Array<{ name: string; weight: number }>} */
   #keys;
 
+  static #SENTINEL = Symbol('FuzzyObjectIndex.internal');
+
   /**
    * @param {T[]} items - Array of objects to index.
    * @param {object} options - Index configuration.
    * @param {Array<string | { name: string; weight?: number }>} options.keys - Keys to search.
    */
-  constructor(items, options) {
+  constructor(items, options, _sentinel) {
+    if (_sentinel === FuzzyObjectIndex.#SENTINEL) return;
     if (!options?.keys?.length) {
       throw new TypeError('options.keys must be a non-empty array');
     }
@@ -169,6 +172,52 @@ class FuzzyObjectIndex {
   destroy() {
     this.#items = [];
     this.#index.destroy();
+  }
+
+  /**
+   * Serialize the index and its items to a Buffer for storage or transfer.
+   *
+   * Items must be JSON-serializable. The returned Buffer can be passed to
+   * `FuzzyObjectIndex.deserialize()` to reconstruct the index without
+   * re-processing the original data.
+   *
+   * @returns {Buffer}
+   */
+  serialize() {
+    const metaStr = JSON.stringify({ items: this.#items, keys: this.#keys });
+    const metaBuf = Buffer.from(metaStr, 'utf8');
+    const indexBuf = this.#index.serialize();
+    const header = Buffer.allocUnsafe(4);
+    header.writeUInt32LE(metaBuf.length, 0);
+    return Buffer.concat([header, metaBuf, indexBuf]);
+  }
+
+  /**
+   * @param {Array<T>} items
+   * @param {Array<{ name: string; weight: number }>} keys
+   * @param {KeyedFuzzyIndex} index
+   * @returns {FuzzyObjectIndex<T>}
+   */
+  static #fromState(items, keys, index) {
+    const instance = new FuzzyObjectIndex(undefined, undefined, FuzzyObjectIndex.#SENTINEL);
+    instance.#items = items;
+    instance.#keys = keys;
+    instance.#index = index;
+    return instance;
+  }
+
+  /**
+   * Reconstruct a `FuzzyObjectIndex` from a Buffer produced by `serialize()`.
+   *
+   * @template T
+   * @param {Buffer} buffer - A Buffer previously returned by `serialize()`.
+   * @returns {FuzzyObjectIndex<T>}
+   */
+  static deserialize(buffer) {
+    const metaLen = buffer.readUInt32LE(0);
+    const { items, keys } = JSON.parse(buffer.subarray(4, 4 + metaLen).toString('utf8'));
+    const index = KeyedFuzzyIndex.deserialize(buffer.subarray(4 + metaLen));
+    return FuzzyObjectIndex.#fromState(items, keys, index);
   }
 }
 


### PR DESCRIPTION
## Summary

Add `serialize()` and `static deserialize()` to `FuzzyObjectIndex`, enabling SSR/SSG pre-building patterns.

**Serialization format:** `[meta_len: uint32 LE][meta JSON: items + keys config][KeyedFuzzyIndex binary]`

The binary from `KeyedFuzzyIndex.serialize()` (merged in #431) is embedded verbatim. Items are JSON-serialized, so they must be JSON-compatible.

**Usage pattern:**
```typescript
// Build time (SSG/SSR)
const index = new FuzzyObjectIndex(items, { keys: ['name', 'email'] });
fs.writeFileSync('search-index.bin', index.serialize());

// Runtime
const index = FuzzyObjectIndex.deserialize(fs.readFileSync('search-index.bin'));
const results = index.search('john');
```

## Related issues

Closes #418
Depends on #431 (KeyedFuzzyIndex.serialize — already merged)

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (272 tests, +4 new serialization round-trip tests)
- [x] TypeScript declarations updated in `objects.d.ts`
- [x] Changeset added