### PR TITLE
docs(readme): fix Quick Start output and update package description

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Try rapid-fuzzy in the browser — no installation required: **[Open Playground]
 import { search } from 'rapid-fuzzy';
 
 const results = search('typscript', ['TypeScript', 'JavaScript', 'Python']);
-// → [{ item: 'TypeScript', score: 0.85, index: 0 }, ...]
+// → [{ item: 'TypeScript', score: 0.85, index: 0, positions: [] }, ...]
 ```
 
 For repeated searches, use `FuzzyIndex` for up to 297x faster lookups:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rapid-fuzzy",
   "version": "1.2.0",
-  "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. 10-50x faster than fuse.js/leven.",
+  "description": "Rust-powered fuzzy search and string distance for JavaScript/TypeScript. Up to 15,000x faster than fuse.js with indexed mode.",
   "license": "MIT",
   "author": "derodero24",
   "repository": {


### PR DESCRIPTION
## Summary

- Add missing `positions: []` field to Quick Start search result example for consistency with the API section
- Update package.json description from "10-50x faster" to "Up to 15,000x faster with indexed mode" to reflect benchmarks

## Related issue

Closes #480

## Checklist

- [x] `pnpm run check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated search results example to clarify that the `positions` field is included in output.
  * Refreshed performance metrics in package description to reflect current benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->