### PR TITLE
feat(ecosystem): add VitePress local search plugin example

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -131,6 +131,19 @@
       }
     },
     {
+      "includes": ["examples/vitepress-plugin/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noDefaultExport": "off"
+          },
+          "correctness": {
+            "noUndeclaredDependencies": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["playground/**"],
       "linter": {
         "rules": {

--- a/examples/vitepress-plugin/SearchBox.vue
+++ b/examples/vitepress-plugin/SearchBox.vue
@@ -1,0 +1,177 @@
+<!--
+  SearchBox.vue — VitePress search component backed by rapid-fuzzy
+
+  Loads the pre-built KeyedFuzzyIndex from /search-index.bin and
+  /search-manifest.json at mount time, then queries it on every keystroke.
+
+  Usage (.vitepress/theme/index.ts):
+    import { h } from 'vue'
+    import DefaultTheme from 'vitepress/theme'
+    import SearchBox from '../../examples/vitepress-plugin/SearchBox.vue'
+
+    export default {
+      extends: DefaultTheme,
+      Layout: () => h(DefaultTheme.Layout, null, {
+        'nav-bar-content-after': () => h(SearchBox),
+      }),
+    }
+-->
+<script setup lang="ts">
+import { useRouter, withBase } from 'vitepress';
+import { onMounted, ref, watch } from 'vue';
+
+import type { PageMeta } from './plugin.ts';
+
+// rapid-fuzzy is imported dynamically from the CDN so no bundler configuration
+// is needed for the WASM binary. esm.sh resolves the `browser` export condition
+// automatically and serves the wasm-bindgen build.
+const RAPID_FUZZY_CDN = 'https://esm.sh/rapid-fuzzy';
+
+interface WasmFuzzyResult {
+  index: number;
+  score: number;
+}
+
+interface WasmKeyedFuzzyIndex {
+  search(query: string, options?: { maxResults?: number }): WasmFuzzyResult[];
+}
+
+interface WasmModule {
+  KeyedFuzzyIndex: {
+    deserialize(data: Uint8Array): WasmKeyedFuzzyIndex;
+  };
+}
+
+const router = useRouter();
+const query = ref('');
+const results = ref<PageMeta[]>([]);
+const open = ref(false);
+
+let fuzzyIndex: WasmKeyedFuzzyIndex | null = null;
+let manifest: PageMeta[] = [];
+
+onMounted(async () => {
+  const [mod, manifestRes, binRes] = await Promise.all([
+    import(/* @vite-ignore */ RAPID_FUZZY_CDN) as Promise<WasmModule>,
+    fetch(withBase('/search-manifest.json')).then((r) => r.json() as Promise<PageMeta[]>),
+    fetch(withBase('/search-index.bin')),
+  ]);
+
+  manifest = manifestRes;
+  const buf = await binRes.arrayBuffer();
+  fuzzyIndex = mod.KeyedFuzzyIndex.deserialize(new Uint8Array(buf));
+});
+
+watch(query, (q) => {
+  if (!fuzzyIndex || !q.trim()) {
+    results.value = [];
+    open.value = false;
+    return;
+  }
+  const hits = fuzzyIndex.search(q, { maxResults: 8 });
+  results.value = hits.map((h) => manifest[h.index]).filter(Boolean);
+  open.value = results.value.length > 0;
+});
+
+// biome-ignore lint/correctness/noUnusedVariables: used in Vue template
+function navigate(url: string) {
+  router.go(url);
+  query.value = '';
+  open.value = false;
+}
+
+// biome-ignore lint/correctness/noUnusedVariables: used in Vue template
+function onBlur() {
+  // Delay so click on a result fires before hiding the list
+  setTimeout(() => {
+    open.value = false;
+  }, 150);
+}
+</script>
+
+<template>
+  <div class="rf-search">
+    <input
+      v-model="query"
+      type="search"
+      class="rf-search__input"
+      placeholder="Search..."
+      aria-label="Search"
+      aria-autocomplete="list"
+      :aria-expanded="open"
+      @focus="open = results.length > 0"
+      @blur="onBlur"
+    />
+    <ul v-if="open" class="rf-search__results" role="listbox">
+      <li
+        v-for="page in results"
+        :key="page.url"
+        class="rf-search__result"
+        role="option"
+        @mousedown.prevent="navigate(page.url)"
+      >
+        <span class="rf-search__title">{{ page.title || page.url }}</span>
+        <span class="rf-search__url">{{ page.url }}</span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.rf-search {
+  position: relative;
+  display: inline-block;
+}
+
+.rf-search__input {
+  padding: 4px 10px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 4px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  font-size: 14px;
+  width: 200px;
+  outline: none;
+}
+
+.rf-search__input:focus {
+  border-color: var(--vp-c-brand-1);
+}
+
+.rf-search__results {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 280px;
+  background: var(--vp-c-bg-elv);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  z-index: 100;
+}
+
+.rf-search__result {
+  display: flex;
+  flex-direction: column;
+  padding: 8px 14px;
+  cursor: pointer;
+  gap: 2px;
+}
+
+.rf-search__result:hover {
+  background: var(--vp-c-default-soft);
+}
+
+.rf-search__title {
+  font-size: 14px;
+  color: var(--vp-c-text-1);
+}
+
+.rf-search__url {
+  font-size: 11px;
+  color: var(--vp-c-text-3);
+}
+</style>

--- a/examples/vitepress-plugin/package.json
+++ b/examples/vitepress-plugin/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vitepress-plugin-rapid-fuzzy-example",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "rapid-fuzzy": "*"
+  },
+  "peerDependencies": {
+    "vite": ">=5",
+    "vitepress": ">=1",
+    "vue": ">=3"
+  }
+}

--- a/examples/vitepress-plugin/plugin.ts
+++ b/examples/vitepress-plugin/plugin.ts
@@ -1,0 +1,131 @@
+/**
+ * rapidFuzzySearch — VitePress Vite plugin
+ *
+ * At build time this plugin:
+ *  1. Walks the docs directory and reads all .md files
+ *  2. Extracts frontmatter title and plain text from each page
+ *  3. Builds a KeyedFuzzyIndex (title weight=2, body weight=1)
+ *  4. Writes search-index.bin and search-manifest.json to the output directory
+ *
+ * Usage (.vitepress/config.ts):
+ *   import { rapidFuzzySearch } from '../examples/vitepress-plugin/plugin'
+ *   export default defineConfig({
+ *     vite: { plugins: [rapidFuzzySearch('.')] }
+ *   })
+ */
+import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { extname, join, relative } from 'node:path';
+import { KeyedFuzzyIndex } from 'rapid-fuzzy';
+import type { Plugin, ResolvedConfig } from 'vite';
+
+export interface PageMeta {
+  url: string;
+  title: string;
+}
+
+function extractFrontmatterTitle(content: string): string {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (match) {
+    const titleLine = match[1].match(/^title:\s*(.+)$/m);
+    if (titleLine) return titleLine[1].trim().replace(/^['"]|['"]$/g, '');
+  }
+  return '';
+}
+
+function extractTitle(content: string): string {
+  const fmTitle = extractFrontmatterTitle(content);
+  if (fmTitle) return fmTitle;
+  const headingMatch = content.match(/^#\s+(.+)/m);
+  return headingMatch ? headingMatch[1].trim() : '';
+}
+
+function extractText(content: string): string {
+  return (
+    content
+      // Remove frontmatter
+      .replace(/^---[\s\S]*?---\r?\n/, '')
+      // Remove fenced code blocks
+      .replace(/```[\s\S]*?```/g, '')
+      // Remove inline code
+      .replace(/`[^`]+`/g, '')
+      // Images
+      .replace(/!\[.*?\]\(.*?\)/g, '')
+      // Links → keep text
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      // Heading markers
+      .replace(/^#{1,6}\s+/gm, '')
+      // Bold / italic / strikethrough markers
+      .replace(/[*_~]{1,3}/g, '')
+      // Blockquotes
+      .replace(/^\s*>\s*/gm, '')
+      // HTML tags
+      .replace(/<[^>]+>/g, '')
+      // Collapse whitespace
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
+function mdFileToUrl(filePath: string, docsDir: string): string {
+  const rel = relative(docsDir, filePath).replace(/\\/g, '/');
+  const withoutExt = rel.replace(/\.md$/, '');
+  if (withoutExt === 'index') return '/';
+  if (withoutExt.endsWith('/index')) return `/${withoutExt.slice(0, -'/index'.length)}/`;
+  return `/${withoutExt}`;
+}
+
+function collectMdFiles(dir: string, results: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.') || entry === 'node_modules') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectMdFiles(full, results);
+    } else if (extname(entry) === '.md' && !entry.startsWith('_')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Create the rapid-fuzzy VitePress search plugin.
+ *
+ * @param docsDir - Absolute path to the VitePress docs root (the directory
+ *                  containing `.vitepress/`). Usually `__dirname` of your
+ *                  `config.ts`.
+ */
+export function rapidFuzzySearch(docsDir: string): Plugin {
+  let resolvedConfig: ResolvedConfig;
+
+  return {
+    name: 'vitepress-plugin-rapid-fuzzy-search',
+    apply: 'build',
+
+    configResolved(config) {
+      resolvedConfig = config;
+    },
+
+    closeBundle() {
+      const files = collectMdFiles(docsDir);
+      const meta: PageMeta[] = [];
+      const titles: string[] = [];
+      const texts: string[] = [];
+
+      for (const file of files) {
+        const content = readFileSync(file, 'utf-8');
+        meta.push({ url: mdFileToUrl(file, docsDir), title: extractTitle(content) });
+        titles.push(extractTitle(content));
+        texts.push(extractText(content));
+      }
+
+      // Two-key index: key 0 = title (weight 2), key 1 = body text (weight 1)
+      const index = new KeyedFuzzyIndex([titles, texts], [2, 1]);
+      const serialized = index.serialize();
+
+      const outDir = resolvedConfig.build.outDir;
+      mkdirSync(outDir, { recursive: true });
+      writeFileSync(join(outDir, 'search-index.bin'), serialized);
+      writeFileSync(join(outDir, 'search-manifest.json'), JSON.stringify(meta));
+    },
+  };
+}

--- a/examples/vitepress-plugin/plugin.ts
+++ b/examples/vitepress-plugin/plugin.ts
@@ -58,11 +58,9 @@ function extractText(content: string): string {
       .replace(/[*_~]{1,3}/g, '')
       // Blockquotes
       .replace(/^\s*>\s*/gm, '')
-      // Script and style blocks (before generic tag removal)
-      .replace(/<script[\s\S]*?<\/script>/gi, '')
-      .replace(/<style[\s\S]*?<\/style>/gi, '')
-      // HTML tags
-      .replace(/<[^>]+>/g, '')
+      // Angle brackets (replaces rather than strips to avoid partial tag remnants)
+      .replace(/</g, ' ')
+      .replace(/>/g, ' ')
       // Collapse whitespace
       .replace(/\s+/g, ' ')
       .trim()

--- a/examples/vitepress-plugin/plugin.ts
+++ b/examples/vitepress-plugin/plugin.ts
@@ -113,8 +113,9 @@ export function rapidFuzzySearch(docsDir: string): Plugin {
 
       for (const file of files) {
         const content = readFileSync(file, 'utf-8');
-        meta.push({ url: mdFileToUrl(file, docsDir), title: extractTitle(content) });
-        titles.push(extractTitle(content));
+        const title = extractTitle(content);
+        meta.push({ url: mdFileToUrl(file, docsDir), title });
+        titles.push(title);
         texts.push(extractText(content));
       }
 

--- a/examples/vitepress-plugin/plugin.ts
+++ b/examples/vitepress-plugin/plugin.ts
@@ -58,6 +58,9 @@ function extractText(content: string): string {
       .replace(/[*_~]{1,3}/g, '')
       // Blockquotes
       .replace(/^\s*>\s*/gm, '')
+      // Script and style blocks (before generic tag removal)
+      .replace(/<script[\s\S]*?<\/script>/gi, '')
+      .replace(/<style[\s\S]*?<\/style>/gi, '')
       // HTML tags
       .replace(/<[^>]+>/g, '')
       // Collapse whitespace

--- a/examples/vitepress-plugin/theme.ts
+++ b/examples/vitepress-plugin/theme.ts
@@ -1,0 +1,45 @@
+/**
+ * VitePress theme integration for the rapid-fuzzy search plugin.
+ *
+ * Copy these snippets into your .vitepress/theme/index.ts to replace
+ * VitePress's built-in local search with rapid-fuzzy.
+ *
+ * Step 1 — add the Vite plugin to .vitepress/config.ts:
+ *
+ *   import { defineConfig } from 'vitepress'
+ *   import { rapidFuzzySearch } from 'vitepress-plugin-rapid-fuzzy/plugin'
+ *
+ *   export default defineConfig({
+ *     // Disable the built-in local search
+ *     themeConfig: { search: { provider: 'local', options: {} } },
+ *     vite: {
+ *       plugins: [rapidFuzzySearch(__dirname)],
+ *     },
+ *   })
+ *
+ * Step 2 — extend the default theme in .vitepress/theme/index.ts:
+ *
+ *   import { h } from 'vue'
+ *   import DefaultTheme from 'vitepress/theme'
+ *   import SearchBox from 'vitepress-plugin-rapid-fuzzy/SearchBox.vue'
+ *
+ *   export default {
+ *     extends: DefaultTheme,
+ *     Layout: () =>
+ *       h(DefaultTheme.Layout, null, {
+ *         'nav-bar-content-after': () => h(SearchBox),
+ *       }),
+ *   }
+ */
+
+import DefaultTheme from 'vitepress/theme';
+import { h } from 'vue';
+import SearchBox from './SearchBox.vue';
+
+export default {
+  extends: DefaultTheme,
+  Layout: () =>
+    h(DefaultTheme.Layout, null, {
+      'nav-bar-content-after': () => h(SearchBox),
+    }),
+};


### PR DESCRIPTION
## Summary

- Adds `examples/vitepress-plugin/` with a working VitePress search integration example
- `plugin.ts`: Vite build plugin — walks docs directory, builds `KeyedFuzzyIndex` (title weight=2, body weight=1), serializes to `search-index.bin` + `search-manifest.json`
- `SearchBox.vue`: Vue 3 search component — loads rapid-fuzzy from CDN at runtime, deserializes the pre-built index, queries on each keystroke, renders a styled dropdown
- `theme.ts`: VitePress theme integration via `nav-bar-content-after` layout slot
- Updates `biome.json` with a lint override for the new example directory

## Related issue

Closes #424

## Technical notes

The hard blocker in #424 was the SharedArrayBuffer/COOP-COEP requirement. This is resolved — the wasm-bindgen build shipped in #445 runs without those headers. The CDN import (`esm.sh/rapid-fuzzy`) resolves the `browser` export condition and serves the wasm-bindgen build automatically.

The plugin uses `KeyedFuzzyIndex` with two keys (title and body text) so title matches rank higher than body matches, matching typical search UX expectations.

## Checklist

- [x] Vite build plugin generates serialized index at build time
- [x] Vue component loads and searches the pre-built index at runtime  
- [x] No SharedArrayBuffer required — works on GitHub Pages, Netlify, Cloudflare Pages
- [x] All Biome lint checks pass
- [x] All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive VitePress plugin example demonstrating fuzzy-search integration for documentation websites. Includes an interactive search component with real-time results, automatic search index generation from markdown files, and seamless navigation bar integration for improved documentation discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->