### PR TITLE
fix(changeset): add missing changeset for objects.js mutation ordering fix

### DIFF
--- a/.changeset/objects-mutation-order-fix.md
+++ b/.changeset/objects-mutation-order-fix.md
@@ -1,0 +1,5 @@
+---
+"rapid-fuzzy": patch
+---
+
+Fix mutation ordering in `objects.js` where the JS items array was mutated before Rust operations completed, which could cause state divergence if the Rust call threw an error.


### PR DESCRIPTION
## Summary

- Add a `patch` changeset for the objects.js mutation ordering bug fix from #449
- The fix is part of the distributed npm package but was missing a changeset entry

Closes #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mutation ordering to prevent state inconsistency when operations encounter errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->