### PR TITLE
docs: add migration guides for fuzzball, FlexSearch, and MiniSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,9 @@ Switching from another library? These guides provide API mapping tables, code ex
 - [**From leven / fastest-levenshtein**](docs/migration/from-leven.md) — Multi-algorithm upgrade with batch APIs
 - [**From fuzzysort**](docs/migration/from-fuzzysort.md) — Richer matching with query syntax and 10 distance algorithms
 - [**From uFuzzy**](docs/migration/from-ufuzzy.md) — Weighted object search, batch APIs, and persistent indexes
+- [**From fuzzball**](docs/migration/from-fuzzball.md) — Same ratio functions (token sort, token set, weighted), now 0.0–1.0 scale
+- [**From FlexSearch**](docs/migration/from-flexsearch.md) — Typo-tolerant fuzzy search to replace exact-token full-text search
+- [**From MiniSearch**](docs/migration/from-minisearch.md) — Faster fuzzy search with richer distance algorithms
 
 ## License
 

--- a/docs/migration/from-flexsearch.md
+++ b/docs/migration/from-flexsearch.md
@@ -1,0 +1,107 @@
+# Migrating from FlexSearch to rapid-fuzzy
+
+[FlexSearch](https://www.npmjs.com/package/flexsearch) is a full-text search engine that uses inverted indexes and tokenization. rapid-fuzzy is a fuzzy matching library that finds approximate string matches using edit distance and similarity algorithms. They serve different primary use cases, but rapid-fuzzy can replace FlexSearch for autocomplete and typo-tolerant search scenarios.
+
+## When to switch
+
+**Switch to rapid-fuzzy when**:
+- You need typo tolerance (e.g., "typscript" → "TypeScript")
+- You want ranked results by string similarity
+- You need match highlighting positions
+- You search short strings (names, tags, file names, commands)
+
+**Stay with FlexSearch when**:
+- You search full-text documents (articles, blog posts, logs)
+- You rely on tokenization, stemming, or language-specific analyzers
+- You need field-level scoring with document weights
+
+## Installation
+
+```bash
+# Remove FlexSearch
+npm uninstall flexsearch
+
+# Install rapid-fuzzy
+npm install rapid-fuzzy
+```
+
+## API Mapping
+
+| FlexSearch | rapid-fuzzy | Notes |
+|---|---|---|
+| `new Index()` + `index.add(id, text)` | `new FuzzyIndex(items)` | rapid-fuzzy indexes by array position |
+| `index.search(query)` | `index.search(query)` | Returns `{ item, score, index }[]` |
+| `index.add(id, text)` | `index.add(item)` | Appends to index |
+| `index.remove(id)` | `index.remove(index)` | Removes by position |
+
+## Code Examples
+
+### Basic search
+
+```typescript
+// Before (FlexSearch)
+import { Index } from 'flexsearch';
+const index = new Index();
+items.forEach((item, i) => index.add(i, item));
+const ids = index.search('typscript'); // [0] — returns IDs only
+
+// After (rapid-fuzzy)
+import { FuzzyIndex } from 'rapid-fuzzy';
+const index = new FuzzyIndex(items);
+const results = index.search('typscript');
+// [{ item: 'TypeScript', score: 0.85, index: 0, positions: [] }]
+```
+
+### Standalone search (no index)
+
+```typescript
+// Before (FlexSearch) — always requires index setup
+import { Index } from 'flexsearch';
+const index = new Index();
+items.forEach((item, i) => index.add(i, item));
+const ids = index.search(query);
+
+// After (rapid-fuzzy) — one-liner for simple cases
+import { search } from 'rapid-fuzzy';
+const results = search(query, items);
+```
+
+### Options
+
+```typescript
+// Before (FlexSearch)
+index.search(query, { limit: 10 });
+
+// After (rapid-fuzzy)
+index.search(query, { maxResults: 10, minScore: 0.3 });
+```
+
+## What You Gain
+
+### Typo tolerance
+
+FlexSearch matches exact tokens — "typscript" won't find "TypeScript". rapid-fuzzy uses fuzzy algorithms that handle typos, transpositions, and partial matches automatically.
+
+### Similarity scores
+
+Every result includes a normalized score (0.0–1.0), enabling threshold-based filtering and ranked display.
+
+### Match positions
+
+Get character-level match positions for highlighting:
+
+```typescript
+import { search } from 'rapid-fuzzy';
+import { highlight } from 'rapid-fuzzy/highlight';
+
+const results = search('type', items, { includePositions: true });
+const html = highlight(results[0].item, results[0].positions, '<b>', '</b>');
+```
+
+### Additional algorithms
+
+Access 10 distance algorithms for specialized use cases:
+
+```typescript
+import { levenshtein, jaroWinkler, sorensenDice } from 'rapid-fuzzy';
+```

--- a/docs/migration/from-fuzzball.md
+++ b/docs/migration/from-fuzzball.md
@@ -1,0 +1,137 @@
+# Migrating from fuzzball to rapid-fuzzy
+
+[fuzzball](https://www.npmjs.com/package/fuzzball) is a JavaScript port of Python's fuzzywuzzy library, providing ratio-based string matching with token sort/set algorithms. rapid-fuzzy provides the same ratio functions with better performance and additional distance algorithms — all powered by a Rust core.
+
+## Installation
+
+```bash
+# Remove fuzzball
+npm uninstall fuzzball
+
+# Install rapid-fuzzy
+npm install rapid-fuzzy
+```
+
+## API Mapping
+
+| fuzzball | rapid-fuzzy | Notes |
+|---|---|---|
+| `fuzz.ratio(a, b)` | `normalizedLevenshtein(a, b) * 100` | fuzzball returns 0–100, rapid-fuzzy returns 0.0–1.0 |
+| `fuzz.partial_ratio(a, b)` | `partialRatio(a, b)` | Returns 0.0–1.0 |
+| `fuzz.token_sort_ratio(a, b)` | `tokenSortRatio(a, b)` | Returns 0.0–1.0 |
+| `fuzz.token_set_ratio(a, b)` | `tokenSetRatio(a, b)` | Returns 0.0–1.0 |
+| `fuzz.WRatio(a, b)` | `weightedRatio(a, b)` | Returns 0.0–1.0 |
+| `fuzz.extract(query, choices)` | `search(query, choices)` | Returns `{ item, score, index }[]` |
+
+> **Score scale difference**: fuzzball returns integers 0–100, rapid-fuzzy returns floats 0.0–1.0. Multiply by 100 if you need the old scale.
+
+## Code Examples
+
+### Basic ratio
+
+```typescript
+// Before (fuzzball)
+import * as fuzz from 'fuzzball';
+fuzz.ratio('hello', 'hello');  // 100
+fuzz.ratio('hello', 'world');  // 20
+
+// After (rapid-fuzzy)
+import { normalizedLevenshtein } from 'rapid-fuzzy';
+normalizedLevenshtein('hello', 'hello');  // 1.0
+normalizedLevenshtein('hello', 'world');  // 0.2
+```
+
+### Token-based matching
+
+```typescript
+// Before (fuzzball)
+import * as fuzz from 'fuzzball';
+fuzz.token_sort_ratio('New York Mets', 'Mets New York');   // 100
+fuzz.token_set_ratio('hello', 'hello world');               // 100
+
+// After (rapid-fuzzy)
+import { tokenSortRatio, tokenSetRatio } from 'rapid-fuzzy';
+tokenSortRatio('New York Mets', 'Mets New York');  // 1.0
+tokenSetRatio('hello', 'hello world');               // 1.0
+```
+
+### Weighted ratio
+
+```typescript
+// Before (fuzzball)
+import * as fuzz from 'fuzzball';
+fuzz.WRatio('hello world', 'world hello');  // 100
+
+// After (rapid-fuzzy)
+import { weightedRatio } from 'rapid-fuzzy';
+weightedRatio('hello world', 'world hello');  // 1.0
+```
+
+### Extract best matches
+
+```typescript
+// Before (fuzzball)
+import * as fuzz from 'fuzzball';
+const results = fuzz.extract('python', ['Python', 'JavaScript', 'TypeScript']);
+// [[string, score, index], ...]
+
+// After (rapid-fuzzy)
+import { search } from 'rapid-fuzzy';
+const results = search('python', ['Python', 'JavaScript', 'TypeScript']);
+// [{ item: 'Python', score: 1.0, index: 0, positions: [] }, ...]
+```
+
+## What You Gain
+
+### Batch APIs
+
+Process multiple comparisons in a single call for better throughput:
+
+```typescript
+import { tokenSortRatioBatch, tokenSortRatioMany } from 'rapid-fuzzy';
+
+// Compare multiple pairs at once
+tokenSortRatioBatch([
+  ['hello world', 'world hello'],
+  ['foo bar', 'baz qux'],
+]);
+
+// Compare one string against many
+tokenSortRatioMany('hello world', candidates);
+```
+
+### Additional algorithms
+
+Beyond ratio-based functions, access edit distance and similarity algorithms:
+
+```typescript
+import {
+  levenshtein,        // Edit distance (integer)
+  damerauLevenshtein, // Handles transpositions
+  jaroWinkler,        // Prefix-weighted, great for names
+  sorensenDice,       // Bigram-based similarity
+  hamming,            // Fixed-length positional comparison
+} from 'rapid-fuzzy';
+```
+
+### Persistent indexed search
+
+For repeated searches, `FuzzyIndex` is dramatically faster than calling `search()` in a loop:
+
+```typescript
+import { FuzzyIndex } from 'rapid-fuzzy';
+const index = new FuzzyIndex(items);
+index.search('python');   // Sub-millisecond on large datasets
+index.closest('python');  // Best single match
+```
+
+### TypeScript support
+
+rapid-fuzzy ships with built-in TypeScript declarations. No `@types/` package needed.
+
+## Key Differences
+
+- **Score scale**: fuzzball returns 0–100 (integer); rapid-fuzzy returns 0.0–1.0 (float). Adjust thresholds accordingly.
+- **Partial ratio**: Both implement the same algorithm (best substring alignment via normalized Levenshtein).
+- **`extract` vs `search`**: `search()` returns richer result objects with `item`, `score`, `index`, and `positions`.
+- **`process` module**: fuzzball's `process.extract` / `process.extractBests` map to `search()` with `maxResults` and `minScore` options.

--- a/docs/migration/from-minisearch.md
+++ b/docs/migration/from-minisearch.md
@@ -1,0 +1,118 @@
+# Migrating from MiniSearch to rapid-fuzzy
+
+[MiniSearch](https://www.npmjs.com/package/minisearch) is a lightweight full-text search library with prefix search and fuzzy matching. rapid-fuzzy provides higher-performance fuzzy search with richer distance algorithms. Both support typo tolerance, but rapid-fuzzy is significantly faster on medium-to-large datasets with indexed mode.
+
+## When to switch
+
+**Switch to rapid-fuzzy when**:
+- You need faster fuzzy search on 1K+ item datasets
+- You want multiple distance algorithms (Levenshtein, Jaro-Winkler, Dice, etc.)
+- You need batch distance operations
+- You want match positions for highlighting
+- You want a persistent index with `serialize()` / `deserialize()`
+
+**Stay with MiniSearch when**:
+- You search structured documents with multiple fields and need field-level boosting
+- You rely on prefix matching for autocomplete on exact prefixes
+- You need custom tokenizers or term processing pipelines
+
+## Installation
+
+```bash
+# Remove MiniSearch
+npm uninstall minisearch
+
+# Install rapid-fuzzy
+npm install rapid-fuzzy
+```
+
+## API Mapping
+
+| MiniSearch | rapid-fuzzy | Notes |
+|---|---|---|
+| `new MiniSearch({ fields })` + `ms.addAll(docs)` | `new FuzzyIndex(items)` | rapid-fuzzy works on string arrays |
+| `ms.search(query)` | `index.search(query)` | Returns `{ item, score, index }[]` |
+| `ms.search(query, { fuzzy: 0.2 })` | `index.search(query, { minScore: 0.3 })` | Different threshold semantics |
+| `ms.add(doc)` | `index.add(item)` | Append to index |
+| `ms.remove(doc)` | `index.remove(index)` | Remove by position |
+| Multi-field search | `searchObjects(query, items, { keys })` | Weighted multi-key search |
+
+## Code Examples
+
+### Basic search
+
+```typescript
+// Before (MiniSearch)
+import MiniSearch from 'minisearch';
+const ms = new MiniSearch({ fields: ['name'], storeFields: ['name'] });
+ms.addAll(items.map((name, id) => ({ id, name })));
+const results = ms.search('typscript', { fuzzy: 0.2 });
+
+// After (rapid-fuzzy)
+import { FuzzyIndex } from 'rapid-fuzzy';
+const index = new FuzzyIndex(items);
+const results = index.search('typscript');
+// [{ item: 'TypeScript', score: 0.85, index: 0, positions: [] }]
+```
+
+### Multi-field object search
+
+```typescript
+// Before (MiniSearch)
+import MiniSearch from 'minisearch';
+const ms = new MiniSearch({
+  fields: ['name', 'email'],
+  storeFields: ['name', 'email'],
+  searchOptions: { boost: { name: 2 } },
+});
+ms.addAll(users);
+
+// After (rapid-fuzzy)
+import { searchObjects } from 'rapid-fuzzy/objects';
+const results = searchObjects('john', users, {
+  keys: [{ name: 'name', weight: 2 }, 'email'],
+});
+// [{ item: { name: 'John', email: '...' }, index: 0, score: 0.9, keyScores: [...] }]
+```
+
+### Standalone search (no index)
+
+```typescript
+// After (rapid-fuzzy) — no index required for simple cases
+import { search } from 'rapid-fuzzy';
+const results = search('typscript', items);
+```
+
+## What You Gain
+
+### Performance
+
+`FuzzyIndex` keeps data on the Rust side with precomputed structures, providing sub-millisecond search on large datasets. For repeated searches against the same dataset, indexed mode is orders of magnitude faster than rebuilding results each time.
+
+### Index serialization
+
+Save and restore indexes without rebuilding:
+
+```typescript
+const buffer = index.serialize();
+// ... later
+const restored = FuzzyIndex.deserialize(buffer);
+```
+
+### Distance algorithms
+
+Use specialized algorithms beyond fuzzy search:
+
+```typescript
+import { levenshtein, jaroWinkler, sorensenDice, closest } from 'rapid-fuzzy';
+
+levenshtein('kitten', 'sitting');     // 3 (edit distance)
+jaroWinkler('Martha', 'Marhta');      // 0.961 (name matching)
+closest('fast', ['slow', 'faster']);   // 'faster'
+```
+
+## Key Differences
+
+- **Scoring**: MiniSearch uses TF-IDF-based scoring; rapid-fuzzy uses character-level similarity (0.0–1.0).
+- **Tokenization**: MiniSearch tokenizes text into terms; rapid-fuzzy matches on the full string.
+- **Fuzzy threshold**: MiniSearch's `fuzzy: 0.2` means max 20% edit distance per term; rapid-fuzzy's `minScore` filters by overall similarity.


### PR DESCRIPTION
## Summary

- Add migration guide for **fuzzball**: API mapping for ratio/token functions (0–100 → 0.0–1.0 scale difference), batch APIs, indexed search
- Add migration guide for **FlexSearch**: clarify full-text vs fuzzy search, when to switch, typo tolerance advantage
- Add migration guide for **MiniSearch**: multi-field search migration with `searchObjects`, performance and scoring differences
- Update README Migration Guides section with links to new guides

These three libraries were benchmarked in `search.compare.bench.ts` and `distance.compare.bench.ts` but lacked migration guides.

## Related issue

Closes #481

## Checklist

- [x] `pnpm run check` passes
- [x] Follows existing migration guide format and style
- [x] README updated with new guide links