### PR TITLE
feat(search): add FuzzyIndex.fromAsync() for non-blocking index construction

### DIFF
--- a/.changeset/async-fuzzy-index.md
+++ b/.changeset/async-fuzzy-index.md
@@ -1,0 +1,5 @@
+---
+"rapid-fuzzy": minor
+---
+
+Add `FuzzyIndex.fromAsync(items)` static factory that constructs the index on the libuv thread pool, returning `Promise<FuzzyIndex>`. For large datasets this keeps the JavaScript event loop unblocked during index construction — useful in Next.js API routes, Nuxt server handlers, and other environments where blocking is a concern.

--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -1436,6 +1436,42 @@ describe('FuzzyIndex', () => {
   });
 });
 
+describe('FuzzyIndex.fromAsync', () => {
+  const items = ['apple', 'banana', 'grape', 'orange', 'pineapple'];
+
+  it('should return a Promise', () => {
+    const result = FuzzyIndex.fromAsync(items);
+    expect(result).toBeInstanceOf(Promise);
+    return result;
+  });
+
+  it('should resolve to a FuzzyIndex with correct size', async () => {
+    const index = await FuzzyIndex.fromAsync(items);
+    expect(index).toBeInstanceOf(FuzzyIndex);
+    expect(index.size).toBe(items.length);
+  });
+
+  it('should produce search results matching the synchronous constructor', async () => {
+    const syncIndex = new FuzzyIndex(items);
+    const asyncIndex = await FuzzyIndex.fromAsync(items);
+
+    const syncResults = syncIndex.search('aple');
+    const asyncResults = asyncIndex.search('aple');
+
+    expect(asyncResults.length).toBe(syncResults.length);
+    for (let i = 0; i < syncResults.length; i++) {
+      expect(asyncResults[i]?.item).toBe(syncResults[i]?.item);
+      expect(asyncResults[i]?.score).toBeCloseTo(syncResults[i]?.score ?? 0);
+    }
+  });
+
+  it('should handle empty items', async () => {
+    const index = await FuzzyIndex.fromAsync([]);
+    expect(index.size).toBe(0);
+    expect(index.search('anything')).toEqual([]);
+  });
+});
+
 describe('FuzzyIndex serialization', () => {
   it('should round-trip serialize and deserialize', () => {
     const items = ['TypeScript', 'JavaScript', 'Python', 'Rust'];

--- a/crates/core/src/search/index.rs
+++ b/crates/core/src/search/index.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
-use napi::Either;
-use napi::bindgen_prelude::Buffer;
+use napi::bindgen_prelude::{AsyncTask, Buffer};
+use napi::{Either, Task};
 use napi_derive::napi;
 use nucleo_matcher::pattern::CaseMatching;
 use nucleo_matcher::{Config, Matcher, Utf32String};
@@ -11,6 +11,51 @@ use super::{
     compute_char_mask, extract_query_bigrams, intersect_sorted, resolve_case_matching,
     search_over_precomputed, search_over_precomputed_indices,
 };
+
+/// Precomputed index data — all fields `Send`, used to transfer work off the event loop.
+pub struct FuzzyIndexData {
+    items: Vec<String>,
+    utf32_items: Vec<Utf32String>,
+    char_masks: Vec<u64>,
+    bigram_index: BigramIndex,
+}
+
+pub struct BuildFuzzyIndexTask {
+    items: Vec<String>,
+}
+
+impl Task for BuildFuzzyIndexTask {
+    type Output = FuzzyIndexData;
+    type JsValue = FuzzyIndex;
+
+    fn compute(&mut self) -> napi::Result<Self::Output> {
+        let utf32_items: Vec<Utf32String> = self
+            .items
+            .iter()
+            .map(|s| Utf32String::from(s.as_str()))
+            .collect();
+        let char_masks: Vec<u64> = self.items.iter().map(|s| compute_char_mask(s)).collect();
+        let bigram_index = BigramIndex::new(&self.items);
+        Ok(FuzzyIndexData {
+            items: std::mem::take(&mut self.items),
+            utf32_items,
+            char_masks,
+            bigram_index,
+        })
+    }
+
+    fn resolve(&mut self, _env: napi::Env, output: Self::Output) -> napi::Result<Self::JsValue> {
+        Ok(FuzzyIndex {
+            items: output.items,
+            utf32_items: output.utf32_items,
+            char_masks: output.char_masks,
+            bigram_index: output.bigram_index,
+            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
+            last_query: RefCell::new(String::new()),
+            last_matching_indices: RefCell::new(Vec::new()),
+        })
+    }
+}
 
 /// Minimum dataset size for bigram pre-filtering at query time.
 /// Below this threshold, the overhead of bigram intersection exceeds the
@@ -58,6 +103,15 @@ impl FuzzyIndex {
             last_query: RefCell::new(String::new()),
             last_matching_indices: RefCell::new(Vec::new()),
         }
+    }
+
+    /// Construct a FuzzyIndex on the libuv thread pool, returning a Promise.
+    ///
+    /// For large datasets this keeps the JavaScript event loop unblocked during
+    /// index construction. The synchronous constructor is fine for small datasets.
+    #[napi(ts_return_type = "Promise<FuzzyIndex>")]
+    pub fn from_async(items: Vec<String>) -> AsyncTask<BuildFuzzyIndexTask> {
+        AsyncTask::new(BuildFuzzyIndexTask { items })
     }
 
     /// Return the number of items in the index.

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,13 @@
 export declare class FuzzyIndex {
   /** Create a new FuzzyIndex from an array of strings. */
   constructor(items: Array<string>)
+  /**
+   * Construct a FuzzyIndex on the libuv thread pool, returning a Promise.
+   *
+   * For large datasets this keeps the JavaScript event loop unblocked during
+   * index construction. The synchronous constructor is fine for small datasets.
+   */
+  static fromAsync(items: Array<string>): Promise<FuzzyIndex>
   /** Return the number of items in the index. */
   get size(): number
   /**


### PR DESCRIPTION
## Summary

- Adds `static fromAsync(items: string[]): Promise<FuzzyIndex>` to `FuzzyIndex`
- Construction runs on the libuv thread pool via a napi `Task` implementation
- The heavy work (UTF-32 conversion, char mask computation, bigram index build) runs off the event loop; `RefCell`-based matcher state is initialized on the main thread in `resolve()`
- No changes to the synchronous constructor; `fromAsync` is a pure addition

**Usage:**
```typescript
// Non-blocking — event loop stays free during index construction
const index = await FuzzyIndex.fromAsync(largeDataset);
const results = index.search('query');
```

## Implementation notes

- `FuzzyIndexData` (intermediate Send struct) carries precomputed `Utf32String`, char masks, and the bigram index across the thread boundary
- `BuildFuzzyIndexTask::resolve()` assembles the final `FuzzyIndex` on the main thread where `RefCell` usage is safe
- `ts_return_type = "Promise<FuzzyIndex>"` annotation gives the correct TypeScript return type

## Related issue

Closes #416

## Checklist

- [x] 4 new tests: returns Promise, resolves to correct FuzzyIndex, matches sync constructor results, handles empty items
- [x] All 276 tests pass
- [x] Rust clippy, biome lint, and TypeScript typecheck pass
- [x] Generated `index.d.ts` shows correct `Promise<FuzzyIndex>` return type
- [x] Changeset created