### PR TITLE
fix(deps): resolve critical axios vulnerability via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,9 @@
     "onlyBuiltDependencies": [
       "lefthook"
     ],
+    "overrides": {
+      "axios": ">=1.15.0"
+    },
     "peerDependencyRules": {
       "allowedVersions": {
         "@codspeed/vitest-plugin>vite": "8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  axios: '>=1.15.0'
+
 importers:
 
   .:
@@ -1133,8 +1136,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -1908,8 +1911,9 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   publint@0.3.18:
     resolution: {integrity: sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==}
@@ -2391,7 +2395,7 @@ snapshots:
 
   '@codspeed/core@5.2.0':
     dependencies:
-      axios: 1.13.6
+      axios: 1.15.0
       find-up: 6.3.0
       form-data: 4.0.5
       node-gyp-build: 4.8.4
@@ -3213,11 +3217,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.13.6:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -3854,7 +3858,7 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   publint@0.3.18:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `pnpm.overrides` to force `axios >= 1.15.0`
- Fixes two critical Dependabot alerts (#6, #7):
  - SSRF via NO_PROXY Hostname Normalization Bypass
  - Unrestricted Cloud Metadata Exfiltration via Header Injection Chain

`axios` is a transitive devDependency via `@codspeed/core`, which specifies `^1.4.0` but hasn't updated to require `>= 1.15.0`. No production impact as it's devDependencies only.

## Related issue

Closes #503

## Checklist

- [x] `pnpm why axios` confirms 1.15.0
- [x] No source code changes — package.json + lockfile only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to ensure axios resolves to version 1.15.0 or higher for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->