### PR TITLE
test(wasm): add missing tests for indel, normalizedIndel, and normalizedHamming

### DIFF
--- a/__test__/wasm.spec.ts
+++ b/__test__/wasm.spec.ts
@@ -28,6 +28,9 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
         'hamming',
         'hammingBatch',
         'hammingMany',
+        'indel',
+        'indelBatch',
+        'indelMany',
         'jaro',
         'jaroBatch',
         'jaroMany',
@@ -37,6 +40,12 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
         'levenshtein',
         'levenshteinBatch',
         'levenshteinMany',
+        'normalizedHamming',
+        'normalizedHammingBatch',
+        'normalizedHammingMany',
+        'normalizedIndel',
+        'normalizedIndelBatch',
+        'normalizedIndelMany',
         'normalizedLevenshtein',
         'normalizedLevenshteinBatch',
         'normalizedLevenshteinMany',
@@ -113,6 +122,31 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
       expect(wasm.hamming('hello', 'world')).toBe(4);
       expect(wasm.hamming('hello', 'hi')).toBeNull();
       expect(wasm.hamming('', '')).toBe(0);
+    });
+
+    it('indel', () => {
+      expect(wasm.indel('hello', 'hello')).toBe(0);
+      expect(wasm.indel('abc', 'ac')).toBe(1);
+      expect(wasm.indel('abc', 'bc')).toBe(1);
+      expect(wasm.indel('', '')).toBe(0);
+      expect(wasm.indel('abc', '')).toBe(3);
+    });
+
+    it('normalizedIndel', () => {
+      expect(wasm.normalizedIndel('hello', 'hello')).toBe(1.0);
+      expect(wasm.normalizedIndel('', '')).toBe(1.0);
+      const score = wasm.normalizedIndel('hello', 'world');
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+
+    it('normalizedHamming', () => {
+      expect(wasm.normalizedHamming('hello', 'hello')).toBe(1.0);
+      expect(wasm.normalizedHamming('', '')).toBe(1.0);
+      expect(wasm.normalizedHamming('hello', 'hi')).toBeNull();
+      const score = wasm.normalizedHamming('karolin', 'kathrin');
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
     });
 
     it('tokenSortRatio', () => {
@@ -213,6 +247,34 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
       expect(result[2]).toBeNull();
     });
 
+    it('indelBatch', () => {
+      const result = wasm.indelBatch([
+        ['hello', 'hello'],
+        ['abc', 'ac'],
+      ]);
+      expect(result).toEqual([0, 1]);
+    });
+
+    it('normalizedIndelBatch', () => {
+      const result = wasm.normalizedIndelBatch([
+        ['hello', 'hello'],
+        ['hello', 'world'],
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(1.0);
+    });
+
+    it('normalizedHammingBatch', () => {
+      const result = wasm.normalizedHammingBatch([
+        ['hello', 'hello'],
+        ['hello', 'world'],
+        ['hello', 'hi'],
+      ]);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toBe(1.0);
+      expect(result[2]).toBeNull();
+    });
+
     it('tokenSortRatioBatch', () => {
       const result = wasm.tokenSortRatioBatch([
         ['hello world', 'hello world'],
@@ -292,6 +354,26 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
       expect(result).toHaveLength(3);
       expect(result[0]).toBe(0);
       expect(result[1]).toBe(4);
+      expect(result[2]).toBeNull();
+    });
+
+    it('indelMany', () => {
+      const result = wasm.indelMany('abc', ['abc', 'ac', 'bc', '']);
+      expect(result).toHaveLength(4);
+      expect(result[0]).toBe(0);
+      expect(result[1]).toBe(1);
+    });
+
+    it('normalizedIndelMany', () => {
+      const result = wasm.normalizedIndelMany('hello', ['hello', 'world']);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(1.0);
+    });
+
+    it('normalizedHammingMany', () => {
+      const result = wasm.normalizedHammingMany('hello', ['hello', 'world', 'hi']);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toBe(1.0);
       expect(result[2]).toBeNull();
     });
 
@@ -409,6 +491,24 @@ describe.skipIf(!wasmAvailable)('wasm', () => {
     it('hamming results should match native', () => {
       for (const [a, b] of testPairs) {
         expect(wasm.hamming(a, b)).toBe(native.hamming(a, b));
+      }
+    });
+
+    it('indel results should match native', () => {
+      for (const [a, b] of testPairs) {
+        expect(wasm.indel(a, b)).toBe(native.indel(a, b));
+      }
+    });
+
+    it('normalizedIndel results should match native', () => {
+      for (const [a, b] of testPairs) {
+        expect(wasm.normalizedIndel(a, b)).toBe(native.normalizedIndel(a, b));
+      }
+    });
+
+    it('normalizedHamming results should match native', () => {
+      for (const [a, b] of testPairs) {
+        expect(wasm.normalizedHamming(a, b)).toBe(native.normalizedHamming(a, b));
       }
     });
 

--- a/e2e/browser.spec.ts
+++ b/e2e/browser.spec.ts
@@ -56,6 +56,36 @@ test.describe('distance functions', () => {
     const score = await page.evaluate(() => window.__results.sorensenDice);
     expect(score).toBe(1.0);
   });
+
+  test('hamming', async ({ page }) => {
+    const dist = await page.evaluate(() => window.__results.hamming);
+    expect(dist).toBe(3);
+  });
+
+  test('hamming returns null for different lengths', async ({ page }) => {
+    const result = await page.evaluate(() => window.__results.hammingNull);
+    expect(result).toBeNull();
+  });
+
+  test('indel', async ({ page }) => {
+    const dist = await page.evaluate(() => window.__results.indel);
+    expect(dist).toBe(1);
+  });
+
+  test('normalizedIndel', async ({ page }) => {
+    const score = await page.evaluate(() => window.__results.normalizedIndel);
+    expect(score).toBe(1.0);
+  });
+
+  test('normalizedHamming', async ({ page }) => {
+    const score = await page.evaluate(() => window.__results.normalizedHamming);
+    expect(score).toBe(1.0);
+  });
+
+  test('normalizedHamming returns null for different lengths', async ({ page }) => {
+    const result = await page.evaluate(() => window.__results.normalizedHammingNull);
+    expect(result).toBeNull();
+  });
 });
 
 test.describe('batch functions', () => {

--- a/e2e/browser.spec.ts
+++ b/e2e/browser.spec.ts
@@ -100,6 +100,28 @@ test.describe('batch functions', () => {
     expect(result[0]).toBe(1.0);
     expect(result[1]).toBe(0.0);
   });
+
+  test('hammingBatch', async ({ page }) => {
+    const result = await page.evaluate(() => window.__results.hammingBatch);
+    expect(result).toEqual([0, 3]);
+  });
+
+  test('indelBatch', async ({ page }) => {
+    const result = await page.evaluate(() => window.__results.indelBatch);
+    expect(result).toEqual([0, 1]);
+  });
+
+  test('normalizedIndelBatch', async ({ page }) => {
+    const result = await page.evaluate(() => window.__results.normalizedIndelBatch);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(1.0);
+  });
+
+  test('normalizedHammingBatch', async ({ page }) => {
+    const result = await page.evaluate(() => window.__results.normalizedHammingBatch);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(1.0);
+  });
 });
 
 test.describe('many functions', () => {
@@ -113,6 +135,33 @@ test.describe('many functions', () => {
     const result = await page.evaluate(() => window.__results.jaroMany);
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(1.0);
+  });
+
+  test('hammingMany', async ({ page }) => {
+    const result = await page.evaluate(() => window.__results.hammingMany);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe(0);
+    expect(result[2]).toBeNull();
+  });
+
+  test('indelMany', async ({ page }) => {
+    const result = await page.evaluate(() => window.__results.indelMany);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBe(1);
+  });
+
+  test('normalizedIndelMany', async ({ page }) => {
+    const result = await page.evaluate(() => window.__results.normalizedIndelMany);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(1.0);
+  });
+
+  test('normalizedHammingMany', async ({ page }) => {
+    const result = await page.evaluate(() => window.__results.normalizedHammingMany);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe(1.0);
+    expect(result[2]).toBeNull();
   });
 });
 

--- a/e2e/browser.spec.ts
+++ b/e2e/browser.spec.ts
@@ -64,6 +64,7 @@ test.describe('distance functions', () => {
 
   test('hamming returns null for different lengths', async ({ page }) => {
     const result = await page.evaluate(() => window.__results.hammingNull);
+    // wasm-bindgen single functions return JsValue::NULL which Playwright preserves as null
     expect(result).toBeNull();
   });
 
@@ -141,7 +142,8 @@ test.describe('many functions', () => {
     const result = await page.evaluate(() => window.__results.hammingMany);
     expect(result).toHaveLength(3);
     expect(result[0]).toBe(0);
-    expect(result[2]).toBeNull();
+    // serde_wasm_bindgen serializes None as undefined in arrays; Playwright preserves it
+    expect(result[2]).toBeUndefined();
   });
 
   test('indelMany', async ({ page }) => {
@@ -161,7 +163,8 @@ test.describe('many functions', () => {
     const result = await page.evaluate(() => window.__results.normalizedHammingMany);
     expect(result).toHaveLength(3);
     expect(result[0]).toBe(1.0);
-    expect(result[2]).toBeNull();
+    // serde_wasm_bindgen serializes None as undefined in arrays; Playwright preserves it
+    expect(result[2]).toBeUndefined();
   });
 });
 

--- a/e2e/global.d.ts
+++ b/e2e/global.d.ts
@@ -17,8 +17,16 @@ interface Window {
     normalizedHammingNull: number | null;
     levenshteinBatch: number[];
     jaroBatch: number[];
+    hammingBatch: (number | null)[];
+    indelBatch: number[];
+    normalizedIndelBatch: number[];
+    normalizedHammingBatch: (number | null)[];
     levenshteinMany: number[];
     jaroMany: number[];
+    hammingMany: (number | null)[];
+    indelMany: number[];
+    normalizedIndelMany: number[];
+    normalizedHammingMany: (number | null)[];
     tokenSortRatio: number;
     tokenSetRatio: number;
     partialRatio: number;

--- a/e2e/global.d.ts
+++ b/e2e/global.d.ts
@@ -9,6 +9,12 @@ interface Window {
     jaro: number;
     jaroWinkler: number;
     sorensenDice: number;
+    hamming: number;
+    hammingNull: number | null;
+    indel: number;
+    normalizedIndel: number;
+    normalizedHamming: number;
+    normalizedHammingNull: number | null;
     levenshteinBatch: number[];
     jaroBatch: number[];
     levenshteinMany: number[];

--- a/e2e/index.html
+++ b/e2e/index.html
@@ -56,9 +56,18 @@
       results.levenshteinBatch = Array.from(mod.levenshteinBatch([['hello', 'hello'], ['hello', 'world']]));
       results.jaroBatch = Array.from(mod.jaroBatch([['hello', 'hello'], ['abc', 'xyz']]));
 
+      results.hammingBatch = Array.from(mod.hammingBatch([['hello', 'hello'], ['karolin', 'kathrin']]));
+      results.indelBatch = Array.from(mod.indelBatch([['hello', 'hello'], ['abc', 'ac']]));
+      results.normalizedIndelBatch = Array.from(mod.normalizedIndelBatch([['hello', 'hello'], ['hello', 'world']]));
+      results.normalizedHammingBatch = Array.from(mod.normalizedHammingBatch([['hello', 'hello'], ['hello', 'world']]));
+
       // Many functions — convert TypedArray to plain array for JSON serialization
       results.levenshteinMany = Array.from(mod.levenshteinMany('hello', ['hello', 'world', 'help']));
       results.jaroMany = Array.from(mod.jaroMany('hello', ['hello', 'world']));
+      results.hammingMany = Array.from(mod.hammingMany('hello', ['hello', 'world', 'hi']));
+      results.indelMany = Array.from(mod.indelMany('abc', ['abc', 'ac', '']));
+      results.normalizedIndelMany = Array.from(mod.normalizedIndelMany('hello', ['hello', 'world']));
+      results.normalizedHammingMany = Array.from(mod.normalizedHammingMany('hello', ['hello', 'world', 'hi']));
 
       // Token-based functions
       results.tokenSortRatio = mod.tokenSortRatio('New York Mets', 'Mets New York');

--- a/e2e/index.html
+++ b/e2e/index.html
@@ -45,6 +45,12 @@
       results.jaro = mod.jaro('hello', 'hello');
       results.jaroWinkler = mod.jaroWinkler('hello', 'hello');
       results.sorensenDice = mod.sorensenDice('hello', 'hello');
+      results.hamming = mod.hamming('karolin', 'kathrin');
+      results.hammingNull = mod.hamming('hello', 'hi');
+      results.indel = mod.indel('abc', 'ac');
+      results.normalizedIndel = mod.normalizedIndel('hello', 'hello');
+      results.normalizedHamming = mod.normalizedHamming('hello', 'hello');
+      results.normalizedHammingNull = mod.normalizedHamming('hello', 'hi');
 
       // Batch functions — convert TypedArray to plain array for JSON serialization
       results.levenshteinBatch = Array.from(mod.levenshteinBatch([['hello', 'hello'], ['hello', 'world']]));
@@ -81,10 +87,14 @@
 
       // Export list check
       const expectedExports = [
-        'closest', 'search', 'FuzzyIndex',
+        'closest', 'search', 'searchKeys', 'FuzzyIndex',
         'levenshtein', 'levenshteinBatch', 'levenshteinMany',
         'normalizedLevenshtein', 'normalizedLevenshteinBatch', 'normalizedLevenshteinMany',
         'damerauLevenshtein', 'damerauLevenshteinBatch', 'damerauLevenshteinMany',
+        'hamming', 'hammingBatch', 'hammingMany',
+        'indel', 'indelBatch', 'indelMany',
+        'normalizedIndel', 'normalizedIndelBatch', 'normalizedIndelMany',
+        'normalizedHamming', 'normalizedHammingBatch', 'normalizedHammingMany',
         'jaro', 'jaroBatch', 'jaroMany',
         'jaroWinkler', 'jaroWinklerBatch', 'jaroWinklerMany',
         'sorensenDice', 'sorensenDiceBatch', 'sorensenDiceMany',

--- a/e2e/index.html
+++ b/e2e/index.html
@@ -52,7 +52,7 @@
       results.normalizedHamming = mod.normalizedHamming('hello', 'hello');
       results.normalizedHammingNull = mod.normalizedHamming('hello', 'hi');
 
-      // Batch functions — convert TypedArray to plain array for JSON serialization
+      // Batch functions — normalize to plain arrays for consistent JSON serialization
       results.levenshteinBatch = Array.from(mod.levenshteinBatch([['hello', 'hello'], ['hello', 'world']]));
       results.jaroBatch = Array.from(mod.jaroBatch([['hello', 'hello'], ['abc', 'xyz']]));
 
@@ -61,7 +61,7 @@
       results.normalizedIndelBatch = Array.from(mod.normalizedIndelBatch([['hello', 'hello'], ['hello', 'world']]));
       results.normalizedHammingBatch = Array.from(mod.normalizedHammingBatch([['hello', 'hello'], ['hello', 'world']]));
 
-      // Many functions — convert TypedArray to plain array for JSON serialization
+      // Many functions — normalize to plain arrays for consistent JSON serialization
       results.levenshteinMany = Array.from(mod.levenshteinMany('hello', ['hello', 'world', 'help']));
       results.jaroMany = Array.from(mod.jaroMany('hello', ['hello', 'world']));
       results.hammingMany = Array.from(mod.hammingMany('hello', ['hello', 'world', 'hi']));

--- a/e2e/wasm-bun.test.ts
+++ b/e2e/wasm-bun.test.ts
@@ -45,6 +45,26 @@ describe('WASM on Bun (wasm-bindgen)', () => {
     test('sorensenDice', () => {
       expect(wasm.sorensenDice('hello', 'hello')).toBe(1.0);
     });
+
+    test('hamming', () => {
+      expect(wasm.hamming('hello', 'hello')).toBe(0);
+      expect(wasm.hamming('karolin', 'kathrin')).toBe(3);
+      expect(wasm.hamming('hello', 'hi')).toBeNull();
+    });
+
+    test('indel', () => {
+      expect(wasm.indel('hello', 'hello')).toBe(0);
+      expect(wasm.indel('abc', 'ac')).toBe(1);
+    });
+
+    test('normalizedIndel', () => {
+      expect(wasm.normalizedIndel('hello', 'hello')).toBe(1.0);
+    });
+
+    test('normalizedHamming', () => {
+      expect(wasm.normalizedHamming('hello', 'hello')).toBe(1.0);
+      expect(wasm.normalizedHamming('hello', 'hi')).toBeNull();
+    });
   });
 
   describe('batch functions', () => {

--- a/e2e/wasm-bun.test.ts
+++ b/e2e/wasm-bun.test.ts
@@ -113,7 +113,8 @@ describe('WASM on Bun (wasm-bindgen)', () => {
       const result = wasm.normalizedHammingMany('hello', ['hello', 'world', 'hi']);
       expect(result).toHaveLength(3);
       expect(result[0]).toBe(1.0);
-      expect(result[2]).toBeNull();
+      // wasm-bindgen serializes None as undefined inside arrays (not null)
+      expect(result[2]).toBeUndefined();
     });
   });
 

--- a/e2e/wasm-bun.test.ts
+++ b/e2e/wasm-bun.test.ts
@@ -76,6 +76,23 @@ describe('WASM on Bun (wasm-bindgen)', () => {
         ]),
       ).toEqual(new Uint32Array([0, 4]));
     });
+
+    test('indelBatch', () => {
+      const result = wasm.indelBatch([
+        ['hello', 'hello'],
+        ['abc', 'ac'],
+      ]);
+      expect(Array.from(result)).toEqual([0, 1]);
+    });
+
+    test('normalizedHammingBatch', () => {
+      const result = wasm.normalizedHammingBatch([
+        ['hello', 'hello'],
+        ['hello', 'world'],
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(1.0);
+    });
   });
 
   describe('many functions', () => {
@@ -83,6 +100,20 @@ describe('WASM on Bun (wasm-bindgen)', () => {
       const result = wasm.levenshteinMany('hello', ['hello', 'world', 'help']);
       expect(result).toHaveLength(3);
       expect(result[0]).toBe(0);
+    });
+
+    test('indelMany', () => {
+      const result = wasm.indelMany('abc', ['abc', 'ac', '']);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toBe(0);
+      expect(result[1]).toBe(1);
+    });
+
+    test('normalizedHammingMany', () => {
+      const result = wasm.normalizedHammingMany('hello', ['hello', 'world', 'hi']);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toBe(1.0);
+      expect(result[2]).toBeNull();
     });
   });
 

--- a/e2e/wasm-deno.test.ts
+++ b/e2e/wasm-deno.test.ts
@@ -58,10 +58,32 @@ Deno.test('batch - levenshteinBatch', () => {
   );
 });
 
+Deno.test('batch - indelBatch', () => {
+  const result = wasm.indelBatch([
+    ['hello', 'hello'],
+    ['abc', 'ac'],
+  ]);
+  assertEquals(Array.from(result), [0, 1]);
+});
+
 Deno.test('many - levenshteinMany', () => {
   const result = wasm.levenshteinMany('hello', ['hello', 'world', 'help']);
   assertEquals(result.length, 3);
   assertEquals(result[0], 0);
+});
+
+Deno.test('many - indelMany', () => {
+  const result = wasm.indelMany('abc', ['abc', 'ac', '']);
+  assertEquals(result.length, 3);
+  assertEquals(result[0], 0);
+  assertEquals(result[1], 1);
+});
+
+Deno.test('many - normalizedHammingMany', () => {
+  const result = wasm.normalizedHammingMany('hello', ['hello', 'world', 'hi']);
+  assertEquals(result.length, 3);
+  assertEquals(result[0], 1.0);
+  assertEquals(result[2], null);
 });
 
 Deno.test('token - tokenSortRatio', () => {

--- a/e2e/wasm-deno.test.ts
+++ b/e2e/wasm-deno.test.ts
@@ -83,7 +83,8 @@ Deno.test('many - normalizedHammingMany', () => {
   const result = wasm.normalizedHammingMany('hello', ['hello', 'world', 'hi']);
   assertEquals(result.length, 3);
   assertEquals(result[0], 1.0);
-  assertEquals(result[2], null);
+  // wasm-bindgen serializes None as undefined inside arrays (not null)
+  assertEquals(result[2], undefined);
 });
 
 Deno.test('token - tokenSortRatio', () => {

--- a/e2e/wasm-deno.test.ts
+++ b/e2e/wasm-deno.test.ts
@@ -28,6 +28,26 @@ Deno.test('distance - sorensenDice', () => {
   assertEquals(wasm.sorensenDice('hello', 'hello'), 1.0);
 });
 
+Deno.test('distance - hamming', () => {
+  assertEquals(wasm.hamming('hello', 'hello'), 0);
+  assertEquals(wasm.hamming('karolin', 'kathrin'), 3);
+  assertEquals(wasm.hamming('hello', 'hi'), null);
+});
+
+Deno.test('distance - indel', () => {
+  assertEquals(wasm.indel('hello', 'hello'), 0);
+  assertEquals(wasm.indel('abc', 'ac'), 1);
+});
+
+Deno.test('distance - normalizedIndel', () => {
+  assertEquals(wasm.normalizedIndel('hello', 'hello'), 1.0);
+});
+
+Deno.test('distance - normalizedHamming', () => {
+  assertEquals(wasm.normalizedHamming('hello', 'hello'), 1.0);
+  assertEquals(wasm.normalizedHamming('hello', 'hi'), null);
+});
+
 Deno.test('batch - levenshteinBatch', () => {
   assertEquals(
     wasm.levenshteinBatch([


### PR DESCRIPTION
## Summary

- Add WASM test coverage for distance functions introduced in v1.2.0 (`indel`, `normalizedIndel`, `normalizedHamming` and their batch/many variants)
- Also add pre-existing gaps for `hamming` in browser, Bun, and Deno tests

## Changes

### `__test__/wasm.spec.ts` (WASI WASM)
- Add 9 functions to `expectedExports`: `indel`, `indelBatch`, `indelMany`, `normalizedIndel`, `normalizedIndelBatch`, `normalizedIndelMany`, `normalizedHamming`, `normalizedHammingBatch`, `normalizedHammingMany`
- Add single, batch, many, and native-parity test cases

### `e2e/index.html` + `e2e/browser.spec.ts` (Browser wasm-bindgen)
- Add `hamming`, `indel`, `normalizedIndel`, `normalizedHamming`, `searchKeys` to `expectedExports`
- Add result generation and Playwright assertions

### `e2e/wasm-bun.test.ts` / `e2e/wasm-deno.test.ts`
- Add test cases for `hamming`, `indel`, `normalizedIndel`, `normalizedHamming`

## Related issue

Closes #478

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (WASM tests correctly skipped without WASM binary)
- [x] `cargo clippy` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end and unit test coverage for string distance metrics (Hamming plus new Indel and normalized variants) across WASM, browser, Deno, and Bun.
  * Added checks for single-value, batch, and “many” call forms, including handling of incompatible inputs (null/undefined cases) and verification of returned array shapes and values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->