### PR TITLE
chore(renovate): add 3-day minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "baseBranchPatterns": ["develop"],
+  "minimumReleaseAge": "3 days",
   "prConcurrentLimit": 0,
   "ignoreDeps": ["string-similarity", "@types/string-similarity"],
   "lockFileMaintenance": {


### PR DESCRIPTION
## Summary

- Add `minimumReleaseAge: "3 days"` to Renovate configuration
- Applies globally to all managers (npm, cargo, GitHub Actions)
- Packages must be published for at least 3 days before Renovate creates update PRs

This helps avoid pulling in potentially malicious or unstable releases that may be yanked shortly after publication.

## Related issue

Closes #499

## Checklist

- [x] No source code changes — Renovate config only
- [x] Verified option against [Renovate docs](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency update configuration to set the minimum release age to 3 days. Dependency updates will now only be considered for adoption once the corresponding package releases have been publicly available for at least 3 days, introducing an additional timing gating mechanism to the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->