### PR TITLE
chore: add CODE_OF_CONDUCT.md, bugs field, and update playground version

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+Please read the full text at the link above. By participating in this project, you agree to abide by its terms.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it by opening a [GitHub Security Advisory](https://github.com/derodero24/rapid-fuzzy/security/advisories/new) or contacting the maintainer directly.
+
+Reports will be reviewed and handled confidentially.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "url": "git+https://github.com/derodero24/rapid-fuzzy.git"
   },
   "homepage": "https://github.com/derodero24/rapid-fuzzy",
+  "bugs": {
+    "url": "https://github.com/derodero24/rapid-fuzzy/issues"
+  },
   "keywords": [
     "fuzzy",
     "fuzzy-search",

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "rapid-fuzzy": "^1.0.0"
+    "rapid-fuzzy": "^1.2.0"
   },
   "devDependencies": {
     "vite": "^8.0.0"


### PR DESCRIPTION
## Summary

- Add `CODE_OF_CONDUCT.md` referencing Contributor Covenant v2.1
- Add `bugs` URL field to `package.json`
- Update playground dependency from `^1.0.0` to `^1.2.0`

## Related issue

Closes #510

## Checklist

- [x] No source code changes
- [x] CODE_OF_CONDUCT.md links to standard Contributor Covenant