### PR TITLE
fix(ci): use specific version tags for actions without major tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Create version PR or detect release
         id: changesets
-        uses: changesets/action@ce079ea084e08a340947ed4d6ecedb2433c8f293 # v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: pnpm changeset:version
           title: "chore(release): version packages"


### PR DESCRIPTION
## Summary

- Update `denoland/setup-deno` digest (v2.0.3 → v2.0.4) with specific version tag
- Update `changesets/action` digest (v1.0.0 → v1.7.0) with specific version tag

These repos don't maintain major version tags (`v1`, `v2`), which caused Renovate to fail digest lookups with:
> Could not determine new digest for update (github-tags package denoland/setup-deno)
> Could not determine new digest for update (github-tags package changesets/action)

Using specific version tags (e.g., `v2.0.4` instead of `v2`) allows Renovate to resolve digests correctly.

## Checklist

- [x] No source code changes — CI workflow only
- [x] Verified latest tag SHAs match via GitHub API