### PR TITLE
fix(objects): perform Rust operations before mutating JS items array

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/objects.js
+++ b/objects.js
@@ -136,8 +136,8 @@ class FuzzyObjectIndex {
    * @param {T} item
    */
   add(item) {
-    this.#items.push(item);
     this.#index.add(this.#keys.map((k) => getNestedValue(item, k.name)));
+    this.#items.push(item);
   }
 
   /**
@@ -145,10 +145,10 @@ class FuzzyObjectIndex {
    * @param {T[]} items
    */
   addMany(items) {
+    this.#index.addMany(items.map((item) => this.#keys.map((k) => getNestedValue(item, k.name))));
     for (const item of items) {
       this.#items.push(item);
     }
-    this.#index.addMany(items.map((item) => this.#keys.map((k) => getNestedValue(item, k.name))));
   }
 
   /**
@@ -159,13 +159,14 @@ class FuzzyObjectIndex {
    */
   remove(index) {
     if (index < 0 || index >= this.#items.length) return false;
-    // Swap-remove to match Rust-side behavior
+    if (!this.#index.remove(index)) return false;
+    // Mirror the Rust-side swap-remove on the JS items array
     const lastIdx = this.#items.length - 1;
     if (index !== lastIdx) {
       this.#items[index] = this.#items[lastIdx];
     }
     this.#items.pop();
-    return this.#index.remove(index);
+    return true;
   }
 
   /** Free all internal data. */


### PR DESCRIPTION
## Summary

- `add()`: call `#index.add()` before pushing to `#items`
- `addMany()`: call `#index.addMany()` before pushing to `#items`
- `remove()`: call `#index.remove()` first, return `false` on failure, then apply swap-remove to `#items`
- Updates `biome.json` `$schema` to `2.4.9` to match the installed CLI version

## Related issue

Closes #448

## Background

In all three methods, the JS-side `#items` array was mutated before the corresponding Rust-side operation. If the Rust call threw or `remove()` returned `false`, `#items` and `#index` would be out of sync — `#items` modified but `#index` unchanged.

Reordering ensures `#items` is only updated after the Rust operation succeeds.

## Checklist

- [x] All tests pass
- [x] Biome lint passes (no warnings)