### PR TITLE
docs: add browser and edge runtime usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,8 @@ pnpm add rapid-fuzzy
 ### Runtime-specific notes
 
 - **Node.js** (>=20): Uses native bindings via napi-rs for best performance.
-- **Browser / Deno / Bun**: Falls back to a WASM build automatically. The WASM binary is ~660 KB raw (~230 KB gzipped).
-
-> **Browser WASM requirement**: The WASM build uses `SharedArrayBuffer` for threading, which requires the following HTTP headers on your page:
-> ```
-> Cross-Origin-Opener-Policy: same-origin
-> Cross-Origin-Embedder-Policy: require-corp
-> ```
-> Without these headers, you will see `SharedArrayBuffer is not defined`. See [MDN: SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements) for details.
+- **Bun**: Uses native napi-rs bindings. WASM fallback also works — see [Bun section](#bun) below.
+- **Browser / CDN / Cloudflare Workers / Deno**: Falls back to the wasm-bindgen WASM build (~195 KB raw). No `SharedArrayBuffer` or COOP/COEP headers required.
 
 ### Framework Integration (SSR)
 
@@ -84,7 +78,82 @@ export default {
 };
 ```
 
-On the client side, rapid-fuzzy automatically falls back to WASM — no additional configuration needed beyond the SharedArrayBuffer headers above.
+On the client side, rapid-fuzzy automatically falls back to WASM — no additional configuration needed.
+
+### Browser and Edge Runtime Usage
+
+#### CDN (no bundler required)
+
+Import directly from [esm.sh](https://esm.sh) in any `<script type="module">`:
+
+```html
+<script type="module">
+  import { search, FuzzyIndex } from 'https://esm.sh/rapid-fuzzy';
+
+  const results = search('typscript', ['TypeScript', 'JavaScript', 'Python']);
+  console.log(results[0].item); // 'TypeScript'
+
+  const index = new FuzzyIndex(['TypeScript', 'JavaScript', 'Python']);
+  console.log(index.search('typscript')[0].item); // 'TypeScript'
+  index.destroy();
+</script>
+```
+
+See [`examples/cdn-usage/`](examples/cdn-usage/) for a complete HTML example.
+
+#### Cloudflare Workers
+
+Install the package and import it in your Worker script. Wrangler bundles the WASM binary automatically:
+
+```bash
+npm install rapid-fuzzy
+```
+
+```js
+// worker.js
+import { search, FuzzyIndex } from 'rapid-fuzzy';
+
+// Create the index once at module scope (shared across requests)
+const index = new FuzzyIndex(['hello', 'world', 'foo', 'bar']);
+
+export default {
+  async fetch(request) {
+    const { searchParams } = new URL(request.url);
+    const query = searchParams.get('q') ?? '';
+    const results = index.search(query);
+    return Response.json(results);
+  },
+};
+```
+
+```toml
+# wrangler.toml
+name = "rapid-fuzzy-worker"
+compatibility_date = "2025-01-01"
+```
+
+See [`examples/cloudflare-workers/`](examples/cloudflare-workers/) for a complete example.
+
+#### Deno
+
+Use rapid-fuzzy via the `npm:` specifier (Deno 1.28+):
+
+```ts
+import { search } from 'npm:rapid-fuzzy';
+
+const results = search('typscript', ['TypeScript', 'JavaScript', 'Python']);
+console.log(results[0].item); // 'TypeScript'
+```
+
+Or import from a CDN directly:
+
+```ts
+import { search } from 'https://esm.sh/rapid-fuzzy';
+```
+
+#### Bun
+
+Bun uses the native napi-rs bindings when available (fastest). You can also use the wasm-bindgen WASM files directly if needed — see [`e2e/wasm-bun.test.ts`](e2e/wasm-bun.test.ts) for the manual initialization pattern.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ import { search, FuzzyIndex } from 'rapid-fuzzy';
 const index = new FuzzyIndex(['hello', 'world', 'foo', 'bar']);
 
 export default {
-  async fetch(request) {
+  fetch(request) {
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q') ?? '';
     const results = index.search(query);
@@ -129,6 +129,7 @@ export default {
 ```toml
 # wrangler.toml
 name = "rapid-fuzzy-worker"
+main = "worker.js"
 compatibility_date = "2025-01-01"
 ```
 

--- a/examples/cdn-usage/index.html
+++ b/examples/cdn-usage/index.html
@@ -39,6 +39,9 @@
     const firstResult = document.createElement('p');
     firstResult.textContent = `search("javas") → ${oneOff.map((r) => r.item).join(', ')}`;
     document.body.appendChild(firstResult);
+
+    // Release Rust-side memory when the page is unloaded
+    window.addEventListener('beforeunload', () => index.destroy());
   </script>
 </body>
 </html>

--- a/examples/cdn-usage/index.html
+++ b/examples/cdn-usage/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>rapid-fuzzy CDN example</title>
+</head>
+<body>
+  <h1>rapid-fuzzy CDN example</h1>
+  <label>
+    Search: <input id="query" type="search" placeholder="e.g. typscript" />
+  </label>
+  <ul id="results"></ul>
+
+  <script type="module">
+    // Import directly from esm.sh — no npm install or bundler required.
+    // esm.sh resolves the `browser` export condition and serves the WASM build.
+    import { FuzzyIndex, search } from 'https://esm.sh/rapid-fuzzy';
+
+    const items = ['TypeScript', 'JavaScript', 'Python', 'Rust', 'Go', 'TypeSpec'];
+    const index = new FuzzyIndex(items);
+
+    const input = document.getElementById('query');
+    const list = document.getElementById('results');
+
+    function render(query) {
+      const matches = query ? index.search(query) : [];
+      list.innerHTML = matches.map((r) => `<li>${r.item} (${r.score.toFixed(2)})</li>`).join('');
+    }
+
+    input.addEventListener('input', (e) => render(e.currentTarget.value));
+
+    // Initial render with a sample query to demonstrate the library
+    input.value = 'typscript';
+    render('typscript');
+
+    // Also demonstrate standalone search (no index needed for one-off queries)
+    const oneOff = search('javas', items);
+    const firstResult = document.createElement('p');
+    firstResult.textContent = `search("javas") → ${oneOff.map((r) => r.item).join(', ')}`;
+    document.body.appendChild(firstResult);
+  </script>
+</body>
+</html>

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rapid-fuzzy-cloudflare-workers-example",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "dependencies": {
+    "rapid-fuzzy": "*"
+  },
+  "devDependencies": {
+    "wrangler": "^3.0.0"
+  }
+}

--- a/examples/cloudflare-workers/worker.js
+++ b/examples/cloudflare-workers/worker.js
@@ -1,0 +1,38 @@
+import { closest, FuzzyIndex } from 'rapid-fuzzy';
+
+// Create the index once at module scope.
+// It is shared across all requests in the same isolate, avoiding
+// the per-request overhead of rebuilding the index.
+const ITEMS = [
+  'TypeScript',
+  'JavaScript',
+  'Python',
+  'Rust',
+  'Go',
+  'TypeSpec',
+  'WebAssembly',
+  'Cloudflare Workers',
+];
+const index = new FuzzyIndex(ITEMS);
+
+// biome-ignore lint/style/noDefaultExport: required by Cloudflare Workers
+export default {
+  /**
+   * Handle incoming requests.
+   *
+   * GET /?q=<query>          → fuzzy search results (JSON array)
+   * GET /?q=<query>&closest  → closest single match (JSON string)
+   */
+  fetch(request) {
+    const { searchParams } = new URL(request.url);
+    const query = searchParams.get('q') ?? '';
+
+    if (searchParams.has('closest')) {
+      const match = closest(query, ITEMS);
+      return Response.json(match ?? null);
+    }
+
+    const results = index.search(query);
+    return Response.json(results);
+  },
+};

--- a/examples/cloudflare-workers/wrangler.toml
+++ b/examples/cloudflare-workers/wrangler.toml
@@ -1,0 +1,3 @@
+name = "rapid-fuzzy-worker"
+main = "worker.js"
+compatibility_date = "2025-01-01"


### PR DESCRIPTION
## Summary

- Adds "Browser and Edge Runtime Usage" section to README covering CDN, Cloudflare Workers, Deno, and Bun
- Removes outdated SharedArrayBuffer / COOP-COEP header requirement notice (resolved by #445)
- Adds `examples/cdn-usage/index.html`: interactive search-as-you-type demo using esm.sh CDN
- Adds `examples/cloudflare-workers/`: Cloudflare Workers example with Wrangler config and module-scope FuzzyIndex

## Related issue

Closes #417

## Checklist

- [x] README updated with CDN and edge runtime documentation
- [x] Working CDN example (no bundler required, imports from esm.sh)
- [x] Working Cloudflare Workers example with wrangler.toml
- [x] All Biome lint checks pass
- [x] All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified runtime guidance: removed SharedArrayBuffer/COOP/COEP header requirements and clarified Browser/CDN/Cloudflare Workers/Deno usage; noted Bun uses native bindings with a WASM fallback
  * Added a new "Browser and Edge Runtime Usage" section with concrete import/setup examples for CDN, Cloudflare Workers, Deno, and Bun

* **New Features**
  * Added a self-contained browser/CDN demo
  * Added a Cloudflare Workers example with deployment configuration and package setup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->