### PR TITLE
feat(wasm): add wasm-bindgen browser binding crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +911,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapid-fuzzy-wasm"
+version = "1.1.1"
+dependencies = [
+ "js-sys",
+ "nucleo-matcher",
+ "rapid-fuzzy-core",
+ "rapidfuzz",
+ "serde",
+ "serde-wasm-bindgen",
+ "strsim",
+ "tsify-next",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "rapidfuzz"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1043,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1067,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1107,6 +1157,32 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tsify-next"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0f2208feeb5f7a6edb15a2389c14cd42480ef6417318316bb866da5806a61d"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tsify-next-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-next-macros"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81253930d0d388a3ab8fa4ae56da9973ab171ef833d1be2e9080fc3ce502bd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,7 +921,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "strsim",
- "tsify-next",
+ "tsify",
  "wasm-bindgen",
 ]
 
@@ -1160,24 +1160,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tsify-next"
+name = "tsify"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0f2208feeb5f7a6edb15a2389c14cd42480ef6417318316bb866da5806a61d"
+checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
 dependencies = [
  "gloo-utils",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "tsify-next-macros",
+ "tsify-macros",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "tsify-next-macros"
+name = "tsify-macros"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81253930d0d388a3ab8fa4ae56da9973ab171ef833d1be2e9080fc3ce502bd6"
+checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/core", "crates/core-lib", "crates/bench"]
+members = ["crates/core", "crates/core-lib", "crates/wasm", "crates/bench"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rapid-fuzzy-wasm"
+version = "1.1.1"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+rapid-fuzzy-core = { path = "../core-lib" }
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+tsify-next = { version = "0.5", features = ["js"] }
+nucleo-matcher = { workspace = true }
+strsim = { workspace = true }
+rapidfuzz = { workspace = true }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -14,7 +14,7 @@ wasm-bindgen = "0.2"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
-tsify-next = { version = "0.5", features = ["js"] }
+tsify = { version = "0.5", features = ["js"] }
 nucleo-matcher = { workspace = true }
 strsim = { workspace = true }
 rapidfuzz = { workspace = true }

--- a/crates/wasm/src/distance/mod.rs
+++ b/crates/wasm/src/distance/mod.rs
@@ -1,0 +1,757 @@
+use rapidfuzz::distance::damerau_levenshtein as rapid_damerau;
+use rapidfuzz::distance::hamming as rapid_hamming;
+use rapidfuzz::distance::indel as rapid_indel;
+use rapidfuzz::distance::jaro as rapid_jaro;
+use rapidfuzz::distance::jaro_winkler as rapid_jw;
+use rapidfuzz::distance::levenshtein as rapid_lev;
+use wasm_bindgen::prelude::*;
+
+fn batch_apply<T: Default + serde::Serialize, F: Fn(&str, &str) -> T>(
+    pairs: JsValue,
+    f: F,
+) -> JsValue {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return JsValue::from(js_sys::Array::new()),
+    };
+    let results: Vec<T> = pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                f(&pair[0], &pair[1])
+            } else {
+                T::default()
+            }
+        })
+        .collect();
+    serde_wasm_bindgen::to_value(&results).unwrap_or(JsValue::NULL)
+}
+
+// ─── Levenshtein ────────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = "levenshtein")]
+pub fn levenshtein(a: String, b: String) -> u32 {
+    rapid_lev::distance(a.chars(), b.chars()) as u32
+}
+
+#[wasm_bindgen(js_name = "levenshteinBatch")]
+pub fn levenshtein_batch(pairs: JsValue) -> Vec<u32> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                rapid_lev::distance(pair[0].chars(), pair[1].chars()) as u32
+            } else {
+                0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "levenshteinMany")]
+pub fn levenshtein_many(
+    reference: String,
+    candidates: Vec<String>,
+    max_distance: Option<u32>,
+) -> Vec<u32> {
+    let scorer = rapid_lev::BatchComparator::new(reference.chars());
+    match max_distance {
+        Some(cutoff) => {
+            let args = rapid_lev::Args::default().score_cutoff(cutoff as usize);
+            let sentinel = cutoff + 1;
+            candidates
+                .iter()
+                .map(|c| {
+                    scorer
+                        .distance_with_args(c.chars(), &args)
+                        .map_or(sentinel, |d| d as u32)
+                })
+                .collect()
+        }
+        None => candidates
+            .iter()
+            .map(|c| scorer.distance(c.chars()) as u32)
+            .collect(),
+    }
+}
+
+// ─── Damerau-Levenshtein ────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = "damerauLevenshtein")]
+pub fn damerau_levenshtein(a: String, b: String) -> u32 {
+    rapid_damerau::distance(a.chars(), b.chars()) as u32
+}
+
+#[wasm_bindgen(js_name = "damerauLevenshteinBatch")]
+pub fn damerau_levenshtein_batch(pairs: JsValue) -> Vec<u32> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                rapid_damerau::distance(pair[0].chars(), pair[1].chars()) as u32
+            } else {
+                0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "damerauLevenshteinMany")]
+pub fn damerau_levenshtein_many(
+    reference: String,
+    candidates: Vec<String>,
+    max_distance: Option<u32>,
+) -> Vec<u32> {
+    let scorer = rapid_damerau::BatchComparator::new(reference.chars());
+    match max_distance {
+        Some(cutoff) => {
+            let args = rapid_damerau::Args::default().score_cutoff(cutoff as usize);
+            let sentinel = cutoff + 1;
+            candidates
+                .iter()
+                .map(|c| {
+                    scorer
+                        .distance_with_args(c.chars(), &args)
+                        .map_or(sentinel, |d| d as u32)
+                })
+                .collect()
+        }
+        None => candidates
+            .iter()
+            .map(|c| scorer.distance(c.chars()) as u32)
+            .collect(),
+    }
+}
+
+// ─── Hamming ─────────────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = "hamming")]
+pub fn hamming(a: String, b: String) -> JsValue {
+    match rapid_hamming::distance(a.chars(), b.chars()) {
+        Ok(d) => JsValue::from_f64(d as f64),
+        Err(_) => JsValue::NULL,
+    }
+}
+
+#[wasm_bindgen(js_name = "hammingBatch")]
+pub fn hamming_batch(pairs: JsValue) -> JsValue {
+    batch_apply::<Option<u32>, _>(pairs, |a, b| {
+        rapid_hamming::distance(a.chars(), b.chars())
+            .ok()
+            .map(|d| d as u32)
+    })
+}
+
+#[wasm_bindgen(js_name = "hammingMany")]
+pub fn hamming_many(
+    reference: String,
+    candidates: Vec<String>,
+    max_distance: Option<u32>,
+) -> JsValue {
+    let scorer = rapid_hamming::BatchComparator::new(reference.chars());
+    let results: Vec<Option<u32>> = match max_distance {
+        Some(cutoff) => {
+            let args = rapid_hamming::Args::default().score_cutoff(cutoff as usize);
+            candidates
+                .iter()
+                .map(|c| {
+                    scorer
+                        .distance_with_args(c.chars(), &args)
+                        .ok()
+                        .flatten()
+                        .map(|d| d as u32)
+                })
+                .collect()
+        }
+        None => candidates
+            .iter()
+            .map(|c| scorer.distance(c.chars()).ok().map(|d| d as u32))
+            .collect(),
+    };
+    serde_wasm_bindgen::to_value(&results).unwrap_or(JsValue::NULL)
+}
+
+// ─── Normalized Hamming ──────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = "normalizedHamming")]
+pub fn normalized_hamming(a: String, b: String) -> JsValue {
+    match rapid_hamming::normalized_similarity(a.chars(), b.chars()) {
+        Ok(s) => JsValue::from_f64(s),
+        Err(_) => JsValue::NULL,
+    }
+}
+
+#[wasm_bindgen(js_name = "normalizedHammingBatch")]
+pub fn normalized_hamming_batch(pairs: JsValue) -> JsValue {
+    batch_apply::<Option<f64>, _>(pairs, |a, b| {
+        rapid_hamming::normalized_similarity(a.chars(), b.chars()).ok()
+    })
+}
+
+#[wasm_bindgen(js_name = "normalizedHammingMany")]
+pub fn normalized_hamming_many(
+    reference: String,
+    candidates: Vec<String>,
+    score_cutoff: Option<f64>,
+) -> JsValue {
+    let scorer = rapid_hamming::BatchComparator::new(reference.chars());
+    let results: Vec<Option<f64>> = match score_cutoff {
+        Some(cutoff) => {
+            let args = rapid_hamming::Args::default().score_cutoff(cutoff);
+            candidates
+                .iter()
+                .map(|c| {
+                    scorer
+                        .normalized_similarity_with_args(c.chars(), &args)
+                        .ok()
+                        .flatten()
+                })
+                .collect()
+        }
+        None => candidates
+            .iter()
+            .map(|c| scorer.normalized_similarity(c.chars()).ok())
+            .collect(),
+    };
+    serde_wasm_bindgen::to_value(&results).unwrap_or(JsValue::NULL)
+}
+
+// ─── Jaro ────────────────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = "jaro")]
+pub fn jaro(a: String, b: String) -> f64 {
+    rapid_jaro::normalized_similarity(a.chars(), b.chars())
+}
+
+#[wasm_bindgen(js_name = "jaroBatch")]
+pub fn jaro_batch(pairs: JsValue) -> Vec<f64> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                rapid_jaro::normalized_similarity(pair[0].chars(), pair[1].chars())
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "jaroMany")]
+pub fn jaro_many(
+    reference: String,
+    candidates: Vec<String>,
+    score_cutoff: Option<f64>,
+) -> Vec<f64> {
+    let scorer = rapid_jaro::BatchComparator::new(reference.chars());
+    match score_cutoff {
+        Some(cutoff) => {
+            let args = rapid_jaro::Args::default().score_cutoff(cutoff);
+            candidates
+                .iter()
+                .map(|c| {
+                    scorer
+                        .normalized_similarity_with_args(c.chars(), &args)
+                        .unwrap_or(0.0)
+                })
+                .collect()
+        }
+        None => candidates
+            .iter()
+            .map(|c| scorer.normalized_similarity(c.chars()))
+            .collect(),
+    }
+}
+
+// ─── Jaro-Winkler ────────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = "jaroWinkler")]
+pub fn jaro_winkler(a: String, b: String) -> f64 {
+    rapid_jw::normalized_similarity(a.chars(), b.chars())
+}
+
+#[wasm_bindgen(js_name = "jaroWinklerBatch")]
+pub fn jaro_winkler_batch(pairs: JsValue) -> Vec<f64> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                rapid_jw::normalized_similarity(pair[0].chars(), pair[1].chars())
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "jaroWinklerMany")]
+pub fn jaro_winkler_many(
+    reference: String,
+    candidates: Vec<String>,
+    score_cutoff: Option<f64>,
+) -> Vec<f64> {
+    let scorer = rapid_jw::BatchComparator::new(reference.chars());
+    match score_cutoff {
+        Some(cutoff) => {
+            let args = rapid_jw::Args::default().score_cutoff(cutoff);
+            candidates
+                .iter()
+                .map(|c| {
+                    scorer
+                        .normalized_similarity_with_args(c.chars(), &args)
+                        .unwrap_or(0.0)
+                })
+                .collect()
+        }
+        None => candidates
+            .iter()
+            .map(|c| scorer.normalized_similarity(c.chars()))
+            .collect(),
+    }
+}
+
+// ─── Sorensen-Dice ───────────────────────────────────────────────────────────
+
+fn sorensen_dice_impl(a: &str, b: &str) -> f64 {
+    strsim::sorensen_dice(a, b)
+}
+
+#[wasm_bindgen(js_name = "sorensenDice")]
+pub fn sorensen_dice(a: String, b: String) -> f64 {
+    sorensen_dice_impl(&a, &b)
+}
+
+#[wasm_bindgen(js_name = "sorensenDiceBatch")]
+pub fn sorensen_dice_batch(pairs: JsValue) -> Vec<f64> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                sorensen_dice_impl(&pair[0], &pair[1])
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "sorensenDiceMany")]
+pub fn sorensen_dice_many(
+    reference: String,
+    candidates: Vec<String>,
+    score_cutoff: Option<f64>,
+) -> Vec<f64> {
+    let threshold = score_cutoff.unwrap_or(0.0);
+    candidates
+        .iter()
+        .map(|c| {
+            let s = sorensen_dice_impl(&reference, c);
+            if s >= threshold { s } else { 0.0 }
+        })
+        .collect()
+}
+
+// ─── Normalized Levenshtein ──────────────────────────────────────────────────
+
+fn normalized_levenshtein_impl(a: &str, b: &str) -> f64 {
+    strsim::normalized_levenshtein(a, b)
+}
+
+#[wasm_bindgen(js_name = "normalizedLevenshtein")]
+pub fn normalized_levenshtein(a: String, b: String) -> f64 {
+    normalized_levenshtein_impl(&a, &b)
+}
+
+#[wasm_bindgen(js_name = "normalizedLevenshteinBatch")]
+pub fn normalized_levenshtein_batch(pairs: JsValue) -> Vec<f64> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                normalized_levenshtein_impl(&pair[0], &pair[1])
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "normalizedLevenshteinMany")]
+pub fn normalized_levenshtein_many(
+    reference: String,
+    candidates: Vec<String>,
+    score_cutoff: Option<f64>,
+) -> Vec<f64> {
+    let threshold = score_cutoff.unwrap_or(0.0);
+    candidates
+        .iter()
+        .map(|c| {
+            let s = normalized_levenshtein_impl(&reference, c);
+            if s >= threshold { s } else { 0.0 }
+        })
+        .collect()
+}
+
+// ─── Indel ───────────────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = "indel")]
+pub fn indel(a: String, b: String) -> u32 {
+    rapid_indel::distance(a.chars(), b.chars()) as u32
+}
+
+#[wasm_bindgen(js_name = "indelBatch")]
+pub fn indel_batch(pairs: JsValue) -> Vec<u32> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                rapid_indel::distance(pair[0].chars(), pair[1].chars()) as u32
+            } else {
+                0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "indelMany")]
+pub fn indel_many(
+    reference: String,
+    candidates: Vec<String>,
+    max_distance: Option<u32>,
+) -> Vec<u32> {
+    let scorer = rapid_indel::BatchComparator::new(reference.chars());
+    match max_distance {
+        Some(cutoff) => {
+            let args = rapid_indel::Args::default().score_cutoff(cutoff as usize);
+            let sentinel = cutoff + 1;
+            candidates
+                .iter()
+                .map(|c| {
+                    scorer
+                        .distance_with_args(c.chars(), &args)
+                        .map_or(sentinel, |d| d as u32)
+                })
+                .collect()
+        }
+        None => candidates
+            .iter()
+            .map(|c| scorer.distance(c.chars()) as u32)
+            .collect(),
+    }
+}
+
+// ─── Normalized Indel ────────────────────────────────────────────────────────
+
+#[wasm_bindgen(js_name = "normalizedIndel")]
+pub fn normalized_indel(a: String, b: String) -> f64 {
+    rapid_indel::normalized_similarity(a.chars(), b.chars())
+}
+
+#[wasm_bindgen(js_name = "normalizedIndelBatch")]
+pub fn normalized_indel_batch(pairs: JsValue) -> Vec<f64> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                rapid_indel::normalized_similarity(pair[0].chars(), pair[1].chars())
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "normalizedIndelMany")]
+pub fn normalized_indel_many(
+    reference: String,
+    candidates: Vec<String>,
+    score_cutoff: Option<f64>,
+) -> Vec<f64> {
+    let scorer = rapid_indel::BatchComparator::new(reference.chars());
+    match score_cutoff {
+        Some(cutoff) => {
+            let args = rapid_indel::Args::default().score_cutoff(cutoff);
+            candidates
+                .iter()
+                .map(|c| {
+                    scorer
+                        .normalized_similarity_with_args(c.chars(), &args)
+                        .unwrap_or(0.0)
+                })
+                .collect()
+        }
+        None => candidates
+            .iter()
+            .map(|c| scorer.normalized_similarity(c.chars()))
+            .collect(),
+    }
+}
+
+// ─── Token Sort Ratio ────────────────────────────────────────────────────────
+
+fn token_sort_ratio_impl(a: &str, b: &str) -> f64 {
+    let mut a_tokens: Vec<&str> = a.split_whitespace().collect();
+    let mut b_tokens: Vec<&str> = b.split_whitespace().collect();
+    a_tokens.sort_unstable();
+    b_tokens.sort_unstable();
+    let a_sorted = a_tokens.join(" ");
+    let b_sorted = b_tokens.join(" ");
+    strsim::normalized_levenshtein(&a_sorted, &b_sorted)
+}
+
+#[wasm_bindgen(js_name = "tokenSortRatio")]
+pub fn token_sort_ratio(a: String, b: String) -> f64 {
+    token_sort_ratio_impl(&a, &b)
+}
+
+#[wasm_bindgen(js_name = "tokenSortRatioBatch")]
+pub fn token_sort_ratio_batch(pairs: JsValue) -> Vec<f64> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                token_sort_ratio_impl(&pair[0], &pair[1])
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "tokenSortRatioMany")]
+pub fn token_sort_ratio_many(
+    reference: String,
+    candidates: Vec<String>,
+    score_cutoff: Option<f64>,
+) -> Vec<f64> {
+    let threshold = score_cutoff.unwrap_or(0.0);
+    let mut ref_tokens: Vec<&str> = reference.split_whitespace().collect();
+    ref_tokens.sort_unstable();
+    let ref_sorted = ref_tokens.join(" ");
+    candidates
+        .iter()
+        .map(|c| {
+            let mut c_tokens: Vec<&str> = c.split_whitespace().collect();
+            c_tokens.sort_unstable();
+            let c_sorted = c_tokens.join(" ");
+            let s = strsim::normalized_levenshtein(&ref_sorted, &c_sorted);
+            if s >= threshold { s } else { 0.0 }
+        })
+        .collect()
+}
+
+// ─── Token Set Ratio ─────────────────────────────────────────────────────────
+
+fn token_set_ratio_impl(a: &str, b: &str) -> f64 {
+    use std::collections::BTreeSet;
+    let a_set: BTreeSet<&str> = a.split_whitespace().collect();
+    let b_set: BTreeSet<&str> = b.split_whitespace().collect();
+
+    let intersection: Vec<&&str> = a_set.intersection(&b_set).collect();
+    if intersection.is_empty() {
+        return 0.0;
+    }
+
+    let mut intersection_sorted: Vec<&str> = intersection.iter().map(|&&s| s).collect();
+    intersection_sorted.sort_unstable();
+    let base = intersection_sorted.join(" ");
+
+    let mut a_diff: Vec<&str> = a_set.difference(&b_set).copied().collect();
+    a_diff.sort_unstable();
+    let mut b_diff: Vec<&str> = b_set.difference(&a_set).copied().collect();
+    b_diff.sort_unstable();
+
+    let a_rest = a_diff.join(" ");
+    let b_rest = b_diff.join(" ");
+
+    let s1 = if a_rest.is_empty() {
+        base.clone()
+    } else {
+        format!("{base} {a_rest}")
+    };
+    let s2 = if b_rest.is_empty() {
+        base.clone()
+    } else {
+        format!("{base} {b_rest}")
+    };
+
+    strsim::normalized_levenshtein(&s1, &s2)
+        .max(strsim::normalized_levenshtein(&base, &s1))
+        .max(strsim::normalized_levenshtein(&base, &s2))
+}
+
+#[wasm_bindgen(js_name = "tokenSetRatio")]
+pub fn token_set_ratio(a: String, b: String) -> f64 {
+    token_set_ratio_impl(&a, &b)
+}
+
+#[wasm_bindgen(js_name = "tokenSetRatioBatch")]
+pub fn token_set_ratio_batch(pairs: JsValue) -> Vec<f64> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                token_set_ratio_impl(&pair[0], &pair[1])
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "tokenSetRatioMany")]
+pub fn token_set_ratio_many(
+    reference: String,
+    candidates: Vec<String>,
+    score_cutoff: Option<f64>,
+) -> Vec<f64> {
+    let threshold = score_cutoff.unwrap_or(0.0);
+    candidates
+        .iter()
+        .map(|c| {
+            let s = token_set_ratio_impl(&reference, c);
+            if s >= threshold { s } else { 0.0 }
+        })
+        .collect()
+}
+
+// ─── Partial Ratio ───────────────────────────────────────────────────────────
+
+fn partial_ratio_impl(a: &str, b: &str) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return if a == b { 1.0 } else { 0.0 };
+    }
+    let (shorter, longer) = if a.len() <= b.len() { (a, b) } else { (b, a) };
+    let window = shorter.len();
+    (0..=(longer.len().saturating_sub(window)))
+        .map(|i| strsim::normalized_levenshtein(shorter, &longer[i..i + window]))
+        .fold(0.0f64, f64::max)
+}
+
+#[wasm_bindgen(js_name = "partialRatio")]
+pub fn partial_ratio(a: String, b: String) -> f64 {
+    partial_ratio_impl(&a, &b)
+}
+
+#[wasm_bindgen(js_name = "partialRatioBatch")]
+pub fn partial_ratio_batch(pairs: JsValue) -> Vec<f64> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                partial_ratio_impl(&pair[0], &pair[1])
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "partialRatioMany")]
+pub fn partial_ratio_many(
+    reference: String,
+    candidates: Vec<String>,
+    score_cutoff: Option<f64>,
+) -> Vec<f64> {
+    let threshold = score_cutoff.unwrap_or(0.0);
+    candidates
+        .iter()
+        .map(|c| {
+            let s = partial_ratio_impl(&reference, c);
+            if s >= threshold { s } else { 0.0 }
+        })
+        .collect()
+}
+
+// ─── Weighted Ratio ──────────────────────────────────────────────────────────
+
+fn weighted_ratio_impl(a: &str, b: &str) -> f64 {
+    let base = strsim::normalized_levenshtein(a, b);
+    let partial = partial_ratio_impl(a, b);
+    let token_sort = token_sort_ratio_impl(a, b);
+    let token_set = token_set_ratio_impl(a, b);
+    base.max(partial).max(token_sort).max(token_set)
+}
+
+#[wasm_bindgen(js_name = "weightedRatio")]
+pub fn weighted_ratio(a: String, b: String) -> f64 {
+    weighted_ratio_impl(&a, &b)
+}
+
+#[wasm_bindgen(js_name = "weightedRatioBatch")]
+pub fn weighted_ratio_batch(pairs: JsValue) -> Vec<f64> {
+    let pairs: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(pairs) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    pairs
+        .iter()
+        .map(|pair| {
+            if pair.len() >= 2 {
+                weighted_ratio_impl(&pair[0], &pair[1])
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+#[wasm_bindgen(js_name = "weightedRatioMany")]
+pub fn weighted_ratio_many(
+    reference: String,
+    candidates: Vec<String>,
+    score_cutoff: Option<f64>,
+) -> Vec<f64> {
+    let threshold = score_cutoff.unwrap_or(0.0);
+    candidates
+        .iter()
+        .map(|c| {
+            let s = weighted_ratio_impl(&reference, c);
+            if s >= threshold { s } else { 0.0 }
+        })
+        .collect()
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,0 +1,5 @@
+mod distance;
+mod search;
+
+pub use distance::*;
+pub use search::*;

--- a/crates/wasm/src/search/index.rs
+++ b/crates/wasm/src/search/index.rs
@@ -1,0 +1,395 @@
+use std::cell::RefCell;
+
+use nucleo_matcher::pattern::CaseMatching;
+use nucleo_matcher::{Config, Matcher, Utf32String};
+use wasm_bindgen::prelude::*;
+
+use super::{
+    BigramIndex, IndexSearchResult, PrecomputedSearch, SearchOptions, SearchResult,
+    compute_char_mask, extract_query_bigrams, resolve_case_matching, search_over_precomputed,
+    search_over_precomputed_indices, to_js,
+};
+
+const BIGRAM_THRESHOLD: usize = 5_000;
+const SERIALIZE_MAGIC: &[u8] = b"RFUZ";
+const SERIALIZE_VERSION: u32 = 1;
+
+/// A persistent fuzzy search index backed by Rust-side data.
+///
+/// Holds items in memory on the Rust side, avoiding repeated FFI overhead
+/// for applications that search the same dataset multiple times.
+#[wasm_bindgen]
+pub struct FuzzyIndex {
+    items: Vec<String>,
+    utf32_items: Vec<Utf32String>,
+    char_masks: Vec<u64>,
+    bigram_index: BigramIndex,
+    matcher: RefCell<Matcher>,
+    last_query: RefCell<String>,
+    last_matching_indices: RefCell<Vec<u32>>,
+}
+
+#[wasm_bindgen]
+impl FuzzyIndex {
+    /// Create a new FuzzyIndex from an array of strings.
+    #[wasm_bindgen(constructor)]
+    pub fn new(items: Vec<String>) -> Self {
+        let utf32_items: Vec<Utf32String> = items
+            .iter()
+            .map(|s| Utf32String::from(s.as_str()))
+            .collect();
+        let char_masks: Vec<u64> = items.iter().map(|s| compute_char_mask(s)).collect();
+        let bigram_index = BigramIndex::new(&items);
+        Self {
+            items,
+            utf32_items,
+            char_masks,
+            bigram_index,
+            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
+            last_query: RefCell::new(String::new()),
+            last_matching_indices: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Return the number of items in the index.
+    #[wasm_bindgen(getter)]
+    pub fn size(&self) -> u32 {
+        self.items.len() as u32
+    }
+
+    /// Search the index for items matching the query.
+    ///
+    /// Returns matches sorted by score (best match first) as a JS Array.
+    pub fn search(&self, query: String, options: Option<SearchOptions>) -> JsValue {
+        let opts = options.unwrap_or_default();
+        let (max_results, min_score, include_positions, case_matching, return_all_on_empty) = (
+            opts.max_results,
+            opts.min_score,
+            opts.include_positions.unwrap_or(false),
+            resolve_case_matching(opts.is_case_sensitive),
+            opts.return_all_on_empty.unwrap_or(false),
+        );
+
+        if return_all_on_empty && query.trim().is_empty() {
+            let limit = max_results.unwrap_or(self.items.len() as u32) as usize;
+            let results: Vec<SearchResult> = self
+                .items
+                .iter()
+                .enumerate()
+                .take(limit)
+                .map(|(i, item)| SearchResult {
+                    item: item.clone(),
+                    score: 1.0,
+                    index: i as u32,
+                    positions: Vec::new(),
+                    match_type: None,
+                })
+                .collect();
+            return to_js(&results);
+        }
+
+        let results = self.search_impl(
+            &query,
+            max_results,
+            min_score,
+            include_positions,
+            case_matching,
+        );
+        to_js(&results)
+    }
+
+    /// Find the closest matching string in the index.
+    ///
+    /// Returns the best match, or null if no match is found.
+    pub fn closest(&self, query: String, min_score: Option<f64>) -> Option<String> {
+        let results = self.search_impl(&query, Some(1), min_score, false, CaseMatching::Smart);
+        results.into_iter().next().map(|r| r.item)
+    }
+
+    /// Search the index, returning only indices and scores (no item strings).
+    #[wasm_bindgen(js_name = "searchIndices")]
+    pub fn search_indices(&self, query: String, options: Option<SearchOptions>) -> JsValue {
+        let opts = options.unwrap_or_default();
+        let (max_results, min_score, include_positions, case_matching, return_all_on_empty) = (
+            opts.max_results,
+            opts.min_score,
+            opts.include_positions.unwrap_or(false),
+            resolve_case_matching(opts.is_case_sensitive),
+            opts.return_all_on_empty.unwrap_or(false),
+        );
+
+        if return_all_on_empty && query.trim().is_empty() {
+            let limit = max_results.unwrap_or(self.items.len() as u32) as usize;
+            let results: Vec<IndexSearchResult> = (0..self.items.len())
+                .take(limit)
+                .map(|i| IndexSearchResult {
+                    index: i as u32,
+                    score: 1.0,
+                    positions: Vec::new(),
+                    match_type: None,
+                })
+                .collect();
+            return to_js(&results);
+        }
+
+        let results = self.search_indices_impl(
+            &query,
+            max_results,
+            min_score,
+            include_positions,
+            case_matching,
+        );
+        to_js(&results)
+    }
+
+    /// Add a single item to the index.
+    pub fn add(&mut self, item: String) {
+        let index = self.items.len() as u32;
+        self.utf32_items.push(Utf32String::from(item.as_str()));
+        self.char_masks.push(compute_char_mask(&item));
+        self.bigram_index.add_item(index, &item);
+        self.items.push(item);
+        self.invalidate_cache();
+    }
+
+    /// Add multiple items to the index at once.
+    #[wasm_bindgen(js_name = "addMany")]
+    pub fn add_many(&mut self, items: Vec<String>) {
+        let base = self.items.len() as u32;
+        for (i, item) in items.iter().enumerate() {
+            self.utf32_items.push(Utf32String::from(item.as_str()));
+            self.char_masks.push(compute_char_mask(item));
+            self.bigram_index.add_item(base + i as u32, item);
+        }
+        self.items.extend(items);
+        self.invalidate_cache();
+    }
+
+    /// Remove the item at the given index.
+    ///
+    /// Uses swap-remove for O(1) performance. Returns false if out of bounds.
+    pub fn remove(&mut self, index: u32) -> bool {
+        let idx = index as usize;
+        if idx < self.items.len() {
+            let last_index = (self.items.len() - 1) as u32;
+            let removed_item = self.items[idx].clone();
+            let last_item = if idx != last_index as usize {
+                Some(self.items[last_index as usize].clone())
+            } else {
+                None
+            };
+            self.bigram_index
+                .remove_item(index, last_index, &removed_item, last_item.as_deref());
+            self.items.swap_remove(idx);
+            self.utf32_items.swap_remove(idx);
+            self.char_masks.swap_remove(idx);
+            self.invalidate_cache();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Free the internal data. After calling this, the index is empty.
+    pub fn destroy(&mut self) {
+        self.items = Vec::new();
+        self.utf32_items = Vec::new();
+        self.char_masks = Vec::new();
+        self.bigram_index.clear();
+        self.invalidate_cache();
+    }
+
+    /// Serialize the index to a compact binary format (Uint8Array).
+    pub fn serialize(&self) -> Vec<u8> {
+        self.serialize_impl()
+    }
+
+    /// Reconstruct a FuzzyIndex from a previously serialized Uint8Array.
+    pub fn deserialize(data: &[u8]) -> Result<FuzzyIndex, JsValue> {
+        Self::deserialize_impl(data).map_err(|e| JsValue::from_str(&e))
+    }
+
+    fn serialize_impl(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(SERIALIZE_MAGIC);
+        buf.extend_from_slice(&SERIALIZE_VERSION.to_le_bytes());
+        buf.extend_from_slice(&(self.items.len() as u32).to_le_bytes());
+        for item in &self.items {
+            buf.extend_from_slice(&(item.len() as u32).to_le_bytes());
+            buf.extend_from_slice(item.as_bytes());
+        }
+        buf
+    }
+
+    fn deserialize_impl(bytes: &[u8]) -> Result<Self, String> {
+        let header_size = SERIALIZE_MAGIC.len() + 4 + 4;
+        if bytes.len() < header_size {
+            return Err("Invalid data: too short".into());
+        }
+        if &bytes[0..4] != SERIALIZE_MAGIC {
+            return Err("Invalid data: bad magic bytes".into());
+        }
+        let version = u32::from_le_bytes(
+            bytes[4..8]
+                .try_into()
+                .map_err(|_| "Invalid data: truncated header".to_string())?,
+        );
+        if version != SERIALIZE_VERSION {
+            return Err(format!(
+                "Unsupported format version: expected {SERIALIZE_VERSION}, got {version}"
+            ));
+        }
+        let count = u32::from_le_bytes(
+            bytes[8..12]
+                .try_into()
+                .map_err(|_| "Invalid data: truncated header".to_string())?,
+        ) as usize;
+        let mut offset = header_size;
+        let max_possible = bytes.len().saturating_sub(header_size) / 4;
+        if count > max_possible {
+            return Err("Invalid data: item count exceeds payload size".into());
+        }
+        let mut items = Vec::with_capacity(count);
+        for _ in 0..count {
+            if offset + 4 > bytes.len() {
+                return Err("Invalid data: truncated".into());
+            }
+            let len = u32::from_le_bytes(
+                bytes[offset..offset + 4]
+                    .try_into()
+                    .map_err(|_| "Invalid data: truncated".to_string())?,
+            ) as usize;
+            offset += 4;
+            if offset + len > bytes.len() {
+                return Err("Invalid data: truncated".into());
+            }
+            let s = std::str::from_utf8(&bytes[offset..offset + len])
+                .map_err(|e| format!("Invalid UTF-8: {e}"))?;
+            items.push(s.to_owned());
+            offset += len;
+        }
+        if offset != bytes.len() {
+            return Err("Invalid data: trailing bytes".into());
+        }
+        Ok(Self::new(items))
+    }
+
+    fn search_impl(
+        &self,
+        query: &str,
+        max_results: Option<u32>,
+        min_score: Option<f64>,
+        include_positions: bool,
+        case_matching: CaseMatching,
+    ) -> Vec<SearchResult> {
+        // Determine incremental search cache candidates.
+        let cache_candidates: Option<Vec<u32>> = {
+            let last_q = self.last_query.borrow();
+            let last_indices = self.last_matching_indices.borrow();
+            if !query.is_empty()
+                && !last_q.is_empty()
+                && query.starts_with(last_q.as_str())
+                && !last_indices.is_empty()
+                && !last_q.contains('!')
+                && !query.contains('!')
+            {
+                Some(last_indices.clone())
+            } else {
+                None
+            }
+        };
+
+        // Apply bigram pre-filtering when the dataset is large enough.
+        let bigram_candidates: Option<Vec<u32>> =
+            if self.items.len() >= BIGRAM_THRESHOLD && cache_candidates.is_none() {
+                let qbigrams = extract_query_bigrams(query);
+                if qbigrams.is_empty() {
+                    None
+                } else {
+                    self.bigram_index.candidates(&qbigrams)
+                }
+            } else {
+                None
+            };
+
+        let candidate_indices: Option<&[u32]> =
+            cache_candidates.as_deref().or(bigram_candidates.as_deref());
+
+        let ctx = PrecomputedSearch {
+            items: &self.items,
+            utf32_items: &self.utf32_items,
+            char_masks: &self.char_masks,
+            candidate_indices,
+            matcher: &self.matcher,
+        };
+
+        let outcome = search_over_precomputed(
+            query,
+            &ctx,
+            max_results,
+            min_score,
+            include_positions,
+            case_matching,
+        );
+
+        *self.last_query.borrow_mut() = query.to_owned();
+        *self.last_matching_indices.borrow_mut() = outcome.all_matching_indices;
+
+        outcome
+            .results
+            .into_iter()
+            .map(SearchResult::from)
+            .collect()
+    }
+
+    fn search_indices_impl(
+        &self,
+        query: &str,
+        max_results: Option<u32>,
+        min_score: Option<f64>,
+        include_positions: bool,
+        case_matching: CaseMatching,
+    ) -> Vec<IndexSearchResult> {
+        let bigram_candidates: Option<Vec<u32>> = if self.items.len() >= BIGRAM_THRESHOLD {
+            let qbigrams = extract_query_bigrams(query);
+            if qbigrams.is_empty() {
+                None
+            } else {
+                self.bigram_index.candidates(&qbigrams)
+            }
+        } else {
+            None
+        };
+
+        let ctx = PrecomputedSearch {
+            items: &self.items,
+            utf32_items: &self.utf32_items,
+            char_masks: &self.char_masks,
+            candidate_indices: bigram_candidates.as_deref(),
+            matcher: &self.matcher,
+        };
+
+        let outcome = search_over_precomputed_indices(
+            query,
+            &ctx,
+            max_results,
+            min_score,
+            include_positions,
+            case_matching,
+        );
+
+        *self.last_query.borrow_mut() = query.to_owned();
+        *self.last_matching_indices.borrow_mut() = outcome.all_matching_indices;
+
+        outcome
+            .results
+            .into_iter()
+            .map(IndexSearchResult::from)
+            .collect()
+    }
+
+    fn invalidate_cache(&self) {
+        self.last_query.borrow_mut().clear();
+        self.last_matching_indices.borrow_mut().clear();
+    }
+}

--- a/crates/wasm/src/search/keyed_index.rs
+++ b/crates/wasm/src/search/keyed_index.rs
@@ -1,0 +1,399 @@
+use std::cell::RefCell;
+
+use nucleo_matcher::pattern::{Normalization, Pattern};
+use nucleo_matcher::{Config, Matcher, Utf32String};
+use wasm_bindgen::prelude::*;
+
+use super::{
+    SearchOptions, compute_char_mask, compute_max_score, compute_query_mask, resolve_case_matching,
+    to_js,
+};
+
+use super::keys::KeySearchResult;
+
+const SERIALIZE_MAGIC: &[u8; 4] = b"RFKI";
+const SERIALIZE_VERSION: u32 = 1;
+
+fn to_utf32(texts: &[String]) -> Vec<Utf32String> {
+    texts
+        .iter()
+        .map(|s| Utf32String::from(s.as_str()))
+        .collect()
+}
+
+/// A persistent multi-key fuzzy search index backed by Rust-side data.
+///
+/// Holds key text arrays and weights in memory on the Rust side.
+#[wasm_bindgen]
+pub struct KeyedFuzzyIndex {
+    key_texts: Vec<Vec<String>>,
+    utf32_keys: Vec<Vec<Utf32String>>,
+    key_char_masks: Vec<Vec<u64>>,
+    weights: Vec<f64>,
+    total_weight: f64,
+    matcher: RefCell<Matcher>,
+}
+
+#[wasm_bindgen]
+impl KeyedFuzzyIndex {
+    /// Create a new KeyedFuzzyIndex.
+    ///
+    /// `key_texts` is a JS Array of Arrays of strings (one inner array per key,
+    /// each inner array has one string per item).
+    /// `weights` is a JS Array of numbers.
+    #[wasm_bindgen(constructor)]
+    pub fn new(key_texts: JsValue, weights: Vec<f64>) -> Result<KeyedFuzzyIndex, JsValue> {
+        let key_texts: Vec<Vec<String>> = serde_wasm_bindgen::from_value(key_texts)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        Self::new_impl(key_texts, weights).map_err(|e| JsValue::from_str(&e))
+    }
+
+    fn new_impl(key_texts: Vec<Vec<String>>, weights: Vec<f64>) -> Result<Self, String> {
+        let num_keys = key_texts.len();
+        if let Some(num_items) = key_texts.first().map(Vec::len) {
+            for (k, col) in key_texts.iter().enumerate().skip(1) {
+                if col.len() != num_items {
+                    return Err(format!(
+                        "All key_texts columns must have the same length; key 0 has {}, key {} has {}",
+                        num_items,
+                        k,
+                        col.len()
+                    ));
+                }
+            }
+        }
+        if weights.len() != num_keys {
+            return Err(format!(
+                "Expected {} weights, got {}",
+                num_keys,
+                weights.len()
+            ));
+        }
+        if weights.iter().any(|w| !w.is_finite() || *w < 0.0) {
+            return Err("Weights must be finite non-negative numbers".to_string());
+        }
+        let total_weight: f64 = weights.iter().sum();
+        if total_weight <= 0.0 {
+            return Err("Total weight must be greater than zero".to_string());
+        }
+        let utf32_keys: Vec<Vec<Utf32String>> = key_texts.iter().map(|t| to_utf32(t)).collect();
+        let key_char_masks: Vec<Vec<u64>> = key_texts
+            .iter()
+            .map(|texts| texts.iter().map(|s| compute_char_mask(s)).collect())
+            .collect();
+        Ok(Self {
+            key_texts,
+            utf32_keys,
+            key_char_masks,
+            weights,
+            total_weight,
+            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
+        })
+    }
+
+    /// Return the number of items in the index.
+    #[wasm_bindgen(getter)]
+    pub fn size(&self) -> u32 {
+        self.key_texts.first().map_or(0, |v| v.len() as u32)
+    }
+
+    /// Search the index for items matching the query.
+    ///
+    /// Returns results sorted by combined weighted score as a JS Array.
+    pub fn search(&self, query: String, options: Option<SearchOptions>) -> JsValue {
+        let results = self.search_impl(query, options);
+        to_js(&results)
+    }
+
+    /// Find the index of the closest matching item.
+    pub fn closest(&self, query: String, min_score: Option<f64>) -> Option<u32> {
+        let results = self.search_impl(
+            query,
+            Some(SearchOptions {
+                max_results: Some(1),
+                min_score,
+                ..Default::default()
+            }),
+        );
+        results.into_iter().next().map(|r| r.index)
+    }
+
+    /// Add a single item to the index.
+    ///
+    /// `key_values` must be a JS Array of strings with one value per key.
+    pub fn add(&mut self, key_values: JsValue) -> Result<(), JsValue> {
+        let key_values: Vec<String> = serde_wasm_bindgen::from_value(key_values)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        self.add_impl(key_values).map_err(|e| JsValue::from_str(&e))
+    }
+
+    /// Add multiple items to the index at once.
+    ///
+    /// `items_key_values` is a JS Array where each element is an Array of strings
+    /// (one per key). Throws if any element has the wrong number of key values.
+    #[wasm_bindgen(js_name = "addMany")]
+    pub fn add_many(&mut self, items_key_values: JsValue) -> Result<(), JsValue> {
+        let items: Vec<Vec<String>> = serde_wasm_bindgen::from_value(items_key_values)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        for key_values in items {
+            self.add_impl(key_values)
+                .map_err(|e| JsValue::from_str(&e))?;
+        }
+        Ok(())
+    }
+
+    fn add_impl(&mut self, key_values: Vec<String>) -> Result<(), String> {
+        let num_keys = self.key_texts.len();
+        if key_values.len() != num_keys {
+            return Err(format!(
+                "Expected {num_keys} key values, got {}",
+                key_values.len()
+            ));
+        }
+        for (k, value) in key_values.into_iter().enumerate() {
+            self.utf32_keys[k].push(Utf32String::from(value.as_str()));
+            self.key_char_masks[k].push(compute_char_mask(&value));
+            self.key_texts[k].push(value);
+        }
+        Ok(())
+    }
+
+    /// Remove the item at the given index.
+    ///
+    /// Uses swap-remove for O(1) performance. Returns false if out of bounds.
+    pub fn remove(&mut self, index: u32) -> bool {
+        let idx = index as usize;
+        let num_items = self.size() as usize;
+        if idx >= num_items {
+            return false;
+        }
+        for ((texts, utf32), masks) in self
+            .key_texts
+            .iter_mut()
+            .zip(self.utf32_keys.iter_mut())
+            .zip(self.key_char_masks.iter_mut())
+        {
+            texts.swap_remove(idx);
+            utf32.swap_remove(idx);
+            masks.swap_remove(idx);
+        }
+        true
+    }
+
+    /// Free the internal data. After calling this, the index is empty.
+    pub fn destroy(&mut self) {
+        self.key_texts = Vec::new();
+        self.utf32_keys = Vec::new();
+        self.key_char_masks = Vec::new();
+        self.weights = Vec::new();
+        self.total_weight = 0.0;
+    }
+
+    /// Serialize the index to a compact binary format (Uint8Array).
+    pub fn serialize(&self) -> Vec<u8> {
+        let num_keys = self.weights.len();
+        let num_items = self.size() as usize;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(SERIALIZE_MAGIC);
+        buf.extend_from_slice(&SERIALIZE_VERSION.to_le_bytes());
+        buf.extend_from_slice(&(num_keys as u32).to_le_bytes());
+        buf.extend_from_slice(&(num_items as u32).to_le_bytes());
+        for &w in &self.weights {
+            buf.extend_from_slice(&w.to_le_bytes());
+        }
+        for key_col in &self.key_texts {
+            for item in key_col {
+                buf.extend_from_slice(&(item.len() as u32).to_le_bytes());
+                buf.extend_from_slice(item.as_bytes());
+            }
+        }
+        buf
+    }
+
+    /// Reconstruct a KeyedFuzzyIndex from a previously serialized Uint8Array.
+    pub fn deserialize(data: &[u8]) -> Result<KeyedFuzzyIndex, JsValue> {
+        Self::deserialize_impl(data).map_err(|e| JsValue::from_str(&e))
+    }
+
+    fn deserialize_impl(bytes: &[u8]) -> Result<Self, String> {
+        let header_size = 4 + 4 + 4 + 4;
+        if bytes.len() < header_size {
+            return Err("Invalid data: too short".into());
+        }
+        if &bytes[0..4] != SERIALIZE_MAGIC {
+            return Err("Invalid data: bad magic bytes".into());
+        }
+        let version = u32::from_le_bytes(
+            bytes[4..8]
+                .try_into()
+                .map_err(|_| "Invalid data: truncated header".to_string())?,
+        );
+        if version != SERIALIZE_VERSION {
+            return Err(format!(
+                "Unsupported format version: expected {SERIALIZE_VERSION}, got {version}"
+            ));
+        }
+        let num_keys = u32::from_le_bytes(
+            bytes[8..12]
+                .try_into()
+                .map_err(|_| "Invalid data: truncated header".to_string())?,
+        ) as usize;
+        let num_items = u32::from_le_bytes(
+            bytes[12..16]
+                .try_into()
+                .map_err(|_| "Invalid data: truncated header".to_string())?,
+        ) as usize;
+        let mut offset = header_size;
+        let weights_size = num_keys * 8;
+        if offset + weights_size > bytes.len() {
+            return Err("Invalid data: truncated weights".into());
+        }
+        let mut weights = Vec::with_capacity(num_keys);
+        for _ in 0..num_keys {
+            let w = f64::from_le_bytes(
+                bytes[offset..offset + 8]
+                    .try_into()
+                    .map_err(|_| "Invalid data: truncated weight".to_string())?,
+            );
+            weights.push(w);
+            offset += 8;
+        }
+        let mut key_texts: Vec<Vec<String>> = Vec::with_capacity(num_keys);
+        for _ in 0..num_keys {
+            let mut col = Vec::with_capacity(num_items);
+            for _ in 0..num_items {
+                if offset + 4 > bytes.len() {
+                    return Err("Invalid data: truncated".into());
+                }
+                let len = u32::from_le_bytes(
+                    bytes[offset..offset + 4]
+                        .try_into()
+                        .map_err(|_| "Invalid data: truncated".to_string())?,
+                ) as usize;
+                offset += 4;
+                if offset + len > bytes.len() {
+                    return Err("Invalid data: truncated".into());
+                }
+                let s = std::str::from_utf8(&bytes[offset..offset + len])
+                    .map_err(|e| format!("Invalid UTF-8: {e}"))?;
+                col.push(s.to_owned());
+                offset += len;
+            }
+            key_texts.push(col);
+        }
+        if offset != bytes.len() {
+            return Err("Invalid data: trailing bytes".into());
+        }
+        Self::new_impl(key_texts, weights)
+    }
+
+    fn search_impl(&self, query: String, options: Option<SearchOptions>) -> Vec<KeySearchResult> {
+        let opts = options.unwrap_or_default();
+        let num_keys = self.key_texts.len();
+        if num_keys == 0 {
+            return Vec::new();
+        }
+        let num_items = self.size() as usize;
+        if num_items == 0 {
+            return Vec::new();
+        }
+        let return_all_on_empty = opts.return_all_on_empty.unwrap_or(false);
+        if return_all_on_empty && query.trim().is_empty() {
+            let limit = opts.max_results.unwrap_or(num_items as u32) as usize;
+            return (0..num_items)
+                .take(limit)
+                .map(|i| KeySearchResult {
+                    index: i as u32,
+                    score: 1.0,
+                    key_scores: vec![1.0; num_keys],
+                })
+                .collect();
+        }
+        if query.is_empty() {
+            return Vec::new();
+        }
+        let max_results = opts.max_results;
+        let min_score = opts.min_score;
+        let case_matching = resolve_case_matching(opts.is_case_sensitive);
+        let threshold = min_score.unwrap_or(0.0);
+        if self.weights.iter().any(|w| !w.is_finite() || *w < 0.0) {
+            return Vec::new();
+        }
+        let mut matcher = self.matcher.borrow_mut();
+        let pattern = Pattern::parse(&query, case_matching, Normalization::Smart);
+        let max_score = compute_max_score(&query, &pattern, &mut matcher);
+        let query_mask = compute_query_mask(&query);
+        let active_keys: Vec<usize> = (0..num_keys).filter(|&k| self.weights[k] > 0.0).collect();
+        let active_total_weight: f64 = active_keys.iter().map(|&k| self.weights[k]).sum();
+        let mut per_key_scores: Vec<Vec<f64>> = vec![vec![0.0; num_items]; num_keys];
+        let threshold_weighted = threshold * self.total_weight;
+        let mut scored: Vec<(u32, f64)> = (0..num_items)
+            .filter_map(|i| {
+                let mut weighted_sum = 0.0;
+                let mut matched_any = false;
+                let mut remaining_weight = active_total_weight;
+                for &k in &active_keys {
+                    let w = self.weights[k];
+                    remaining_weight -= w;
+                    if query_mask != 0 && (self.key_char_masks[k][i] & query_mask) != query_mask {
+                        if threshold > 0.0 && weighted_sum + remaining_weight < threshold_weighted {
+                            return None;
+                        }
+                        continue;
+                    }
+                    let atoms = self.utf32_keys[k][i].slice(..);
+                    let score = match pattern.score(atoms, &mut matcher) {
+                        Some(raw) => ((raw as f64) / max_score).min(1.0),
+                        None => 0.0,
+                    };
+                    per_key_scores[k][i] = score;
+                    if score > 0.0 {
+                        weighted_sum += score * w;
+                        matched_any = true;
+                    }
+                    if threshold > 0.0 && weighted_sum + remaining_weight < threshold_weighted {
+                        return None;
+                    }
+                }
+                if !matched_any {
+                    return None;
+                }
+                let combined = weighted_sum / self.total_weight;
+                if combined >= threshold {
+                    Some((i as u32, combined))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let cmp = |a: &(u32, f64), b: &(u32, f64)| {
+            let score_ord = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
+            if score_ord != std::cmp::Ordering::Equal {
+                return score_ord;
+            }
+            a.0.cmp(&b.0)
+        };
+        if let Some(max) = max_results {
+            let k = max as usize;
+            if scored.len() > k {
+                scored.select_nth_unstable_by(k, cmp);
+                scored.truncate(k);
+            }
+        }
+        scored.sort_unstable_by(cmp);
+        scored
+            .into_iter()
+            .map(|(index, score)| {
+                let key_scores: Vec<f64> = per_key_scores
+                    .iter()
+                    .map(|scores| scores[index as usize])
+                    .collect();
+                KeySearchResult {
+                    index,
+                    score,
+                    key_scores,
+                }
+            })
+            .collect()
+    }
+}

--- a/crates/wasm/src/search/keys.rs
+++ b/crates/wasm/src/search/keys.rs
@@ -1,0 +1,167 @@
+use nucleo_matcher::pattern::{Normalization, Pattern};
+use nucleo_matcher::{Config, Matcher};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+use super::{SearchOptions, compute_max_score, resolve_case_matching, to_js};
+
+/// A single result from multi-key fuzzy search.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KeySearchResult {
+    pub index: u32,
+    pub score: f64,
+    pub key_scores: Vec<f64>,
+}
+
+/// Perform fuzzy search across multiple text keys with weights.
+///
+/// `key_texts` is a JS Array of Arrays of strings (one inner array per key,
+/// each inner array has one string per item).
+/// `weights` is a JS Array of numbers specifying the relative importance of each key.
+///
+/// Returns results sorted by combined weighted score as a JS Array.
+#[wasm_bindgen(js_name = "searchKeys")]
+pub fn search_keys(
+    query: String,
+    key_texts: JsValue,
+    weights: Vec<f64>,
+    options: Option<SearchOptions>,
+) -> JsValue {
+    let key_texts: Vec<Vec<String>> = match serde_wasm_bindgen::from_value(key_texts) {
+        Ok(v) => v,
+        Err(_) => return to_js::<Vec<KeySearchResult>>(&Vec::new()),
+    };
+    let results = search_keys_impl(query, key_texts, weights, options);
+    to_js(&results)
+}
+
+pub(crate) fn search_keys_impl(
+    query: String,
+    key_texts: Vec<Vec<String>>,
+    weights: Vec<f64>,
+    options: Option<SearchOptions>,
+) -> Vec<KeySearchResult> {
+    let num_keys = key_texts.len();
+    if num_keys == 0 || weights.len() != num_keys {
+        return Vec::new();
+    }
+    let num_items = key_texts[0].len();
+    if num_items == 0 {
+        return Vec::new();
+    }
+    for texts in &key_texts {
+        if texts.len() != num_items {
+            return Vec::new();
+        }
+    }
+    let opts = options.unwrap_or_default();
+    let return_all_on_empty = opts.return_all_on_empty.unwrap_or(false);
+    if return_all_on_empty && query.trim().is_empty() {
+        let max_results = opts.max_results;
+        let limit = max_results.unwrap_or(num_items as u32) as usize;
+        return (0..num_items)
+            .take(limit)
+            .map(|i| KeySearchResult {
+                index: i as u32,
+                score: 1.0,
+                key_scores: vec![1.0; num_keys],
+            })
+            .collect();
+    }
+    if query.is_empty() {
+        return Vec::new();
+    }
+    let max_results = opts.max_results;
+    let min_score = opts.min_score;
+    let case_matching = resolve_case_matching(opts.is_case_sensitive);
+    let threshold = min_score.unwrap_or(0.0);
+    if weights.iter().any(|w| !w.is_finite() || *w < 0.0) {
+        return Vec::new();
+    }
+    let total_weight: f64 = weights.iter().sum();
+    if total_weight <= 0.0 {
+        return Vec::new();
+    }
+    use nucleo_matcher::Utf32String;
+    let utf32_keys: Vec<Vec<Utf32String>> = key_texts
+        .iter()
+        .map(|texts| {
+            texts
+                .iter()
+                .map(|s| Utf32String::from(s.as_str()))
+                .collect()
+        })
+        .collect();
+    let mut matcher = Matcher::new(Config::DEFAULT);
+    let pattern = Pattern::parse(&query, case_matching, Normalization::Smart);
+    let max_score = compute_max_score(&query, &pattern, &mut matcher);
+    let mut per_key_scores: Vec<Vec<f64>> = Vec::with_capacity(num_keys);
+    let mut buf: Vec<u32> = Vec::new();
+    #[allow(clippy::needless_range_loop)]
+    for k in 0..num_keys {
+        let mut scores = Vec::with_capacity(num_items);
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..num_items {
+            let atoms = utf32_keys[k][i].slice(..);
+            let score = match pattern.score(atoms, &mut matcher) {
+                Some(raw) => ((raw as f64) / max_score).min(1.0),
+                None => 0.0,
+            };
+            scores.push(score);
+        }
+        per_key_scores.push(scores);
+        buf.clear();
+    }
+    let threshold_weighted = threshold * total_weight;
+    let mut scored: Vec<(u32, f64)> = (0..num_items)
+        .filter_map(|i| {
+            let mut weighted_sum = 0.0;
+            let mut matched_any = false;
+            for k in 0..num_keys {
+                let w = weights[k];
+                let s = per_key_scores[k][i];
+                if s > 0.0 {
+                    weighted_sum += s * w;
+                    matched_any = true;
+                }
+            }
+            if !matched_any {
+                return None;
+            }
+            let combined = weighted_sum / total_weight;
+            if combined >= threshold {
+                Some((i as u32, combined))
+            } else {
+                None
+            }
+        })
+        .collect();
+    let _ = threshold_weighted;
+    let cmp = |a: &(u32, f64), b: &(u32, f64)| {
+        let score_ord = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
+        if score_ord != std::cmp::Ordering::Equal {
+            return score_ord;
+        }
+        a.0.cmp(&b.0)
+    };
+    if let Some(max) = max_results {
+        let k = max as usize;
+        if scored.len() > k {
+            scored.select_nth_unstable_by(k, cmp);
+            scored.truncate(k);
+        }
+    }
+    scored.sort_unstable_by(cmp);
+    scored
+        .into_iter()
+        .map(|(index, score)| {
+            let key_scores: Vec<f64> = per_key_scores.iter().map(|s| s[index as usize]).collect();
+            KeySearchResult {
+                index,
+                score,
+                key_scores,
+            }
+        })
+        .collect()
+}

--- a/crates/wasm/src/search/mod.rs
+++ b/crates/wasm/src/search/mod.rs
@@ -1,0 +1,176 @@
+mod index;
+mod keyed_index;
+mod keys;
+
+pub use index::FuzzyIndex;
+pub use keyed_index::KeyedFuzzyIndex;
+pub use keys::search_keys;
+
+use nucleo_matcher::pattern::CaseMatching;
+use rapid_fuzzy_core::search as core;
+use serde::{Deserialize, Serialize};
+use tsify_next::Tsify;
+use wasm_bindgen::prelude::*;
+
+// ─── Shared wasm types ──────────────────────────────────────────────────────
+
+/// Classification of how a query matched an item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MatchType {
+    Exact,
+    Prefix,
+    Contains,
+    Fuzzy,
+}
+
+impl From<core::MatchType> for MatchType {
+    fn from(mt: core::MatchType) -> Self {
+        match mt {
+            core::MatchType::Exact => Self::Exact,
+            core::MatchType::Prefix => Self::Prefix,
+            core::MatchType::Contains => Self::Contains,
+            core::MatchType::Fuzzy => Self::Fuzzy,
+        }
+    }
+}
+
+/// A single fuzzy search result with the matched item and its score.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchResult {
+    pub item: String,
+    pub score: f64,
+    pub index: u32,
+    pub positions: Vec<u32>,
+    pub match_type: Option<MatchType>,
+}
+
+impl From<core::SearchResult> for SearchResult {
+    fn from(r: core::SearchResult) -> Self {
+        Self {
+            item: r.item,
+            score: r.score,
+            index: r.index,
+            positions: r.positions,
+            match_type: r.match_type.map(Into::into),
+        }
+    }
+}
+
+/// A lightweight search result containing only index and score.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexSearchResult {
+    pub index: u32,
+    pub score: f64,
+    pub positions: Vec<u32>,
+    pub match_type: Option<MatchType>,
+}
+
+impl From<core::IndexSearchResult> for IndexSearchResult {
+    fn from(r: core::IndexSearchResult) -> Self {
+        Self {
+            index: r.index,
+            score: r.score,
+            positions: r.positions,
+            match_type: r.match_type.map(Into::into),
+        }
+    }
+}
+
+/// Options for search functions.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Tsify)]
+#[serde(rename_all = "camelCase")]
+#[tsify(from_wasm_abi)]
+pub struct SearchOptions {
+    pub max_results: Option<u32>,
+    pub min_score: Option<f64>,
+    pub include_positions: Option<bool>,
+    pub is_case_sensitive: Option<bool>,
+    pub return_all_on_empty: Option<bool>,
+}
+
+pub(crate) fn to_js<T: Serialize>(value: &T) -> JsValue {
+    serde_wasm_bindgen::to_value(value).unwrap_or(JsValue::NULL)
+}
+
+pub(crate) use rapid_fuzzy_core::search::{
+    BigramIndex, PrecomputedSearch, compute_char_mask, compute_max_score, compute_query_mask,
+    extract_query_bigrams, resolve_case_matching, search_over_precomputed,
+    search_over_precomputed_indices,
+};
+
+// ─── Standalone search functions ────────────────────────────────────────────
+
+pub(crate) fn search_impl(
+    query: String,
+    items: Vec<String>,
+    max_results: Option<u32>,
+    min_score: Option<f64>,
+    include_positions: bool,
+    case_matching: CaseMatching,
+) -> Vec<SearchResult> {
+    core::search_impl(
+        query,
+        items,
+        max_results,
+        min_score,
+        include_positions,
+        case_matching,
+    )
+    .into_iter()
+    .map(SearchResult::from)
+    .collect()
+}
+
+/// Perform fuzzy search over a list of strings.
+///
+/// Returns matches sorted by score (best match first).
+/// Scores are normalized to a 0.0-1.0 range where 1.0 is a perfect match.
+#[wasm_bindgen]
+pub fn search(query: String, items: Vec<String>, options: Option<SearchOptions>) -> JsValue {
+    let opts = options.unwrap_or_default();
+    let (max_results, min_score, include_positions, case_matching, return_all_on_empty) = (
+        opts.max_results,
+        opts.min_score,
+        opts.include_positions.unwrap_or(false),
+        resolve_case_matching(opts.is_case_sensitive),
+        opts.return_all_on_empty.unwrap_or(false),
+    );
+
+    if return_all_on_empty && query.trim().is_empty() {
+        let limit = max_results.unwrap_or(items.len() as u32) as usize;
+        let results: Vec<SearchResult> = items
+            .iter()
+            .enumerate()
+            .take(limit)
+            .map(|(i, item)| SearchResult {
+                item: item.clone(),
+                score: 1.0,
+                index: i as u32,
+                positions: Vec::new(),
+                match_type: None,
+            })
+            .collect();
+        return to_js(&results);
+    }
+
+    let results = search_impl(
+        query,
+        items,
+        max_results,
+        min_score,
+        include_positions,
+        case_matching,
+    );
+    to_js(&results)
+}
+
+/// Find the closest matching string from a list.
+///
+/// Returns the best match, or null if no match is found.
+#[wasm_bindgen]
+pub fn closest(query: String, items: Vec<String>, min_score: Option<f64>) -> Option<String> {
+    let results = search_impl(query, items, Some(1), min_score, false, CaseMatching::Smart);
+    results.into_iter().next().map(|r| r.item)
+}

--- a/crates/wasm/src/search/mod.rs
+++ b/crates/wasm/src/search/mod.rs
@@ -9,7 +9,7 @@ pub use keys::search_keys;
 use nucleo_matcher::pattern::CaseMatching;
 use rapid_fuzzy_core::search as core;
 use serde::{Deserialize, Serialize};
-use tsify_next::Tsify;
+use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 // ─── Shared wasm types ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `crates/wasm` — a new `rapid-fuzzy-wasm` crate that wraps `rapid-fuzzy-core` with `wasm-bindgen` for browser/Deno/Bun deployment
- Implements complete API surface: all 14 distance metrics + `FuzzyIndex`, `KeyedFuzzyIndex`, and `searchKeys` with identical behaviour to the Node.js napi-rs bindings
- No `SharedArrayBuffer` required; targets `wasm32-unknown-unknown` for maximum CDN/edge compatibility
- Serialisation formats (`FuzzyIndex`/`KeyedFuzzyIndex`) are binary-compatible with the Node.js implementation, enabling cross-platform index persistence

## Related issue

Closes #441
Part of #439

## Checklist

- [x] `cargo build -p rapid-fuzzy-wasm --target wasm32-unknown-unknown` passes
- [x] `cargo clippy -p rapid-fuzzy-wasm --target wasm32-unknown-unknown` — no warnings
- [x] `cargo test` — all 268 tests pass
- [x] `pnpm test` — all JS tests pass
- [x] `cargo-deny` advisories — clean (switched `tsify-next` → `tsify` for RUSTSEC-2025-0048)
- [x] Conventional Commits format