### PR TITLE
fix(ci): use pnpm script for changeset version command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         id: changesets
         uses: changesets/action@ce079ea084e08a340947ed4d6ecedb2433c8f293 # v1
         with:
-          version: pnpm changeset version && node scripts/sync-cargo-version.js
+          version: pnpm changeset:version
           title: "chore(release): version packages"
           commit: "chore(release): version packages"
         env:

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "artifacts": "napi artifacts",
     "prepublishOnly": "napi prepublish -t npm",
     "version": "napi version",
+    "changeset:version": "pnpm changeset version && node scripts/sync-cargo-version.js",
     "check": "biome ci",
     "format": "biome format --write",
     "lint": "biome check",


### PR DESCRIPTION
## Summary

- Fix the Release workflow that has been failing on every push to develop since #430
- Root cause: `changesets/action` executes the `version` input via `exec()` without a shell, so `&&` is passed as a literal argument to the changeset CLI
- Fix: wrap the two commands in a `changeset:version` package.json script, where pnpm's shell handles `&&` correctly

## Changes

- `package.json`: add `changeset:version` script
- `.github/workflows/release.yml`: use `pnpm changeset:version` instead of inline `&&` command

Closes #458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal release workflow by consolidating version synchronization commands into a single script invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->