### PR TITLE
fix(test): update WASM search test to verify sort order instead of specific item

### DIFF
--- a/__test__/wasm.spec.ts
+++ b/__test__/wasm.spec.ts
@@ -325,7 +325,10 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
     it('search should return sorted results', () => {
       const results = wasm.search('type', ['TypeScript', 'JavaScript', 'Python', 'TypeSpec']);
       expect(results.length).toBeGreaterThan(0);
-      expect(results[0].item).toBe('TypeScript');
+      // Verify results are sorted by score descending
+      for (let i = 1; i < results.length; i++) {
+        expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+      }
       expect(results[0]).toHaveProperty('score');
       expect(results[0]).toHaveProperty('index');
     });


### PR DESCRIPTION
## Summary

- Removes a fragile item-name assertion from the WASM search test that broke due to a tiebreaker change in PR #237
- Replaces it with a score-ordering check that matches the test's stated intent ("search should return sorted results")

## Root Cause

When `'type'` is searched against `['TypeScript', 'JavaScript', 'Python', 'TypeSpec']`, both `TypeSpec` and `TypeScript` score 1.0. PR #237 added a length-based tiebreaker (shorter items first), so `TypeSpec` (8 bytes) now correctly outranks `TypeScript` (10 bytes). The test was written before that tiebreaker existed and expected `TypeScript` first.

This only caused local failures — the Node.js CI test matrix does not include the WASM binary, so `wasm.spec.ts` is always skipped there.

## Related issue

Closes #437

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes
- [x] `cargo test` passes
- [x] `cargo clippy -- -W clippy::all` passes