### PR TITLE
refactor(core): extract search module logic to core-lib crate

### DIFF
--- a/crates/core-lib/src/search/fuzzy_index.rs
+++ b/crates/core-lib/src/search/fuzzy_index.rs
@@ -1,0 +1,255 @@
+use std::cell::RefCell;
+
+use nucleo_matcher::pattern::CaseMatching;
+use nucleo_matcher::{Config, Matcher, Utf32String};
+
+use super::{
+    BigramIndex, IndexSearchResult, PrecomputedSearch, SearchResult, compute_char_mask,
+    extract_query_bigrams, intersect_sorted, search_over_precomputed,
+    search_over_precomputed_indices,
+};
+
+/// Minimum dataset size for bigram pre-filtering at query time.
+/// Below this threshold, the overhead of bigram intersection exceeds the
+/// benefit of reducing pattern.score() calls.
+const BIGRAM_THRESHOLD: usize = 5_000;
+
+/// Core state and logic for a persistent fuzzy search index.
+///
+/// This struct contains all platform-independent state and methods.
+/// Binding crates (napi, wasm) wrap this with their own FFI layer.
+pub struct FuzzyIndexCore {
+    items: Vec<String>,
+    utf32_items: Vec<Utf32String>,
+    char_masks: Vec<u64>,
+    bigram_index: BigramIndex,
+    matcher: RefCell<Matcher>,
+    /// Incremental search cache: the query from the last search.
+    last_query: RefCell<String>,
+    /// Incremental search cache: indices of all items that matched the last query.
+    last_matching_indices: RefCell<Vec<u32>>,
+}
+
+impl FuzzyIndexCore {
+    /// Create a new FuzzyIndexCore from a list of items.
+    pub fn new(items: Vec<String>) -> Self {
+        let utf32_items: Vec<Utf32String> = items
+            .iter()
+            .map(|s| Utf32String::from(s.as_str()))
+            .collect();
+        let char_masks: Vec<u64> = items.iter().map(|s| compute_char_mask(s)).collect();
+        let bigram_index = BigramIndex::new(&items);
+        Self {
+            items,
+            utf32_items,
+            char_masks,
+            bigram_index,
+            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
+            last_query: RefCell::new(String::new()),
+            last_matching_indices: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Return the number of items in the index.
+    pub fn size(&self) -> u32 {
+        self.items.len() as u32
+    }
+
+    /// Access the items slice.
+    pub fn items(&self) -> &[String] {
+        &self.items
+    }
+
+    /// Search the index for items matching the query.
+    pub fn search_impl(
+        &self,
+        query: &str,
+        max_results: Option<u32>,
+        min_score: Option<f64>,
+        include_positions: bool,
+        case_matching: CaseMatching,
+    ) -> Vec<SearchResult> {
+        // Determine if we can narrow the search to cached matching indices.
+        // Conditions: new query is a prefix extension of the cached query,
+        // the cache has a non-empty candidate set, and neither query uses
+        // inverted terms (which break monotonicity).
+        let cache_candidates: Option<Vec<u32>> = {
+            let last_q = self.last_query.borrow();
+            let last_idx = self.last_matching_indices.borrow();
+            if !last_q.is_empty()
+                && !last_idx.is_empty()
+                && query.len() > last_q.len()
+                && query.starts_with(last_q.as_str())
+                && !query.contains('!')
+                && !last_q.contains('!')
+            {
+                Some(last_idx.clone())
+            } else {
+                None
+            }
+        };
+
+        // Get bigram candidates (only for large datasets).
+        let bigram_candidates = if self.items.len() >= BIGRAM_THRESHOLD {
+            let query_bigrams = extract_query_bigrams(query);
+            self.bigram_index.candidates(&query_bigrams)
+        } else {
+            None
+        };
+
+        // Compose candidate lists: intersect cache and bigram when both available.
+        let candidates: Option<Vec<u32>> = match (cache_candidates, bigram_candidates) {
+            (Some(cache), Some(bigram)) => Some(intersect_sorted(&cache, &bigram)),
+            (Some(cache), None) => Some(cache),
+            (None, Some(bigram)) => Some(bigram),
+            (None, None) => None,
+        };
+
+        let ctx = PrecomputedSearch {
+            items: &self.items,
+            utf32_items: &self.utf32_items,
+            char_masks: &self.char_masks,
+            candidate_indices: candidates.as_deref(),
+            matcher: &self.matcher,
+        };
+
+        let outcome = search_over_precomputed(
+            query,
+            &ctx,
+            max_results,
+            min_score,
+            include_positions,
+            case_matching,
+        );
+
+        // Update incremental cache.
+        *self.last_query.borrow_mut() = query.to_owned();
+        *self.last_matching_indices.borrow_mut() = outcome.all_matching_indices;
+
+        outcome.results
+    }
+
+    /// Search the index, returning only indices and scores (no item strings).
+    pub fn search_indices_impl(
+        &self,
+        query: &str,
+        max_results: Option<u32>,
+        min_score: Option<f64>,
+        include_positions: bool,
+        case_matching: CaseMatching,
+    ) -> Vec<IndexSearchResult> {
+        let cache_candidates: Option<Vec<u32>> = {
+            let last_q = self.last_query.borrow();
+            let last_idx = self.last_matching_indices.borrow();
+            if !last_q.is_empty()
+                && !last_idx.is_empty()
+                && query.len() > last_q.len()
+                && query.starts_with(last_q.as_str())
+                && !query.contains('!')
+                && !last_q.contains('!')
+            {
+                Some(last_idx.clone())
+            } else {
+                None
+            }
+        };
+
+        let bigram_candidates = if self.items.len() >= BIGRAM_THRESHOLD {
+            let query_bigrams = extract_query_bigrams(query);
+            self.bigram_index.candidates(&query_bigrams)
+        } else {
+            None
+        };
+
+        let candidates: Option<Vec<u32>> = match (cache_candidates, bigram_candidates) {
+            (Some(cache), Some(bigram)) => Some(intersect_sorted(&cache, &bigram)),
+            (Some(cache), None) => Some(cache),
+            (None, Some(bigram)) => Some(bigram),
+            (None, None) => None,
+        };
+
+        let ctx = PrecomputedSearch {
+            items: &self.items,
+            utf32_items: &self.utf32_items,
+            char_masks: &self.char_masks,
+            candidate_indices: candidates.as_deref(),
+            matcher: &self.matcher,
+        };
+
+        let outcome = search_over_precomputed_indices(
+            query,
+            &ctx,
+            max_results,
+            min_score,
+            include_positions,
+            case_matching,
+        );
+
+        // Update incremental cache.
+        *self.last_query.borrow_mut() = query.to_owned();
+        *self.last_matching_indices.borrow_mut() = outcome.all_matching_indices;
+
+        outcome.results
+    }
+
+    /// Add a single item to the index.
+    pub fn add(&mut self, item: String) {
+        let index = self.items.len() as u32;
+        self.utf32_items.push(Utf32String::from(item.as_str()));
+        self.char_masks.push(compute_char_mask(&item));
+        self.bigram_index.add_item(index, &item);
+        self.items.push(item);
+        self.invalidate_cache();
+    }
+
+    /// Add multiple items to the index at once.
+    pub fn add_many(&mut self, items: Vec<String>) {
+        let base = self.items.len() as u32;
+        for (i, item) in items.iter().enumerate() {
+            self.utf32_items.push(Utf32String::from(item.as_str()));
+            self.char_masks.push(compute_char_mask(item));
+            self.bigram_index.add_item(base + i as u32, item);
+        }
+        self.items.extend(items);
+        self.invalidate_cache();
+    }
+
+    /// Remove the item at the given index.
+    ///
+    /// Uses swap-remove for O(1) performance. Returns false if out of bounds.
+    pub fn remove(&mut self, index: u32) -> bool {
+        let idx = index as usize;
+        if idx < self.items.len() {
+            let last_index = (self.items.len() - 1) as u32;
+            let removed_item = self.items[idx].clone();
+            let last_item = if idx != last_index as usize {
+                Some(self.items[last_index as usize].clone())
+            } else {
+                None
+            };
+            self.bigram_index
+                .remove_item(index, last_index, &removed_item, last_item.as_deref());
+            self.items.swap_remove(idx);
+            self.utf32_items.swap_remove(idx);
+            self.char_masks.swap_remove(idx);
+            self.invalidate_cache();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Free the internal data. After calling this, the index is empty.
+    pub fn destroy(&mut self) {
+        self.items = Vec::new();
+        self.utf32_items = Vec::new();
+        self.char_masks = Vec::new();
+        self.bigram_index.clear();
+        self.invalidate_cache();
+    }
+
+    fn invalidate_cache(&self) {
+        self.last_query.borrow_mut().clear();
+        self.last_matching_indices.borrow_mut().clear();
+    }
+}

--- a/crates/core-lib/src/search/keyed_index.rs
+++ b/crates/core-lib/src/search/keyed_index.rs
@@ -1,0 +1,291 @@
+use std::cell::RefCell;
+
+use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
+use nucleo_matcher::{Config, Matcher, Utf32String};
+
+use super::{KeySearchResult, compute_char_mask, compute_max_score, compute_query_mask};
+
+fn to_utf32(texts: &[String]) -> Vec<Utf32String> {
+    texts
+        .iter()
+        .map(|s| Utf32String::from(s.as_str()))
+        .collect()
+}
+
+/// Core state and logic for a persistent multi-key fuzzy search index.
+///
+/// This struct contains all platform-independent state and methods.
+/// Binding crates (napi, wasm) wrap this with their own FFI layer.
+pub struct KeyedFuzzyIndexCore {
+    key_texts: Vec<Vec<String>>,
+    utf32_keys: Vec<Vec<Utf32String>>,
+    key_char_masks: Vec<Vec<u64>>,
+    weights: Vec<f64>,
+    total_weight: f64,
+    matcher: RefCell<Matcher>,
+}
+
+impl KeyedFuzzyIndexCore {
+    /// Create a new KeyedFuzzyIndexCore.
+    ///
+    /// `key_texts[k]` is an array of strings for key `k`, one per item.
+    /// All inner arrays must have the same length (the number of items).
+    pub fn new(key_texts: Vec<Vec<String>>, weights: Vec<f64>) -> Result<Self, String> {
+        let num_keys = key_texts.len();
+
+        if let Some(num_items) = key_texts.first().map(Vec::len) {
+            for (k, col) in key_texts.iter().enumerate().skip(1) {
+                if col.len() != num_items {
+                    return Err(format!(
+                        "All key_texts columns must have the same length; key 0 has {}, key {} has {}",
+                        num_items,
+                        k,
+                        col.len()
+                    ));
+                }
+            }
+        }
+
+        if weights.len() != num_keys {
+            return Err(format!(
+                "Expected {} weights, got {}",
+                num_keys,
+                weights.len()
+            ));
+        }
+
+        if weights.iter().any(|w| !w.is_finite() || *w < 0.0) {
+            return Err("Weights must be finite non-negative numbers".to_string());
+        }
+
+        let total_weight: f64 = weights.iter().sum();
+        if total_weight <= 0.0 {
+            return Err("Total weight must be greater than zero".to_string());
+        }
+
+        let utf32_keys: Vec<Vec<Utf32String>> = key_texts.iter().map(|t| to_utf32(t)).collect();
+        let key_char_masks: Vec<Vec<u64>> = key_texts
+            .iter()
+            .map(|texts| texts.iter().map(|s| compute_char_mask(s)).collect())
+            .collect();
+        Ok(Self {
+            key_texts,
+            utf32_keys,
+            key_char_masks,
+            weights,
+            total_weight,
+            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
+        })
+    }
+
+    /// Return the number of items in the index.
+    pub fn size(&self) -> u32 {
+        self.key_texts.first().map_or(0, |v| v.len() as u32)
+    }
+
+    /// Access the key_texts.
+    pub fn key_texts(&self) -> &[Vec<String>] {
+        &self.key_texts
+    }
+
+    /// Access the weights.
+    pub fn weights(&self) -> &[f64] {
+        &self.weights
+    }
+
+    /// Search the index for items matching the query.
+    ///
+    /// Returns results sorted by combined weighted score (best match first).
+    pub fn search(
+        &self,
+        query: &str,
+        max_results: Option<u32>,
+        min_score: Option<f64>,
+        case_matching: CaseMatching,
+        return_all_on_empty: bool,
+    ) -> Vec<KeySearchResult> {
+        let num_keys = self.key_texts.len();
+
+        if num_keys == 0 {
+            return Vec::new();
+        }
+
+        let num_items = self.size() as usize;
+        if num_items == 0 {
+            return Vec::new();
+        }
+
+        if return_all_on_empty && query.trim().is_empty() {
+            let limit = max_results.unwrap_or(num_items as u32) as usize;
+            return (0..num_items)
+                .take(limit)
+                .map(|i| KeySearchResult {
+                    index: i as u32,
+                    score: 1.0,
+                    key_scores: vec![1.0; num_keys],
+                })
+                .collect();
+        }
+
+        if query.is_empty() {
+            return Vec::new();
+        }
+
+        let threshold = min_score.unwrap_or(0.0);
+
+        let mut matcher = self.matcher.borrow_mut();
+        let pattern = Pattern::parse(query, case_matching, Normalization::Smart);
+        let max_score = compute_max_score(query, &pattern, &mut matcher);
+        let query_mask = compute_query_mask(query);
+
+        // Identify keys with non-zero weight to skip unnecessary scoring.
+        let active_keys: Vec<usize> = (0..num_keys).filter(|&k| self.weights[k] > 0.0).collect();
+
+        // Pre-compute the sum of active weights for early exit upper-bound.
+        let active_total_weight: f64 = active_keys.iter().map(|&k| self.weights[k]).sum();
+
+        // Per-item scoring with early exit and per-key char_mask pre-filtering.
+        let mut per_key_scores: Vec<Vec<f64>> = vec![vec![0.0; num_items]; num_keys];
+
+        let threshold_weighted = threshold * self.total_weight;
+
+        let mut scored: Vec<(u32, f64)> = (0..num_items)
+            .filter_map(|i| {
+                let mut weighted_sum = 0.0;
+                let mut matched_any = false;
+                let mut remaining_weight = active_total_weight;
+
+                for &k in &active_keys {
+                    let w = self.weights[k];
+                    remaining_weight -= w;
+
+                    // Per-key char_mask pre-filter: skip expensive scoring if
+                    // the item for this key cannot contain the query characters.
+                    if query_mask != 0 && (self.key_char_masks[k][i] & query_mask) != query_mask {
+                        // Upper bound check: even if all remaining keys score 1.0,
+                        // can we still reach the threshold?
+                        if threshold > 0.0 && weighted_sum + remaining_weight < threshold_weighted {
+                            return None;
+                        }
+                        continue;
+                    }
+
+                    let atoms = self.utf32_keys[k][i].slice(..);
+                    let score = match pattern.score(atoms, &mut matcher) {
+                        Some(raw) => ((raw as f64) / max_score).min(1.0),
+                        None => 0.0,
+                    };
+                    per_key_scores[k][i] = score;
+
+                    if score > 0.0 {
+                        weighted_sum += score * w;
+                        matched_any = true;
+                    }
+
+                    // Early exit: if even perfect scores on remaining keys
+                    // cannot lift the combined score above the threshold,
+                    // skip the remaining keys for this item.
+                    if threshold > 0.0 && weighted_sum + remaining_weight < threshold_weighted {
+                        return None;
+                    }
+                }
+
+                if !matched_any {
+                    return None;
+                }
+
+                let combined = weighted_sum / self.total_weight;
+                if combined >= threshold {
+                    Some((i as u32, combined))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Sort by score descending, with original index as tiebreaker
+        // for deterministic ordering.
+        let cmp = |a: &(u32, f64), b: &(u32, f64)| {
+            let score_ord = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
+            if score_ord != std::cmp::Ordering::Equal {
+                return score_ord;
+            }
+            a.0.cmp(&b.0)
+        };
+
+        // Top-k selection: use quickselect O(n) + sort O(k log k) instead of
+        // full sort O(n log n) when maxResults is set.
+        if let Some(max) = max_results {
+            let k = max as usize;
+            if scored.len() > k {
+                scored.select_nth_unstable_by(k, cmp);
+                scored.truncate(k);
+            }
+        }
+        scored.sort_unstable_by(cmp);
+
+        // Pass 2: Construct KeySearchResult only for the final top-k items.
+        scored
+            .into_iter()
+            .map(|(index, score)| {
+                let key_scores: Vec<f64> = per_key_scores
+                    .iter()
+                    .map(|scores| scores[index as usize])
+                    .collect();
+                KeySearchResult {
+                    index,
+                    score,
+                    key_scores,
+                }
+            })
+            .collect()
+    }
+
+    /// Add a single item to the index.
+    pub fn add(&mut self, key_values: Vec<String>) -> Result<(), String> {
+        let num_keys = self.key_texts.len();
+        if key_values.len() != num_keys {
+            return Err(format!(
+                "Expected {num_keys} key values, got {}",
+                key_values.len()
+            ));
+        }
+        for (k, value) in key_values.into_iter().enumerate() {
+            self.utf32_keys[k].push(Utf32String::from(value.as_str()));
+            self.key_char_masks[k].push(compute_char_mask(&value));
+            self.key_texts[k].push(value);
+        }
+        Ok(())
+    }
+
+    /// Remove the item at the given index.
+    ///
+    /// Uses swap-remove for O(1) performance. Returns false if out of bounds.
+    pub fn remove(&mut self, index: u32) -> bool {
+        let idx = index as usize;
+        let num_items = self.size() as usize;
+        if idx >= num_items {
+            return false;
+        }
+        for ((texts, utf32), masks) in self
+            .key_texts
+            .iter_mut()
+            .zip(self.utf32_keys.iter_mut())
+            .zip(self.key_char_masks.iter_mut())
+        {
+            texts.swap_remove(idx);
+            utf32.swap_remove(idx);
+            masks.swap_remove(idx);
+        }
+        true
+    }
+
+    /// Free the internal data. After calling this, the index is empty.
+    pub fn destroy(&mut self) {
+        self.key_texts = Vec::new();
+        self.utf32_keys = Vec::new();
+        self.key_char_masks = Vec::new();
+        self.weights = Vec::new();
+        self.total_weight = 0.0;
+    }
+}

--- a/crates/core-lib/src/search/keys.rs
+++ b/crates/core-lib/src/search/keys.rs
@@ -1,0 +1,168 @@
+use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
+use nucleo_matcher::{Config, Matcher};
+
+use super::{KeySearchResult, compute_max_score, resolve_case_matching};
+
+/// Search options for the `search_keys_impl` function.
+pub struct SearchKeysOptions {
+    pub max_results: Option<u32>,
+    pub min_score: Option<f64>,
+    pub is_case_sensitive: Option<bool>,
+    pub return_all_on_empty: Option<bool>,
+}
+
+/// Perform fuzzy search across multiple text keys with weights.
+///
+/// `key_texts[k]` is an array of strings for key `k`, one per item.
+/// All inner arrays must have the same length (the number of items).
+/// `weights` specifies the relative importance of each key.
+///
+/// Returns results sorted by combined weighted score (best match first).
+pub fn search_keys_impl(
+    query: &str,
+    key_texts: &[Vec<String>],
+    weights: &[f64],
+    options: Option<SearchKeysOptions>,
+) -> Vec<KeySearchResult> {
+    let num_keys = key_texts.len();
+
+    if num_keys == 0 || weights.len() != num_keys {
+        return Vec::new();
+    }
+
+    let num_items = key_texts[0].len();
+    if num_items == 0 {
+        return Vec::new();
+    }
+
+    // Validate all key_texts have the same length
+    for texts in key_texts {
+        if texts.len() != num_items {
+            return Vec::new();
+        }
+    }
+
+    let (max_results, min_score, case_matching, return_all_on_empty) = match &options {
+        Some(opts) => (
+            opts.max_results,
+            opts.min_score,
+            resolve_case_matching(opts.is_case_sensitive),
+            opts.return_all_on_empty.unwrap_or(false),
+        ),
+        None => (None, None, CaseMatching::Smart, false),
+    };
+
+    if return_all_on_empty && query.trim().is_empty() {
+        let limit = max_results.unwrap_or(num_items as u32) as usize;
+        return (0..num_items)
+            .take(limit)
+            .map(|i| KeySearchResult {
+                index: i as u32,
+                score: 1.0,
+                key_scores: vec![1.0; num_keys],
+            })
+            .collect();
+    }
+
+    if query.is_empty() {
+        return Vec::new();
+    }
+
+    let threshold = min_score.unwrap_or(0.0);
+
+    // Reject negative, NaN, or infinite weights to guarantee scores stay in [0.0, 1.0]
+    if weights.iter().any(|w| !w.is_finite() || *w < 0.0) {
+        return Vec::new();
+    }
+
+    let total_weight: f64 = weights.iter().sum();
+    if total_weight <= 0.0 {
+        return Vec::new();
+    }
+
+    let mut matcher = Matcher::new(Config::DEFAULT);
+    let pattern = Pattern::parse(query, case_matching, Normalization::Smart);
+    let max_score = compute_max_score(query, &pattern, &mut matcher);
+
+    // Compute per-key scores for all items
+    let mut per_key_scores: Vec<Vec<f64>> = Vec::with_capacity(num_keys);
+    let mut buf = Vec::new();
+
+    for texts in key_texts {
+        let mut scores = Vec::with_capacity(num_items);
+        for text in texts {
+            buf.clear();
+            let atoms = nucleo_matcher::Utf32Str::new(text, &mut buf);
+            let score = match pattern.score(atoms, &mut matcher) {
+                Some(raw) => ((raw as f64) / max_score).min(1.0),
+                None => 0.0,
+            };
+            scores.push(score);
+        }
+        per_key_scores.push(scores);
+    }
+
+    // Pass 1: Compute combined scores, collect (index, score) only.
+    let mut scored: Vec<(u32, f64)> = (0..num_items)
+        .filter_map(|i| {
+            let mut weighted_sum = 0.0;
+            let mut matched_any = false;
+
+            for k in 0..num_keys {
+                let score = per_key_scores[k][i];
+                if score > 0.0 {
+                    weighted_sum += score * weights[k];
+                    matched_any = true;
+                }
+            }
+
+            if !matched_any {
+                return None;
+            }
+
+            let combined = weighted_sum / total_weight;
+            if combined >= threshold {
+                Some((i as u32, combined))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Sort by score descending, with original index as tiebreaker
+    // for deterministic ordering.
+    let cmp = |a: &(u32, f64), b: &(u32, f64)| {
+        let score_ord = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
+        if score_ord != std::cmp::Ordering::Equal {
+            return score_ord;
+        }
+        a.0.cmp(&b.0)
+    };
+
+    // Top-k selection: use quickselect O(n) + sort O(k log k) instead of
+    // full sort O(n log n) when maxResults is set.
+    if let Some(max) = max_results {
+        let k = max as usize;
+        if scored.len() > k {
+            scored.select_nth_unstable_by(k, cmp);
+            scored.truncate(k);
+        }
+    }
+    scored.sort_unstable_by(cmp);
+
+    // Pass 2: Construct KeySearchResult only for the final top-k items.
+    scored
+        .into_iter()
+        .map(|(index, score)| {
+            let key_scores: Vec<f64> = per_key_scores
+                .iter()
+                .map(|scores| scores[index as usize])
+                .collect();
+            KeySearchResult {
+                index,
+                score,
+                key_scores,
+            }
+        })
+        .collect()
+}

--- a/crates/core-lib/src/search/mod.rs
+++ b/crates/core-lib/src/search/mod.rs
@@ -1,3 +1,12 @@
+mod fuzzy_index;
+mod keyed_index;
+mod keys;
+pub mod serialization;
+
+pub use fuzzy_index::FuzzyIndexCore;
+pub use keyed_index::KeyedFuzzyIndexCore;
+pub use keys::{SearchKeysOptions, search_keys_impl};
+
 use std::cell::RefCell;
 use std::collections::HashMap;
 

--- a/crates/core-lib/src/search/serialization.rs
+++ b/crates/core-lib/src/search/serialization.rs
@@ -1,0 +1,215 @@
+/// Magic bytes identifying a serialized FuzzyIndex.
+pub const FUZZY_INDEX_MAGIC: &[u8; 4] = b"RFZI";
+
+/// Magic bytes identifying a serialized FuzzyIndex (WASM variant).
+pub const FUZZY_INDEX_WASM_MAGIC: &[u8; 4] = b"RFUZ";
+
+/// Magic bytes identifying a serialized KeyedFuzzyIndex.
+pub const KEYED_INDEX_MAGIC: &[u8; 4] = b"RFKI";
+
+/// Current serialization format version.
+pub const SERIALIZE_VERSION: u32 = 1;
+
+/// Serialize a list of items into a compact binary format.
+///
+/// Format: `[magic 4B] [version u32 LE] [count u32 LE] [items...]`
+/// Each item: `[len u32 LE] [utf-8 bytes]`
+pub fn serialize_items(items: &[String], magic: &[u8; 4]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(magic);
+    buf.extend_from_slice(&SERIALIZE_VERSION.to_le_bytes());
+    buf.extend_from_slice(&(items.len() as u32).to_le_bytes());
+    for item in items {
+        buf.extend_from_slice(&(item.len() as u32).to_le_bytes());
+        buf.extend_from_slice(item.as_bytes());
+    }
+    buf
+}
+
+/// Deserialize a list of items from a compact binary format.
+///
+/// Returns the list of items on success, or an error message on failure.
+pub fn deserialize_items(bytes: &[u8], magic: &[u8; 4]) -> Result<Vec<String>, String> {
+    let header_size = magic.len() + 4 + 4; // magic + version + count
+
+    if bytes.len() < header_size {
+        return Err("Invalid data: too short".into());
+    }
+
+    if &bytes[0..4] != magic {
+        return Err("Invalid data: bad magic bytes".into());
+    }
+
+    let version = u32::from_le_bytes(
+        bytes[4..8]
+            .try_into()
+            .map_err(|_| "Invalid data: truncated header".to_string())?,
+    );
+    if version != SERIALIZE_VERSION {
+        return Err(format!(
+            "Unsupported format version: expected {SERIALIZE_VERSION}, got {version}"
+        ));
+    }
+
+    let count = u32::from_le_bytes(
+        bytes[8..12]
+            .try_into()
+            .map_err(|_| "Invalid data: truncated header".to_string())?,
+    ) as usize;
+    let mut offset = header_size;
+
+    // Reject obviously invalid counts before allocating.
+    // Each item needs at least 4 bytes (length field), so count cannot
+    // exceed the remaining payload divided by 4.
+    let max_possible = bytes.len().saturating_sub(header_size) / 4;
+    if count > max_possible {
+        return Err("Invalid data: item count exceeds payload size".into());
+    }
+
+    let mut items = Vec::with_capacity(count);
+
+    for _ in 0..count {
+        if offset + 4 > bytes.len() {
+            return Err("Invalid data: truncated".into());
+        }
+        let len = u32::from_le_bytes(
+            bytes[offset..offset + 4]
+                .try_into()
+                .map_err(|_| "Invalid data: truncated".to_string())?,
+        ) as usize;
+        offset += 4;
+        if offset + len > bytes.len() {
+            return Err("Invalid data: truncated".into());
+        }
+        let s = std::str::from_utf8(&bytes[offset..offset + len])
+            .map_err(|e| format!("Invalid UTF-8: {e}"))?;
+        items.push(s.to_owned());
+        offset += len;
+    }
+
+    if offset != bytes.len() {
+        return Err("Invalid data: trailing bytes".into());
+    }
+
+    Ok(items)
+}
+
+/// Serialize a keyed index into a compact binary format.
+///
+/// Format:
+///   `[magic 4B] [version u32 LE] [num_keys u32 LE] [num_items u32 LE]`
+///   `[weights: num_keys x f64 LE]`
+///   `[key_texts column-major: for each key, for each item: [len u32 LE][utf-8 bytes]]`
+pub fn serialize_keyed(key_texts: &[Vec<String>], weights: &[f64], magic: &[u8; 4]) -> Vec<u8> {
+    let num_keys = weights.len();
+    let num_items = key_texts.first().map_or(0, |v| v.len());
+
+    let mut buf = Vec::new();
+    buf.extend_from_slice(magic);
+    buf.extend_from_slice(&SERIALIZE_VERSION.to_le_bytes());
+    buf.extend_from_slice(&(num_keys as u32).to_le_bytes());
+    buf.extend_from_slice(&(num_items as u32).to_le_bytes());
+
+    for &w in weights {
+        buf.extend_from_slice(&w.to_le_bytes());
+    }
+
+    for key_col in key_texts {
+        for item in key_col {
+            buf.extend_from_slice(&(item.len() as u32).to_le_bytes());
+            buf.extend_from_slice(item.as_bytes());
+        }
+    }
+
+    buf
+}
+
+/// Deserialize a keyed index from a compact binary format.
+///
+/// Returns `(key_texts, weights)` on success, or an error message on failure.
+pub fn deserialize_keyed(
+    bytes: &[u8],
+    magic: &[u8; 4],
+) -> Result<(Vec<Vec<String>>, Vec<f64>), String> {
+    let header_size = 4 + 4 + 4 + 4; // magic + version + num_keys + num_items
+
+    if bytes.len() < header_size {
+        return Err("Invalid data: too short".into());
+    }
+
+    if &bytes[0..4] != magic {
+        return Err("Invalid data: bad magic bytes".into());
+    }
+
+    let version = u32::from_le_bytes(
+        bytes[4..8]
+            .try_into()
+            .map_err(|_| "Invalid data: truncated header".to_string())?,
+    );
+    if version != SERIALIZE_VERSION {
+        return Err(format!(
+            "Unsupported format version: expected {SERIALIZE_VERSION}, got {version}"
+        ));
+    }
+
+    let num_keys = u32::from_le_bytes(
+        bytes[8..12]
+            .try_into()
+            .map_err(|_| "Invalid data: truncated header".to_string())?,
+    ) as usize;
+
+    let num_items = u32::from_le_bytes(
+        bytes[12..16]
+            .try_into()
+            .map_err(|_| "Invalid data: truncated header".to_string())?,
+    ) as usize;
+
+    let mut offset = header_size;
+
+    // Read weights (num_keys x 8 bytes each)
+    let weights_size = num_keys * 8;
+    if offset + weights_size > bytes.len() {
+        return Err("Invalid data: truncated weights".into());
+    }
+    let mut weights = Vec::with_capacity(num_keys);
+    for _ in 0..num_keys {
+        let w = f64::from_le_bytes(
+            bytes[offset..offset + 8]
+                .try_into()
+                .map_err(|_| "Invalid data: truncated weight".to_string())?,
+        );
+        weights.push(w);
+        offset += 8;
+    }
+
+    // Read key_texts column-major
+    let mut key_texts: Vec<Vec<String>> = Vec::with_capacity(num_keys);
+    for _ in 0..num_keys {
+        let mut col = Vec::with_capacity(num_items);
+        for _ in 0..num_items {
+            if offset + 4 > bytes.len() {
+                return Err("Invalid data: truncated".into());
+            }
+            let len = u32::from_le_bytes(
+                bytes[offset..offset + 4]
+                    .try_into()
+                    .map_err(|_| "Invalid data: truncated".to_string())?,
+            ) as usize;
+            offset += 4;
+            if offset + len > bytes.len() {
+                return Err("Invalid data: truncated".into());
+            }
+            let s = std::str::from_utf8(&bytes[offset..offset + len])
+                .map_err(|e| format!("Invalid UTF-8: {e}"))?;
+            col.push(s.to_owned());
+            offset += len;
+        }
+        key_texts.push(col);
+    }
+
+    if offset != bytes.len() {
+        return Err("Invalid data: trailing bytes".into());
+    }
+
+    Ok((key_texts, weights))
+}

--- a/crates/core/src/search/index.rs
+++ b/crates/core/src/search/index.rs
@@ -1,66 +1,30 @@
-use std::cell::RefCell;
-
 use napi::bindgen_prelude::{AsyncTask, Buffer};
 use napi::{Either, Task};
 use napi_derive::napi;
 use nucleo_matcher::pattern::CaseMatching;
-use nucleo_matcher::{Config, Matcher, Utf32String};
-
-use super::{
-    BigramIndex, IndexSearchResult, PrecomputedSearch, SearchOptions, SearchResult,
-    compute_char_mask, extract_query_bigrams, intersect_sorted, resolve_case_matching,
-    search_over_precomputed, search_over_precomputed_indices,
+use rapid_fuzzy_core::search::FuzzyIndexCore;
+use rapid_fuzzy_core::search::serialization::{
+    FUZZY_INDEX_MAGIC, deserialize_items, serialize_items,
 };
 
-/// Precomputed index data — all fields `Send`, used to transfer work off the event loop.
-pub struct FuzzyIndexData {
-    items: Vec<String>,
-    utf32_items: Vec<Utf32String>,
-    char_masks: Vec<u64>,
-    bigram_index: BigramIndex,
-}
+use super::{IndexSearchResult, SearchOptions, SearchResult, resolve_case_matching};
 
 pub struct BuildFuzzyIndexTask {
     items: Vec<String>,
 }
 
 impl Task for BuildFuzzyIndexTask {
-    type Output = FuzzyIndexData;
+    type Output = FuzzyIndexCore;
     type JsValue = FuzzyIndex;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
-        let utf32_items: Vec<Utf32String> = self
-            .items
-            .iter()
-            .map(|s| Utf32String::from(s.as_str()))
-            .collect();
-        let char_masks: Vec<u64> = self.items.iter().map(|s| compute_char_mask(s)).collect();
-        let bigram_index = BigramIndex::new(&self.items);
-        Ok(FuzzyIndexData {
-            items: std::mem::take(&mut self.items),
-            utf32_items,
-            char_masks,
-            bigram_index,
-        })
+        Ok(FuzzyIndexCore::new(std::mem::take(&mut self.items)))
     }
 
     fn resolve(&mut self, _env: napi::Env, output: Self::Output) -> napi::Result<Self::JsValue> {
-        Ok(FuzzyIndex {
-            items: output.items,
-            utf32_items: output.utf32_items,
-            char_masks: output.char_masks,
-            bigram_index: output.bigram_index,
-            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
-            last_query: RefCell::new(String::new()),
-            last_matching_indices: RefCell::new(Vec::new()),
-        })
+        Ok(FuzzyIndex { core: output })
     }
 }
-
-/// Minimum dataset size for bigram pre-filtering at query time.
-/// Below this threshold, the overhead of bigram intersection exceeds the
-/// benefit of reducing pattern.score() calls.
-const BIGRAM_THRESHOLD: usize = 5_000;
 
 /// A persistent fuzzy search index backed by Rust-side data.
 ///
@@ -72,15 +36,7 @@ const BIGRAM_THRESHOLD: usize = 5_000;
 /// or when `destroy()` is called explicitly.
 #[napi]
 pub struct FuzzyIndex {
-    items: Vec<String>,
-    utf32_items: Vec<Utf32String>,
-    char_masks: Vec<u64>,
-    bigram_index: BigramIndex,
-    matcher: RefCell<Matcher>,
-    /// Incremental search cache: the query from the last search.
-    last_query: RefCell<String>,
-    /// Incremental search cache: indices of all items that matched the last query.
-    last_matching_indices: RefCell<Vec<u32>>,
+    core: FuzzyIndexCore,
 }
 
 #[napi]
@@ -88,20 +44,8 @@ impl FuzzyIndex {
     /// Create a new FuzzyIndex from an array of strings.
     #[napi(constructor)]
     pub fn new(items: Vec<String>) -> Self {
-        let utf32_items: Vec<Utf32String> = items
-            .iter()
-            .map(|s| Utf32String::from(s.as_str()))
-            .collect();
-        let char_masks: Vec<u64> = items.iter().map(|s| compute_char_mask(s)).collect();
-        let bigram_index = BigramIndex::new(&items);
         Self {
-            items,
-            utf32_items,
-            char_masks,
-            bigram_index,
-            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
-            last_query: RefCell::new(String::new()),
-            last_matching_indices: RefCell::new(Vec::new()),
+            core: FuzzyIndexCore::new(items),
         }
     }
 
@@ -117,7 +61,7 @@ impl FuzzyIndex {
     /// Return the number of items in the index.
     #[napi(getter)]
     pub fn size(&self) -> u32 {
-        self.items.len() as u32
+        self.core.size()
     }
 
     /// Search the index for items matching the query.
@@ -144,9 +88,9 @@ impl FuzzyIndex {
             };
 
         if return_all_on_empty && query.trim().is_empty() {
-            let limit = max_results.unwrap_or(self.items.len() as u32) as usize;
-            return self
-                .items
+            let items = self.core.items();
+            let limit = max_results.unwrap_or(items.len() as u32) as usize;
+            return items
                 .iter()
                 .enumerate()
                 .take(limit)
@@ -204,8 +148,9 @@ impl FuzzyIndex {
             };
 
         if return_all_on_empty && query.trim().is_empty() {
-            let limit = max_results.unwrap_or(self.items.len() as u32) as usize;
-            return (0..self.items.len())
+            let num_items = self.core.size() as usize;
+            let limit = max_results.unwrap_or(num_items as u32) as usize;
+            return (0..num_items)
                 .take(limit)
                 .map(|i| IndexSearchResult {
                     index: i as u32,
@@ -228,25 +173,13 @@ impl FuzzyIndex {
     /// Add a single item to the index.
     #[napi]
     pub fn add(&mut self, item: String) {
-        let index = self.items.len() as u32;
-        self.utf32_items.push(Utf32String::from(item.as_str()));
-        self.char_masks.push(compute_char_mask(&item));
-        self.bigram_index.add_item(index, &item);
-        self.items.push(item);
-        self.invalidate_cache();
+        self.core.add(item);
     }
 
     /// Add multiple items to the index at once.
     #[napi]
     pub fn add_many(&mut self, items: Vec<String>) {
-        let base = self.items.len() as u32;
-        for (i, item) in items.iter().enumerate() {
-            self.utf32_items.push(Utf32String::from(item.as_str()));
-            self.char_masks.push(compute_char_mask(item));
-            self.bigram_index.add_item(base + i as u32, item);
-        }
-        self.items.extend(items);
-        self.invalidate_cache();
+        self.core.add_many(items);
     }
 
     /// Remove the item at the given index.
@@ -254,35 +187,13 @@ impl FuzzyIndex {
     /// Uses swap-remove for O(1) performance. Returns false if out of bounds.
     #[napi]
     pub fn remove(&mut self, index: u32) -> bool {
-        let idx = index as usize;
-        if idx < self.items.len() {
-            let last_index = (self.items.len() - 1) as u32;
-            let removed_item = self.items[idx].clone();
-            let last_item = if idx != last_index as usize {
-                Some(self.items[last_index as usize].clone())
-            } else {
-                None
-            };
-            self.bigram_index
-                .remove_item(index, last_index, &removed_item, last_item.as_deref());
-            self.items.swap_remove(idx);
-            self.utf32_items.swap_remove(idx);
-            self.char_masks.swap_remove(idx);
-            self.invalidate_cache();
-            true
-        } else {
-            false
-        }
+        self.core.remove(index)
     }
 
     /// Free the internal data. After calling this, the index is empty.
     #[napi]
     pub fn destroy(&mut self) {
-        self.items = Vec::new();
-        self.utf32_items = Vec::new();
-        self.char_masks = Vec::new();
-        self.bigram_index.clear();
-        self.invalidate_cache();
+        self.core.destroy();
     }
 
     /// Serialize the index to a compact binary format.
@@ -305,81 +216,11 @@ impl FuzzyIndex {
     }
 
     fn serialize_impl(&self) -> Vec<u8> {
-        // Format: [magic 4B] [version u32 LE] [count u32 LE] [items...]
-        // Each item: [len u32 LE] [utf-8 bytes]
-        let mut buf = Vec::new();
-        buf.extend_from_slice(SERIALIZE_MAGIC);
-        buf.extend_from_slice(&SERIALIZE_VERSION.to_le_bytes());
-        buf.extend_from_slice(&(self.items.len() as u32).to_le_bytes());
-        for item in &self.items {
-            buf.extend_from_slice(&(item.len() as u32).to_le_bytes());
-            buf.extend_from_slice(item.as_bytes());
-        }
-        buf
+        serialize_items(self.core.items(), FUZZY_INDEX_MAGIC)
     }
 
     fn deserialize_impl(bytes: &[u8]) -> Result<Self, String> {
-        let header_size = SERIALIZE_MAGIC.len() + 4 + 4; // magic + version + count
-
-        if bytes.len() < header_size {
-            return Err("Invalid data: too short".into());
-        }
-
-        if &bytes[0..4] != SERIALIZE_MAGIC {
-            return Err("Invalid data: bad magic bytes".into());
-        }
-
-        let version = u32::from_le_bytes(
-            bytes[4..8]
-                .try_into()
-                .map_err(|_| "Invalid data: truncated header".to_string())?,
-        );
-        if version != SERIALIZE_VERSION {
-            return Err(format!(
-                "Unsupported format version: expected {SERIALIZE_VERSION}, got {version}"
-            ));
-        }
-
-        let count = u32::from_le_bytes(
-            bytes[8..12]
-                .try_into()
-                .map_err(|_| "Invalid data: truncated header".to_string())?,
-        ) as usize;
-        let mut offset = header_size;
-
-        // Reject obviously invalid counts before allocating.
-        // Each item needs at least 4 bytes (length field), so count cannot
-        // exceed the remaining payload divided by 4.
-        let max_possible = bytes.len().saturating_sub(header_size) / 4;
-        if count > max_possible {
-            return Err("Invalid data: item count exceeds payload size".into());
-        }
-
-        let mut items = Vec::with_capacity(count);
-
-        for _ in 0..count {
-            if offset + 4 > bytes.len() {
-                return Err("Invalid data: truncated".into());
-            }
-            let len = u32::from_le_bytes(
-                bytes[offset..offset + 4]
-                    .try_into()
-                    .map_err(|_| "Invalid data: truncated".to_string())?,
-            ) as usize;
-            offset += 4;
-            if offset + len > bytes.len() {
-                return Err("Invalid data: truncated".into());
-            }
-            let s = std::str::from_utf8(&bytes[offset..offset + len])
-                .map_err(|e| format!("Invalid UTF-8: {e}"))?;
-            items.push(s.to_owned());
-            offset += len;
-        }
-
-        if offset != bytes.len() {
-            return Err("Invalid data: trailing bytes".into());
-        }
-
+        let items = deserialize_items(bytes, FUZZY_INDEX_MAGIC)?;
         Ok(Self::new(items))
     }
 
@@ -391,65 +232,14 @@ impl FuzzyIndex {
         include_positions: bool,
         case_matching: CaseMatching,
     ) -> Vec<SearchResult> {
-        // Determine if we can narrow the search to cached matching indices.
-        // Conditions: new query is a prefix extension of the cached query,
-        // the cache has a non-empty candidate set, and neither query uses
-        // inverted terms (which break monotonicity).
-        let cache_candidates: Option<Vec<u32>> = {
-            let last_q = self.last_query.borrow();
-            let last_idx = self.last_matching_indices.borrow();
-            if !last_q.is_empty()
-                && !last_idx.is_empty()
-                && query.len() > last_q.len()
-                && query.starts_with(last_q.as_str())
-                && !query.contains('!')
-                && !last_q.contains('!')
-            {
-                Some(last_idx.clone())
-            } else {
-                None
-            }
-        };
-
-        // Get bigram candidates (only for large datasets).
-        let bigram_candidates = if self.items.len() >= BIGRAM_THRESHOLD {
-            let query_bigrams = extract_query_bigrams(query);
-            self.bigram_index.candidates(&query_bigrams)
-        } else {
-            None
-        };
-
-        // Compose candidate lists: intersect cache and bigram when both available.
-        let candidates: Option<Vec<u32>> = match (cache_candidates, bigram_candidates) {
-            (Some(cache), Some(bigram)) => Some(intersect_sorted(&cache, &bigram)),
-            (Some(cache), None) => Some(cache),
-            (None, Some(bigram)) => Some(bigram),
-            (None, None) => None,
-        };
-
-        let ctx = PrecomputedSearch {
-            items: &self.items,
-            utf32_items: &self.utf32_items,
-            char_masks: &self.char_masks,
-            candidate_indices: candidates.as_deref(),
-            matcher: &self.matcher,
-        };
-
-        let outcome = search_over_precomputed(
-            query,
-            &ctx,
-            max_results,
-            min_score,
-            include_positions,
-            case_matching,
-        );
-
-        // Update incremental cache.
-        *self.last_query.borrow_mut() = query.to_owned();
-        *self.last_matching_indices.borrow_mut() = outcome.all_matching_indices;
-
-        outcome
-            .results
+        self.core
+            .search_impl(
+                query,
+                max_results,
+                min_score,
+                include_positions,
+                case_matching,
+            )
             .into_iter()
             .map(SearchResult::from)
             .collect()
@@ -463,74 +253,19 @@ impl FuzzyIndex {
         include_positions: bool,
         case_matching: CaseMatching,
     ) -> Vec<IndexSearchResult> {
-        let cache_candidates: Option<Vec<u32>> = {
-            let last_q = self.last_query.borrow();
-            let last_idx = self.last_matching_indices.borrow();
-            if !last_q.is_empty()
-                && !last_idx.is_empty()
-                && query.len() > last_q.len()
-                && query.starts_with(last_q.as_str())
-                && !query.contains('!')
-                && !last_q.contains('!')
-            {
-                Some(last_idx.clone())
-            } else {
-                None
-            }
-        };
-
-        let bigram_candidates = if self.items.len() >= BIGRAM_THRESHOLD {
-            let query_bigrams = extract_query_bigrams(query);
-            self.bigram_index.candidates(&query_bigrams)
-        } else {
-            None
-        };
-
-        let candidates: Option<Vec<u32>> = match (cache_candidates, bigram_candidates) {
-            (Some(cache), Some(bigram)) => Some(intersect_sorted(&cache, &bigram)),
-            (Some(cache), None) => Some(cache),
-            (None, Some(bigram)) => Some(bigram),
-            (None, None) => None,
-        };
-
-        let ctx = PrecomputedSearch {
-            items: &self.items,
-            utf32_items: &self.utf32_items,
-            char_masks: &self.char_masks,
-            candidate_indices: candidates.as_deref(),
-            matcher: &self.matcher,
-        };
-
-        let outcome = search_over_precomputed_indices(
-            query,
-            &ctx,
-            max_results,
-            min_score,
-            include_positions,
-            case_matching,
-        );
-
-        // Update incremental cache.
-        *self.last_query.borrow_mut() = query.to_owned();
-        *self.last_matching_indices.borrow_mut() = outcome.all_matching_indices;
-
-        outcome
-            .results
+        self.core
+            .search_indices_impl(
+                query,
+                max_results,
+                min_score,
+                include_positions,
+                case_matching,
+            )
             .into_iter()
             .map(IndexSearchResult::from)
             .collect()
     }
-
-    fn invalidate_cache(&self) {
-        self.last_query.borrow_mut().clear();
-        self.last_matching_indices.borrow_mut().clear();
-    }
 }
-
-/// Magic bytes identifying a serialized FuzzyIndex.
-const SERIALIZE_MAGIC: &[u8; 4] = b"RFZI";
-/// Current serialization format version.
-const SERIALIZE_VERSION: u32 = 1;
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/search/keyed_index.rs
+++ b/crates/core/src/search/keyed_index.rs
@@ -1,14 +1,12 @@
-use std::cell::RefCell;
-
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
-use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
-use nucleo_matcher::{Config, Matcher, Utf32String};
+use rapid_fuzzy_core::search::KeyedFuzzyIndexCore;
+use rapid_fuzzy_core::search::serialization::{
+    KEYED_INDEX_MAGIC, deserialize_keyed, serialize_keyed,
+};
 
 use super::keys::KeySearchResult;
-use super::{
-    SearchOptions, compute_char_mask, compute_max_score, compute_query_mask, resolve_case_matching,
-};
+use super::{SearchOptions, resolve_case_matching};
 
 /// A persistent multi-key fuzzy search index backed by Rust-side data.
 ///
@@ -22,19 +20,7 @@ use super::{
 /// results back to original objects.
 #[napi]
 pub struct KeyedFuzzyIndex {
-    key_texts: Vec<Vec<String>>,
-    utf32_keys: Vec<Vec<Utf32String>>,
-    key_char_masks: Vec<Vec<u64>>,
-    weights: Vec<f64>,
-    total_weight: f64,
-    matcher: RefCell<Matcher>,
-}
-
-fn to_utf32(texts: &[String]) -> Vec<Utf32String> {
-    texts
-        .iter()
-        .map(|s| Utf32String::from(s.as_str()))
-        .collect()
+    core: KeyedFuzzyIndexCore,
 }
 
 #[napi]
@@ -45,61 +31,19 @@ impl KeyedFuzzyIndex {
     /// All inner arrays must have the same length (the number of items).
     #[napi(constructor)]
     pub fn new(key_texts: Vec<Vec<String>>, weights: Vec<f64>) -> napi::Result<Self> {
-        Self::new_impl(key_texts, weights).map_err(napi::Error::from_reason)
+        KeyedFuzzyIndexCore::new(key_texts, weights)
+            .map(|core| Self { core })
+            .map_err(napi::Error::from_reason)
     }
 
     fn new_impl(key_texts: Vec<Vec<String>>, weights: Vec<f64>) -> Result<Self, String> {
-        let num_keys = key_texts.len();
-
-        if let Some(num_items) = key_texts.first().map(Vec::len) {
-            for (k, col) in key_texts.iter().enumerate().skip(1) {
-                if col.len() != num_items {
-                    return Err(format!(
-                        "All key_texts columns must have the same length; key 0 has {}, key {} has {}",
-                        num_items,
-                        k,
-                        col.len()
-                    ));
-                }
-            }
-        }
-
-        if weights.len() != num_keys {
-            return Err(format!(
-                "Expected {} weights, got {}",
-                num_keys,
-                weights.len()
-            ));
-        }
-
-        if weights.iter().any(|w| !w.is_finite() || *w < 0.0) {
-            return Err("Weights must be finite non-negative numbers".to_string());
-        }
-
-        let total_weight: f64 = weights.iter().sum();
-        if total_weight <= 0.0 {
-            return Err("Total weight must be greater than zero".to_string());
-        }
-
-        let utf32_keys: Vec<Vec<Utf32String>> = key_texts.iter().map(|t| to_utf32(t)).collect();
-        let key_char_masks: Vec<Vec<u64>> = key_texts
-            .iter()
-            .map(|texts| texts.iter().map(|s| compute_char_mask(s)).collect())
-            .collect();
-        Ok(Self {
-            key_texts,
-            utf32_keys,
-            key_char_masks,
-            weights,
-            total_weight,
-            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
-        })
+        KeyedFuzzyIndexCore::new(key_texts, weights).map(|core| Self { core })
     }
 
     /// Return the number of items in the index.
     #[napi(getter)]
     pub fn size(&self) -> u32 {
-        self.key_texts.first().map_or(0, |v| v.len() as u32)
+        self.core.size()
     }
 
     /// Search the index for items matching the query.
@@ -107,157 +51,31 @@ impl KeyedFuzzyIndex {
     /// Returns results sorted by combined weighted score (best match first).
     #[napi]
     pub fn search(&self, query: String, options: Option<SearchOptions>) -> Vec<KeySearchResult> {
-        let num_keys = self.key_texts.len();
-
-        if num_keys == 0 {
-            return Vec::new();
-        }
-
-        let num_items = self.size() as usize;
-        if num_items == 0 {
-            return Vec::new();
-        }
-
-        let return_all_on_empty = options
-            .as_ref()
-            .and_then(|o| o.return_all_on_empty)
-            .unwrap_or(false);
-
-        if return_all_on_empty && query.trim().is_empty() {
-            let max_results = options.as_ref().and_then(|o| o.max_results);
-            let limit = max_results.unwrap_or(num_items as u32) as usize;
-            return (0..num_items)
-                .take(limit)
-                .map(|i| KeySearchResult {
-                    index: i as u32,
-                    score: 1.0,
-                    key_scores: vec![1.0; num_keys],
-                })
-                .collect();
-        }
-
-        if query.is_empty() {
-            return Vec::new();
-        }
-
-        let (max_results, min_score, case_matching) = match &options {
+        let (max_results, min_score, case_matching, return_all_on_empty) = match &options {
             Some(opts) => (
                 opts.max_results,
                 opts.min_score,
                 resolve_case_matching(opts.is_case_sensitive),
+                opts.return_all_on_empty.unwrap_or(false),
             ),
-            None => (None, None, CaseMatching::Smart),
+            None => (
+                None,
+                None,
+                nucleo_matcher::pattern::CaseMatching::Smart,
+                false,
+            ),
         };
 
-        let threshold = min_score.unwrap_or(0.0);
-
-        let mut matcher = self.matcher.borrow_mut();
-        let pattern = Pattern::parse(&query, case_matching, Normalization::Smart);
-        let max_score = compute_max_score(&query, &pattern, &mut matcher);
-        let query_mask = compute_query_mask(&query);
-
-        // Identify keys with non-zero weight to skip unnecessary scoring.
-        let active_keys: Vec<usize> = (0..num_keys).filter(|&k| self.weights[k] > 0.0).collect();
-
-        // Pre-compute the sum of active weights for early exit upper-bound.
-        let active_total_weight: f64 = active_keys.iter().map(|&k| self.weights[k]).sum();
-
-        // Per-item scoring with early exit and per-key char_mask pre-filtering.
-        // Instead of scoring all keys for all items first, we score per-item
-        // and exit early when the upper bound cannot reach the threshold.
-        let mut per_key_scores: Vec<Vec<f64>> = vec![vec![0.0; num_items]; num_keys];
-
-        let threshold_weighted = threshold * self.total_weight;
-
-        let mut scored: Vec<(u32, f64)> = (0..num_items)
-            .filter_map(|i| {
-                let mut weighted_sum = 0.0;
-                let mut matched_any = false;
-                let mut remaining_weight = active_total_weight;
-
-                for &k in &active_keys {
-                    let w = self.weights[k];
-                    remaining_weight -= w;
-
-                    // Per-key char_mask pre-filter: skip expensive scoring if
-                    // the item for this key cannot contain the query characters.
-                    if query_mask != 0 && (self.key_char_masks[k][i] & query_mask) != query_mask {
-                        // Upper bound check: even if all remaining keys score 1.0,
-                        // can we still reach the threshold?
-                        if threshold > 0.0 && weighted_sum + remaining_weight < threshold_weighted {
-                            return None;
-                        }
-                        continue;
-                    }
-
-                    let atoms = self.utf32_keys[k][i].slice(..);
-                    let score = match pattern.score(atoms, &mut matcher) {
-                        Some(raw) => ((raw as f64) / max_score).min(1.0),
-                        None => 0.0,
-                    };
-                    per_key_scores[k][i] = score;
-
-                    if score > 0.0 {
-                        weighted_sum += score * w;
-                        matched_any = true;
-                    }
-
-                    // Early exit: if even perfect scores on remaining keys
-                    // cannot lift the combined score above the threshold,
-                    // skip the remaining keys for this item.
-                    if threshold > 0.0 && weighted_sum + remaining_weight < threshold_weighted {
-                        return None;
-                    }
-                }
-
-                if !matched_any {
-                    return None;
-                }
-
-                let combined = weighted_sum / self.total_weight;
-                if combined >= threshold {
-                    Some((i as u32, combined))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        // Sort by score descending, with original index as tiebreaker
-        // for deterministic ordering.
-        let cmp = |a: &(u32, f64), b: &(u32, f64)| {
-            let score_ord = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
-            if score_ord != std::cmp::Ordering::Equal {
-                return score_ord;
-            }
-            a.0.cmp(&b.0)
-        };
-
-        // Top-k selection: use quickselect O(n) + sort O(k log k) instead of
-        // full sort O(n log n) when maxResults is set.
-        if let Some(max) = max_results {
-            let k = max as usize;
-            if scored.len() > k {
-                scored.select_nth_unstable_by(k, cmp);
-                scored.truncate(k);
-            }
-        }
-        scored.sort_unstable_by(cmp);
-
-        // Pass 2: Construct KeySearchResult only for the final top-k items.
-        scored
+        self.core
+            .search(
+                &query,
+                max_results,
+                min_score,
+                case_matching,
+                return_all_on_empty,
+            )
             .into_iter()
-            .map(|(index, score)| {
-                let key_scores: Vec<f64> = per_key_scores
-                    .iter()
-                    .map(|scores| scores[index as usize])
-                    .collect();
-                KeySearchResult {
-                    index,
-                    score,
-                    key_scores,
-                }
-            })
+            .map(KeySearchResult::from)
             .collect()
     }
 
@@ -269,15 +87,12 @@ impl KeyedFuzzyIndex {
     /// Use the returned index to look up the item in your own data array.
     #[napi]
     pub fn closest(&self, query: String, min_score: Option<f64>) -> Option<u32> {
-        let results = self.search(
-            query,
-            Some(SearchOptions {
-                max_results: Some(1),
-                min_score,
-                include_positions: Some(false),
-                is_case_sensitive: None,
-                return_all_on_empty: None,
-            }),
+        let results = self.core.search(
+            &query,
+            Some(1),
+            min_score,
+            nucleo_matcher::pattern::CaseMatching::Smart,
+            false,
         );
         results.into_iter().next().map(|r| r.index)
     }
@@ -288,7 +103,7 @@ impl KeyedFuzzyIndex {
     /// Throws if the length does not match.
     #[napi]
     pub fn add(&mut self, key_values: Vec<String>) -> napi::Result<()> {
-        self.add_impl(key_values).map_err(napi::Error::from_reason)
+        self.core.add(key_values).map_err(napi::Error::from_reason)
     }
 
     /// Add multiple items to the index at once.
@@ -298,24 +113,9 @@ impl KeyedFuzzyIndex {
     #[napi]
     pub fn add_many(&mut self, items_key_values: Vec<Vec<String>>) -> napi::Result<()> {
         for key_values in items_key_values {
-            self.add_impl(key_values)
+            self.core
+                .add(key_values)
                 .map_err(napi::Error::from_reason)?;
-        }
-        Ok(())
-    }
-
-    fn add_impl(&mut self, key_values: Vec<String>) -> Result<(), String> {
-        let num_keys = self.key_texts.len();
-        if key_values.len() != num_keys {
-            return Err(format!(
-                "Expected {num_keys} key values, got {}",
-                key_values.len()
-            ));
-        }
-        for (k, value) in key_values.into_iter().enumerate() {
-            self.utf32_keys[k].push(Utf32String::from(value.as_str()));
-            self.key_char_masks[k].push(compute_char_mask(&value));
-            self.key_texts[k].push(value);
         }
         Ok(())
     }
@@ -325,32 +125,13 @@ impl KeyedFuzzyIndex {
     /// Uses swap-remove for O(1) performance. Returns false if out of bounds.
     #[napi]
     pub fn remove(&mut self, index: u32) -> bool {
-        let idx = index as usize;
-        let num_items = self.size() as usize;
-        if idx >= num_items {
-            return false;
-        }
-        for ((texts, utf32), masks) in self
-            .key_texts
-            .iter_mut()
-            .zip(self.utf32_keys.iter_mut())
-            .zip(self.key_char_masks.iter_mut())
-        {
-            texts.swap_remove(idx);
-            utf32.swap_remove(idx);
-            masks.swap_remove(idx);
-        }
-        true
+        self.core.remove(index)
     }
 
     /// Free the internal data. After calling this, the index is empty.
     #[napi]
     pub fn destroy(&mut self) {
-        self.key_texts = Vec::new();
-        self.utf32_keys = Vec::new();
-        self.key_char_masks = Vec::new();
-        self.weights = Vec::new();
-        self.total_weight = 0.0;
+        self.core.destroy();
     }
 
     /// Serialize the index to a compact binary format.
@@ -368,124 +149,30 @@ impl KeyedFuzzyIndex {
     pub fn deserialize(data: Buffer) -> napi::Result<Self> {
         Self::deserialize_impl(&data).map_err(napi::Error::from_reason)
     }
+}
 
+/// Non-napi helper methods.
+impl KeyedFuzzyIndex {
     fn serialize_impl(&self) -> Vec<u8> {
-        // Format:
-        //   [magic 4B] [version u32 LE] [num_keys u32 LE] [num_items u32 LE]
-        //   [weights: num_keys × f64 LE]
-        //   [key_texts column-major: for each key, for each item: [len u32 LE][utf-8 bytes]]
-        let num_keys = self.weights.len();
-        let num_items = self.size() as usize;
-
-        let mut buf = Vec::new();
-        buf.extend_from_slice(SERIALIZE_MAGIC);
-        buf.extend_from_slice(&SERIALIZE_VERSION.to_le_bytes());
-        buf.extend_from_slice(&(num_keys as u32).to_le_bytes());
-        buf.extend_from_slice(&(num_items as u32).to_le_bytes());
-
-        for &w in &self.weights {
-            buf.extend_from_slice(&w.to_le_bytes());
-        }
-
-        for key_col in &self.key_texts {
-            for item in key_col {
-                buf.extend_from_slice(&(item.len() as u32).to_le_bytes());
-                buf.extend_from_slice(item.as_bytes());
-            }
-        }
-
-        buf
+        serialize_keyed(
+            self.core.key_texts(),
+            self.core.weights(),
+            KEYED_INDEX_MAGIC,
+        )
     }
 
     fn deserialize_impl(bytes: &[u8]) -> Result<Self, String> {
-        let header_size = 4 + 4 + 4 + 4; // magic + version + num_keys + num_items
-
-        if bytes.len() < header_size {
-            return Err("Invalid data: too short".into());
-        }
-
-        if &bytes[0..4] != SERIALIZE_MAGIC {
-            return Err("Invalid data: bad magic bytes".into());
-        }
-
-        let version = u32::from_le_bytes(
-            bytes[4..8]
-                .try_into()
-                .map_err(|_| "Invalid data: truncated header".to_string())?,
-        );
-        if version != SERIALIZE_VERSION {
-            return Err(format!(
-                "Unsupported format version: expected {SERIALIZE_VERSION}, got {version}"
-            ));
-        }
-
-        let num_keys = u32::from_le_bytes(
-            bytes[8..12]
-                .try_into()
-                .map_err(|_| "Invalid data: truncated header".to_string())?,
-        ) as usize;
-
-        let num_items = u32::from_le_bytes(
-            bytes[12..16]
-                .try_into()
-                .map_err(|_| "Invalid data: truncated header".to_string())?,
-        ) as usize;
-
-        let mut offset = header_size;
-
-        // Read weights (num_keys × 8 bytes each)
-        let weights_size = num_keys * 8;
-        if offset + weights_size > bytes.len() {
-            return Err("Invalid data: truncated weights".into());
-        }
-        let mut weights = Vec::with_capacity(num_keys);
-        for _ in 0..num_keys {
-            let w = f64::from_le_bytes(
-                bytes[offset..offset + 8]
-                    .try_into()
-                    .map_err(|_| "Invalid data: truncated weight".to_string())?,
-            );
-            weights.push(w);
-            offset += 8;
-        }
-
-        // Read key_texts column-major
-        let mut key_texts: Vec<Vec<String>> = Vec::with_capacity(num_keys);
-        for _ in 0..num_keys {
-            let mut col = Vec::with_capacity(num_items);
-            for _ in 0..num_items {
-                if offset + 4 > bytes.len() {
-                    return Err("Invalid data: truncated".into());
-                }
-                let len = u32::from_le_bytes(
-                    bytes[offset..offset + 4]
-                        .try_into()
-                        .map_err(|_| "Invalid data: truncated".to_string())?,
-                ) as usize;
-                offset += 4;
-                if offset + len > bytes.len() {
-                    return Err("Invalid data: truncated".into());
-                }
-                let s = std::str::from_utf8(&bytes[offset..offset + len])
-                    .map_err(|e| format!("Invalid UTF-8: {e}"))?;
-                col.push(s.to_owned());
-                offset += len;
-            }
-            key_texts.push(col);
-        }
-
-        if offset != bytes.len() {
-            return Err("Invalid data: trailing bytes".into());
-        }
-
+        let (key_texts, weights) = deserialize_keyed(bytes, KEYED_INDEX_MAGIC)?;
         Self::new_impl(key_texts, weights)
     }
 }
 
-/// Magic bytes identifying a serialized KeyedFuzzyIndex.
-const SERIALIZE_MAGIC: &[u8; 4] = b"RFKI";
-/// Current serialization format version.
-const SERIALIZE_VERSION: u32 = 1;
+#[cfg(test)]
+impl KeyedFuzzyIndex {
+    fn add_impl(&mut self, key_values: Vec<String>) -> Result<(), String> {
+        self.core.add(key_values)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/search/keys.rs
+++ b/crates/core/src/search/keys.rs
@@ -1,8 +1,11 @@
 use napi_derive::napi;
-use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
-use nucleo_matcher::{Config, Matcher};
+use rapid_fuzzy_core::search::SearchKeysOptions;
 
-use super::{SearchOptions, compute_max_score, resolve_case_matching};
+use super::SearchOptions;
+
+// Re-export CaseMatching so tests can access it via `use super::*`.
+#[cfg(test)]
+pub(crate) use nucleo_matcher::pattern::CaseMatching;
 
 /// A single result from multi-key fuzzy search.
 #[napi(object)]
@@ -14,6 +17,16 @@ pub struct KeySearchResult {
     /// Per-key scores in the same order as the input keys.
     /// A score of 0.0 means the item did not match on that key.
     pub key_scores: Vec<f64>,
+}
+
+impl From<rapid_fuzzy_core::search::KeySearchResult> for KeySearchResult {
+    fn from(r: rapid_fuzzy_core::search::KeySearchResult) -> Self {
+        Self {
+            index: r.index,
+            score: r.score,
+            key_scores: r.key_scores,
+        }
+    }
 }
 
 /// Perform fuzzy search across multiple text keys with weights.
@@ -30,151 +43,16 @@ pub fn search_keys(
     weights: Vec<f64>,
     options: Option<SearchOptions>,
 ) -> Vec<KeySearchResult> {
-    let num_keys = key_texts.len();
+    let core_opts = options.map(|opts| SearchKeysOptions {
+        max_results: opts.max_results,
+        min_score: opts.min_score,
+        is_case_sensitive: opts.is_case_sensitive,
+        return_all_on_empty: opts.return_all_on_empty,
+    });
 
-    if num_keys == 0 || weights.len() != num_keys {
-        return Vec::new();
-    }
-
-    let num_items = key_texts[0].len();
-    if num_items == 0 {
-        return Vec::new();
-    }
-
-    // Validate all key_texts have the same length
-    for texts in &key_texts {
-        if texts.len() != num_items {
-            return Vec::new();
-        }
-    }
-
-    let return_all_on_empty = options
-        .as_ref()
-        .and_then(|o| o.return_all_on_empty)
-        .unwrap_or(false);
-
-    if return_all_on_empty && query.trim().is_empty() {
-        let max_results = options.as_ref().and_then(|o| o.max_results);
-        let limit = max_results.unwrap_or(num_items as u32) as usize;
-        return (0..num_items)
-            .take(limit)
-            .map(|i| KeySearchResult {
-                index: i as u32,
-                score: 1.0,
-                key_scores: vec![1.0; num_keys],
-            })
-            .collect();
-    }
-
-    if query.is_empty() {
-        return Vec::new();
-    }
-
-    let (max_results, min_score, case_matching) = match &options {
-        Some(opts) => (
-            opts.max_results,
-            opts.min_score,
-            resolve_case_matching(opts.is_case_sensitive),
-        ),
-        None => (None, None, CaseMatching::Smart),
-    };
-
-    let threshold = min_score.unwrap_or(0.0);
-
-    // Reject negative, NaN, or infinite weights to guarantee scores stay in [0.0, 1.0]
-    if weights.iter().any(|w| !w.is_finite() || *w < 0.0) {
-        return Vec::new();
-    }
-
-    let total_weight: f64 = weights.iter().sum();
-    if total_weight <= 0.0 {
-        return Vec::new();
-    }
-
-    let mut matcher = Matcher::new(Config::DEFAULT);
-    let pattern = Pattern::parse(&query, case_matching, Normalization::Smart);
-    let max_score = compute_max_score(&query, &pattern, &mut matcher);
-
-    // Compute per-key scores for all items
-    let mut per_key_scores: Vec<Vec<f64>> = Vec::with_capacity(num_keys);
-    let mut buf = Vec::new();
-
-    for texts in &key_texts {
-        let mut scores = Vec::with_capacity(num_items);
-        for text in texts {
-            buf.clear();
-            let atoms = nucleo_matcher::Utf32Str::new(text, &mut buf);
-            let score = match pattern.score(atoms, &mut matcher) {
-                Some(raw) => ((raw as f64) / max_score).min(1.0),
-                None => 0.0,
-            };
-            scores.push(score);
-        }
-        per_key_scores.push(scores);
-    }
-
-    // Pass 1: Compute combined scores, collect (index, score) only.
-    let mut scored: Vec<(u32, f64)> = (0..num_items)
-        .filter_map(|i| {
-            let mut weighted_sum = 0.0;
-            let mut matched_any = false;
-
-            for k in 0..num_keys {
-                let score = per_key_scores[k][i];
-                if score > 0.0 {
-                    weighted_sum += score * weights[k];
-                    matched_any = true;
-                }
-            }
-
-            if !matched_any {
-                return None;
-            }
-
-            let combined = weighted_sum / total_weight;
-            if combined >= threshold {
-                Some((i as u32, combined))
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    // Sort by score descending, with original index as tiebreaker
-    // for deterministic ordering.
-    let cmp = |a: &(u32, f64), b: &(u32, f64)| {
-        let score_ord = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
-        if score_ord != std::cmp::Ordering::Equal {
-            return score_ord;
-        }
-        a.0.cmp(&b.0)
-    };
-
-    // Top-k selection: use quickselect O(n) + sort O(k log k) instead of
-    // full sort O(n log n) when maxResults is set.
-    if let Some(max) = max_results {
-        let k = max as usize;
-        if scored.len() > k {
-            scored.select_nth_unstable_by(k, cmp);
-            scored.truncate(k);
-        }
-    }
-    scored.sort_unstable_by(cmp);
-
-    // Pass 2: Construct KeySearchResult only for the final top-k items.
-    scored
+    rapid_fuzzy_core::search::search_keys_impl(&query, &key_texts, &weights, core_opts)
         .into_iter()
-        .map(|(index, score)| {
-            let key_scores: Vec<f64> = per_key_scores
-                .iter()
-                .map(|scores| scores[index as usize])
-                .collect();
-            KeySearchResult {
-                index,
-                score,
-                key_scores,
-            }
-        })
+        .map(KeySearchResult::from)
         .collect()
 }
 

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -7,14 +7,13 @@ pub use keyed_index::KeyedFuzzyIndex;
 pub use keys::search_keys;
 
 // Re-export core algorithm functions and types for use in submodules and tests.
-pub(crate) use rapid_fuzzy_core::search::{
-    BigramIndex, PrecomputedSearch, compute_char_mask, compute_max_score, compute_query_mask,
-    extract_query_bigrams, intersect_sorted, resolve_case_matching, search_over_precomputed,
-    search_over_precomputed_indices,
-};
+pub(crate) use rapid_fuzzy_core::search::resolve_case_matching;
 
 #[cfg(test)]
-pub(crate) use rapid_fuzzy_core::search::{bigram_key, extract_bigrams};
+pub(crate) use rapid_fuzzy_core::search::{
+    BigramIndex, PrecomputedSearch, bigram_key, compute_char_mask, extract_bigrams,
+    extract_query_bigrams, intersect_sorted, search_over_precomputed,
+};
 
 use napi::Either;
 use napi_derive::napi;

--- a/crates/wasm/src/search/index.rs
+++ b/crates/wasm/src/search/index.rs
@@ -1,18 +1,11 @@
-use std::cell::RefCell;
-
 use nucleo_matcher::pattern::CaseMatching;
-use nucleo_matcher::{Config, Matcher, Utf32String};
+use rapid_fuzzy_core::search::FuzzyIndexCore;
+use rapid_fuzzy_core::search::serialization::{
+    FUZZY_INDEX_WASM_MAGIC, deserialize_items, serialize_items,
+};
 use wasm_bindgen::prelude::*;
 
-use super::{
-    BigramIndex, IndexSearchResult, PrecomputedSearch, SearchOptions, SearchResult,
-    compute_char_mask, extract_query_bigrams, resolve_case_matching, search_over_precomputed,
-    search_over_precomputed_indices, to_js,
-};
-
-const BIGRAM_THRESHOLD: usize = 5_000;
-const SERIALIZE_MAGIC: &[u8] = b"RFUZ";
-const SERIALIZE_VERSION: u32 = 1;
+use super::{IndexSearchResult, SearchOptions, SearchResult, resolve_case_matching, to_js};
 
 /// A persistent fuzzy search index backed by Rust-side data.
 ///
@@ -20,13 +13,7 @@ const SERIALIZE_VERSION: u32 = 1;
 /// for applications that search the same dataset multiple times.
 #[wasm_bindgen]
 pub struct FuzzyIndex {
-    items: Vec<String>,
-    utf32_items: Vec<Utf32String>,
-    char_masks: Vec<u64>,
-    bigram_index: BigramIndex,
-    matcher: RefCell<Matcher>,
-    last_query: RefCell<String>,
-    last_matching_indices: RefCell<Vec<u32>>,
+    core: FuzzyIndexCore,
 }
 
 #[wasm_bindgen]
@@ -34,27 +21,15 @@ impl FuzzyIndex {
     /// Create a new FuzzyIndex from an array of strings.
     #[wasm_bindgen(constructor)]
     pub fn new(items: Vec<String>) -> Self {
-        let utf32_items: Vec<Utf32String> = items
-            .iter()
-            .map(|s| Utf32String::from(s.as_str()))
-            .collect();
-        let char_masks: Vec<u64> = items.iter().map(|s| compute_char_mask(s)).collect();
-        let bigram_index = BigramIndex::new(&items);
         Self {
-            items,
-            utf32_items,
-            char_masks,
-            bigram_index,
-            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
-            last_query: RefCell::new(String::new()),
-            last_matching_indices: RefCell::new(Vec::new()),
+            core: FuzzyIndexCore::new(items),
         }
     }
 
     /// Return the number of items in the index.
     #[wasm_bindgen(getter)]
     pub fn size(&self) -> u32 {
-        self.items.len() as u32
+        self.core.size()
     }
 
     /// Search the index for items matching the query.
@@ -71,9 +46,9 @@ impl FuzzyIndex {
         );
 
         if return_all_on_empty && query.trim().is_empty() {
-            let limit = max_results.unwrap_or(self.items.len() as u32) as usize;
-            let results: Vec<SearchResult> = self
-                .items
+            let items = self.core.items();
+            let limit = max_results.unwrap_or(items.len() as u32) as usize;
+            let results: Vec<SearchResult> = items
                 .iter()
                 .enumerate()
                 .take(limit)
@@ -88,13 +63,18 @@ impl FuzzyIndex {
             return to_js(&results);
         }
 
-        let results = self.search_impl(
-            &query,
-            max_results,
-            min_score,
-            include_positions,
-            case_matching,
-        );
+        let results: Vec<SearchResult> = self
+            .core
+            .search_impl(
+                &query,
+                max_results,
+                min_score,
+                include_positions,
+                case_matching,
+            )
+            .into_iter()
+            .map(SearchResult::from)
+            .collect();
         to_js(&results)
     }
 
@@ -102,7 +82,9 @@ impl FuzzyIndex {
     ///
     /// Returns the best match, or null if no match is found.
     pub fn closest(&self, query: String, min_score: Option<f64>) -> Option<String> {
-        let results = self.search_impl(&query, Some(1), min_score, false, CaseMatching::Smart);
+        let results = self
+            .core
+            .search_impl(&query, Some(1), min_score, false, CaseMatching::Smart);
         results.into_iter().next().map(|r| r.item)
     }
 
@@ -119,8 +101,9 @@ impl FuzzyIndex {
         );
 
         if return_all_on_empty && query.trim().is_empty() {
-            let limit = max_results.unwrap_or(self.items.len() as u32) as usize;
-            let results: Vec<IndexSearchResult> = (0..self.items.len())
+            let num_items = self.core.size() as usize;
+            let limit = max_results.unwrap_or(num_items as u32) as usize;
+            let results: Vec<IndexSearchResult> = (0..num_items)
                 .take(limit)
                 .map(|i| IndexSearchResult {
                     index: i as u32,
@@ -132,264 +115,53 @@ impl FuzzyIndex {
             return to_js(&results);
         }
 
-        let results = self.search_indices_impl(
-            &query,
-            max_results,
-            min_score,
-            include_positions,
-            case_matching,
-        );
+        let results: Vec<IndexSearchResult> = self
+            .core
+            .search_indices_impl(
+                &query,
+                max_results,
+                min_score,
+                include_positions,
+                case_matching,
+            )
+            .into_iter()
+            .map(IndexSearchResult::from)
+            .collect();
         to_js(&results)
     }
 
     /// Add a single item to the index.
     pub fn add(&mut self, item: String) {
-        let index = self.items.len() as u32;
-        self.utf32_items.push(Utf32String::from(item.as_str()));
-        self.char_masks.push(compute_char_mask(&item));
-        self.bigram_index.add_item(index, &item);
-        self.items.push(item);
-        self.invalidate_cache();
+        self.core.add(item);
     }
 
     /// Add multiple items to the index at once.
     #[wasm_bindgen(js_name = "addMany")]
     pub fn add_many(&mut self, items: Vec<String>) {
-        let base = self.items.len() as u32;
-        for (i, item) in items.iter().enumerate() {
-            self.utf32_items.push(Utf32String::from(item.as_str()));
-            self.char_masks.push(compute_char_mask(item));
-            self.bigram_index.add_item(base + i as u32, item);
-        }
-        self.items.extend(items);
-        self.invalidate_cache();
+        self.core.add_many(items);
     }
 
     /// Remove the item at the given index.
     ///
     /// Uses swap-remove for O(1) performance. Returns false if out of bounds.
     pub fn remove(&mut self, index: u32) -> bool {
-        let idx = index as usize;
-        if idx < self.items.len() {
-            let last_index = (self.items.len() - 1) as u32;
-            let removed_item = self.items[idx].clone();
-            let last_item = if idx != last_index as usize {
-                Some(self.items[last_index as usize].clone())
-            } else {
-                None
-            };
-            self.bigram_index
-                .remove_item(index, last_index, &removed_item, last_item.as_deref());
-            self.items.swap_remove(idx);
-            self.utf32_items.swap_remove(idx);
-            self.char_masks.swap_remove(idx);
-            self.invalidate_cache();
-            true
-        } else {
-            false
-        }
+        self.core.remove(index)
     }
 
     /// Free the internal data. After calling this, the index is empty.
     pub fn destroy(&mut self) {
-        self.items = Vec::new();
-        self.utf32_items = Vec::new();
-        self.char_masks = Vec::new();
-        self.bigram_index.clear();
-        self.invalidate_cache();
+        self.core.destroy();
     }
 
     /// Serialize the index to a compact binary format (Uint8Array).
     pub fn serialize(&self) -> Vec<u8> {
-        self.serialize_impl()
+        serialize_items(self.core.items(), FUZZY_INDEX_WASM_MAGIC)
     }
 
     /// Reconstruct a FuzzyIndex from a previously serialized Uint8Array.
     pub fn deserialize(data: &[u8]) -> Result<FuzzyIndex, JsValue> {
-        Self::deserialize_impl(data).map_err(|e| JsValue::from_str(&e))
-    }
-
-    fn serialize_impl(&self) -> Vec<u8> {
-        let mut buf = Vec::new();
-        buf.extend_from_slice(SERIALIZE_MAGIC);
-        buf.extend_from_slice(&SERIALIZE_VERSION.to_le_bytes());
-        buf.extend_from_slice(&(self.items.len() as u32).to_le_bytes());
-        for item in &self.items {
-            buf.extend_from_slice(&(item.len() as u32).to_le_bytes());
-            buf.extend_from_slice(item.as_bytes());
-        }
-        buf
-    }
-
-    fn deserialize_impl(bytes: &[u8]) -> Result<Self, String> {
-        let header_size = SERIALIZE_MAGIC.len() + 4 + 4;
-        if bytes.len() < header_size {
-            return Err("Invalid data: too short".into());
-        }
-        if &bytes[0..4] != SERIALIZE_MAGIC {
-            return Err("Invalid data: bad magic bytes".into());
-        }
-        let version = u32::from_le_bytes(
-            bytes[4..8]
-                .try_into()
-                .map_err(|_| "Invalid data: truncated header".to_string())?,
-        );
-        if version != SERIALIZE_VERSION {
-            return Err(format!(
-                "Unsupported format version: expected {SERIALIZE_VERSION}, got {version}"
-            ));
-        }
-        let count = u32::from_le_bytes(
-            bytes[8..12]
-                .try_into()
-                .map_err(|_| "Invalid data: truncated header".to_string())?,
-        ) as usize;
-        let mut offset = header_size;
-        let max_possible = bytes.len().saturating_sub(header_size) / 4;
-        if count > max_possible {
-            return Err("Invalid data: item count exceeds payload size".into());
-        }
-        let mut items = Vec::with_capacity(count);
-        for _ in 0..count {
-            if offset + 4 > bytes.len() {
-                return Err("Invalid data: truncated".into());
-            }
-            let len = u32::from_le_bytes(
-                bytes[offset..offset + 4]
-                    .try_into()
-                    .map_err(|_| "Invalid data: truncated".to_string())?,
-            ) as usize;
-            offset += 4;
-            if offset + len > bytes.len() {
-                return Err("Invalid data: truncated".into());
-            }
-            let s = std::str::from_utf8(&bytes[offset..offset + len])
-                .map_err(|e| format!("Invalid UTF-8: {e}"))?;
-            items.push(s.to_owned());
-            offset += len;
-        }
-        if offset != bytes.len() {
-            return Err("Invalid data: trailing bytes".into());
-        }
+        let items =
+            deserialize_items(data, FUZZY_INDEX_WASM_MAGIC).map_err(|e| JsValue::from_str(&e))?;
         Ok(Self::new(items))
-    }
-
-    fn search_impl(
-        &self,
-        query: &str,
-        max_results: Option<u32>,
-        min_score: Option<f64>,
-        include_positions: bool,
-        case_matching: CaseMatching,
-    ) -> Vec<SearchResult> {
-        // Determine incremental search cache candidates.
-        let cache_candidates: Option<Vec<u32>> = {
-            let last_q = self.last_query.borrow();
-            let last_indices = self.last_matching_indices.borrow();
-            if !query.is_empty()
-                && !last_q.is_empty()
-                && query.starts_with(last_q.as_str())
-                && !last_indices.is_empty()
-                && !last_q.contains('!')
-                && !query.contains('!')
-            {
-                Some(last_indices.clone())
-            } else {
-                None
-            }
-        };
-
-        // Apply bigram pre-filtering when the dataset is large enough.
-        let bigram_candidates: Option<Vec<u32>> =
-            if self.items.len() >= BIGRAM_THRESHOLD && cache_candidates.is_none() {
-                let qbigrams = extract_query_bigrams(query);
-                if qbigrams.is_empty() {
-                    None
-                } else {
-                    self.bigram_index.candidates(&qbigrams)
-                }
-            } else {
-                None
-            };
-
-        let candidate_indices: Option<&[u32]> =
-            cache_candidates.as_deref().or(bigram_candidates.as_deref());
-
-        let ctx = PrecomputedSearch {
-            items: &self.items,
-            utf32_items: &self.utf32_items,
-            char_masks: &self.char_masks,
-            candidate_indices,
-            matcher: &self.matcher,
-        };
-
-        let outcome = search_over_precomputed(
-            query,
-            &ctx,
-            max_results,
-            min_score,
-            include_positions,
-            case_matching,
-        );
-
-        *self.last_query.borrow_mut() = query.to_owned();
-        *self.last_matching_indices.borrow_mut() = outcome.all_matching_indices;
-
-        outcome
-            .results
-            .into_iter()
-            .map(SearchResult::from)
-            .collect()
-    }
-
-    fn search_indices_impl(
-        &self,
-        query: &str,
-        max_results: Option<u32>,
-        min_score: Option<f64>,
-        include_positions: bool,
-        case_matching: CaseMatching,
-    ) -> Vec<IndexSearchResult> {
-        let bigram_candidates: Option<Vec<u32>> = if self.items.len() >= BIGRAM_THRESHOLD {
-            let qbigrams = extract_query_bigrams(query);
-            if qbigrams.is_empty() {
-                None
-            } else {
-                self.bigram_index.candidates(&qbigrams)
-            }
-        } else {
-            None
-        };
-
-        let ctx = PrecomputedSearch {
-            items: &self.items,
-            utf32_items: &self.utf32_items,
-            char_masks: &self.char_masks,
-            candidate_indices: bigram_candidates.as_deref(),
-            matcher: &self.matcher,
-        };
-
-        let outcome = search_over_precomputed_indices(
-            query,
-            &ctx,
-            max_results,
-            min_score,
-            include_positions,
-            case_matching,
-        );
-
-        *self.last_query.borrow_mut() = query.to_owned();
-        *self.last_matching_indices.borrow_mut() = outcome.all_matching_indices;
-
-        outcome
-            .results
-            .into_iter()
-            .map(IndexSearchResult::from)
-            .collect()
-    }
-
-    fn invalidate_cache(&self) {
-        self.last_query.borrow_mut().clear();
-        self.last_matching_indices.borrow_mut().clear();
     }
 }

--- a/crates/wasm/src/search/keyed_index.rs
+++ b/crates/wasm/src/search/keyed_index.rs
@@ -1,37 +1,18 @@
-use std::cell::RefCell;
-
-use nucleo_matcher::pattern::{Normalization, Pattern};
-use nucleo_matcher::{Config, Matcher, Utf32String};
+use rapid_fuzzy_core::search::KeyedFuzzyIndexCore;
+use rapid_fuzzy_core::search::serialization::{
+    KEYED_INDEX_MAGIC, deserialize_keyed, serialize_keyed,
+};
 use wasm_bindgen::prelude::*;
 
-use super::{
-    SearchOptions, compute_char_mask, compute_max_score, compute_query_mask, resolve_case_matching,
-    to_js,
-};
-
 use super::keys::KeySearchResult;
-
-const SERIALIZE_MAGIC: &[u8; 4] = b"RFKI";
-const SERIALIZE_VERSION: u32 = 1;
-
-fn to_utf32(texts: &[String]) -> Vec<Utf32String> {
-    texts
-        .iter()
-        .map(|s| Utf32String::from(s.as_str()))
-        .collect()
-}
+use super::{SearchOptions, resolve_case_matching, to_js};
 
 /// A persistent multi-key fuzzy search index backed by Rust-side data.
 ///
 /// Holds key text arrays and weights in memory on the Rust side.
 #[wasm_bindgen]
 pub struct KeyedFuzzyIndex {
-    key_texts: Vec<Vec<String>>,
-    utf32_keys: Vec<Vec<Utf32String>>,
-    key_char_masks: Vec<Vec<u64>>,
-    weights: Vec<f64>,
-    total_weight: f64,
-    matcher: RefCell<Matcher>,
+    core: KeyedFuzzyIndexCore,
 }
 
 #[wasm_bindgen]
@@ -45,75 +26,59 @@ impl KeyedFuzzyIndex {
     pub fn new(key_texts: JsValue, weights: Vec<f64>) -> Result<KeyedFuzzyIndex, JsValue> {
         let key_texts: Vec<Vec<String>> = serde_wasm_bindgen::from_value(key_texts)
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
-        Self::new_impl(key_texts, weights).map_err(|e| JsValue::from_str(&e))
-    }
-
-    fn new_impl(key_texts: Vec<Vec<String>>, weights: Vec<f64>) -> Result<Self, String> {
-        let num_keys = key_texts.len();
-        if let Some(num_items) = key_texts.first().map(Vec::len) {
-            for (k, col) in key_texts.iter().enumerate().skip(1) {
-                if col.len() != num_items {
-                    return Err(format!(
-                        "All key_texts columns must have the same length; key 0 has {}, key {} has {}",
-                        num_items,
-                        k,
-                        col.len()
-                    ));
-                }
-            }
-        }
-        if weights.len() != num_keys {
-            return Err(format!(
-                "Expected {} weights, got {}",
-                num_keys,
-                weights.len()
-            ));
-        }
-        if weights.iter().any(|w| !w.is_finite() || *w < 0.0) {
-            return Err("Weights must be finite non-negative numbers".to_string());
-        }
-        let total_weight: f64 = weights.iter().sum();
-        if total_weight <= 0.0 {
-            return Err("Total weight must be greater than zero".to_string());
-        }
-        let utf32_keys: Vec<Vec<Utf32String>> = key_texts.iter().map(|t| to_utf32(t)).collect();
-        let key_char_masks: Vec<Vec<u64>> = key_texts
-            .iter()
-            .map(|texts| texts.iter().map(|s| compute_char_mask(s)).collect())
-            .collect();
-        Ok(Self {
-            key_texts,
-            utf32_keys,
-            key_char_masks,
-            weights,
-            total_weight,
-            matcher: RefCell::new(Matcher::new(Config::DEFAULT)),
-        })
+        KeyedFuzzyIndexCore::new(key_texts, weights)
+            .map(|core| Self { core })
+            .map_err(|e| JsValue::from_str(&e))
     }
 
     /// Return the number of items in the index.
     #[wasm_bindgen(getter)]
     pub fn size(&self) -> u32 {
-        self.key_texts.first().map_or(0, |v| v.len() as u32)
+        self.core.size()
     }
 
     /// Search the index for items matching the query.
     ///
     /// Returns results sorted by combined weighted score as a JS Array.
     pub fn search(&self, query: String, options: Option<SearchOptions>) -> JsValue {
-        let results = self.search_impl(query, options);
+        let (max_results, min_score, case_matching, return_all_on_empty) = match &options {
+            Some(opts) => (
+                opts.max_results,
+                opts.min_score,
+                resolve_case_matching(opts.is_case_sensitive),
+                opts.return_all_on_empty.unwrap_or(false),
+            ),
+            None => (
+                None,
+                None,
+                nucleo_matcher::pattern::CaseMatching::Smart,
+                false,
+            ),
+        };
+
+        let results: Vec<KeySearchResult> = self
+            .core
+            .search(
+                &query,
+                max_results,
+                min_score,
+                case_matching,
+                return_all_on_empty,
+            )
+            .into_iter()
+            .map(KeySearchResult::from)
+            .collect();
         to_js(&results)
     }
 
     /// Find the index of the closest matching item.
     pub fn closest(&self, query: String, min_score: Option<f64>) -> Option<u32> {
-        let results = self.search_impl(
-            query,
-            Some(SearchOptions {
-                max_results: Some(1),
-                min_score,
-                ..Default::default()
-            }),
+        let results = self.core.search(
+            &query,
+            Some(1),
+            min_score,
+            nucleo_matcher::pattern::CaseMatching::Smart,
+            false,
         );
         results.into_iter().next().map(|r| r.index)
     }
@@ -124,7 +89,7 @@ impl KeyedFuzzyIndex {
     pub fn add(&mut self, key_values: JsValue) -> Result<(), JsValue> {
         let key_values: Vec<String> = serde_wasm_bindgen::from_value(key_values)
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
-        self.add_impl(key_values).map_err(|e| JsValue::from_str(&e))
+        self.core.add(key_values).map_err(|e| JsValue::from_str(&e))
     }
 
     /// Add multiple items to the index at once.
@@ -136,24 +101,9 @@ impl KeyedFuzzyIndex {
         let items: Vec<Vec<String>> = serde_wasm_bindgen::from_value(items_key_values)
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
         for key_values in items {
-            self.add_impl(key_values)
+            self.core
+                .add(key_values)
                 .map_err(|e| JsValue::from_str(&e))?;
-        }
-        Ok(())
-    }
-
-    fn add_impl(&mut self, key_values: Vec<String>) -> Result<(), String> {
-        let num_keys = self.key_texts.len();
-        if key_values.len() != num_keys {
-            return Err(format!(
-                "Expected {num_keys} key values, got {}",
-                key_values.len()
-            ));
-        }
-        for (k, value) in key_values.into_iter().enumerate() {
-            self.utf32_keys[k].push(Utf32String::from(value.as_str()));
-            self.key_char_masks[k].push(compute_char_mask(&value));
-            self.key_texts[k].push(value);
         }
         Ok(())
     }
@@ -162,238 +112,29 @@ impl KeyedFuzzyIndex {
     ///
     /// Uses swap-remove for O(1) performance. Returns false if out of bounds.
     pub fn remove(&mut self, index: u32) -> bool {
-        let idx = index as usize;
-        let num_items = self.size() as usize;
-        if idx >= num_items {
-            return false;
-        }
-        for ((texts, utf32), masks) in self
-            .key_texts
-            .iter_mut()
-            .zip(self.utf32_keys.iter_mut())
-            .zip(self.key_char_masks.iter_mut())
-        {
-            texts.swap_remove(idx);
-            utf32.swap_remove(idx);
-            masks.swap_remove(idx);
-        }
-        true
+        self.core.remove(index)
     }
 
     /// Free the internal data. After calling this, the index is empty.
     pub fn destroy(&mut self) {
-        self.key_texts = Vec::new();
-        self.utf32_keys = Vec::new();
-        self.key_char_masks = Vec::new();
-        self.weights = Vec::new();
-        self.total_weight = 0.0;
+        self.core.destroy();
     }
 
     /// Serialize the index to a compact binary format (Uint8Array).
     pub fn serialize(&self) -> Vec<u8> {
-        let num_keys = self.weights.len();
-        let num_items = self.size() as usize;
-        let mut buf = Vec::new();
-        buf.extend_from_slice(SERIALIZE_MAGIC);
-        buf.extend_from_slice(&SERIALIZE_VERSION.to_le_bytes());
-        buf.extend_from_slice(&(num_keys as u32).to_le_bytes());
-        buf.extend_from_slice(&(num_items as u32).to_le_bytes());
-        for &w in &self.weights {
-            buf.extend_from_slice(&w.to_le_bytes());
-        }
-        for key_col in &self.key_texts {
-            for item in key_col {
-                buf.extend_from_slice(&(item.len() as u32).to_le_bytes());
-                buf.extend_from_slice(item.as_bytes());
-            }
-        }
-        buf
+        serialize_keyed(
+            self.core.key_texts(),
+            self.core.weights(),
+            KEYED_INDEX_MAGIC,
+        )
     }
 
     /// Reconstruct a KeyedFuzzyIndex from a previously serialized Uint8Array.
     pub fn deserialize(data: &[u8]) -> Result<KeyedFuzzyIndex, JsValue> {
-        Self::deserialize_impl(data).map_err(|e| JsValue::from_str(&e))
-    }
-
-    fn deserialize_impl(bytes: &[u8]) -> Result<Self, String> {
-        let header_size = 4 + 4 + 4 + 4;
-        if bytes.len() < header_size {
-            return Err("Invalid data: too short".into());
-        }
-        if &bytes[0..4] != SERIALIZE_MAGIC {
-            return Err("Invalid data: bad magic bytes".into());
-        }
-        let version = u32::from_le_bytes(
-            bytes[4..8]
-                .try_into()
-                .map_err(|_| "Invalid data: truncated header".to_string())?,
-        );
-        if version != SERIALIZE_VERSION {
-            return Err(format!(
-                "Unsupported format version: expected {SERIALIZE_VERSION}, got {version}"
-            ));
-        }
-        let num_keys = u32::from_le_bytes(
-            bytes[8..12]
-                .try_into()
-                .map_err(|_| "Invalid data: truncated header".to_string())?,
-        ) as usize;
-        let num_items = u32::from_le_bytes(
-            bytes[12..16]
-                .try_into()
-                .map_err(|_| "Invalid data: truncated header".to_string())?,
-        ) as usize;
-        let mut offset = header_size;
-        let weights_size = num_keys * 8;
-        if offset + weights_size > bytes.len() {
-            return Err("Invalid data: truncated weights".into());
-        }
-        let mut weights = Vec::with_capacity(num_keys);
-        for _ in 0..num_keys {
-            let w = f64::from_le_bytes(
-                bytes[offset..offset + 8]
-                    .try_into()
-                    .map_err(|_| "Invalid data: truncated weight".to_string())?,
-            );
-            weights.push(w);
-            offset += 8;
-        }
-        let mut key_texts: Vec<Vec<String>> = Vec::with_capacity(num_keys);
-        for _ in 0..num_keys {
-            let mut col = Vec::with_capacity(num_items);
-            for _ in 0..num_items {
-                if offset + 4 > bytes.len() {
-                    return Err("Invalid data: truncated".into());
-                }
-                let len = u32::from_le_bytes(
-                    bytes[offset..offset + 4]
-                        .try_into()
-                        .map_err(|_| "Invalid data: truncated".to_string())?,
-                ) as usize;
-                offset += 4;
-                if offset + len > bytes.len() {
-                    return Err("Invalid data: truncated".into());
-                }
-                let s = std::str::from_utf8(&bytes[offset..offset + len])
-                    .map_err(|e| format!("Invalid UTF-8: {e}"))?;
-                col.push(s.to_owned());
-                offset += len;
-            }
-            key_texts.push(col);
-        }
-        if offset != bytes.len() {
-            return Err("Invalid data: trailing bytes".into());
-        }
-        Self::new_impl(key_texts, weights)
-    }
-
-    fn search_impl(&self, query: String, options: Option<SearchOptions>) -> Vec<KeySearchResult> {
-        let opts = options.unwrap_or_default();
-        let num_keys = self.key_texts.len();
-        if num_keys == 0 {
-            return Vec::new();
-        }
-        let num_items = self.size() as usize;
-        if num_items == 0 {
-            return Vec::new();
-        }
-        let return_all_on_empty = opts.return_all_on_empty.unwrap_or(false);
-        if return_all_on_empty && query.trim().is_empty() {
-            let limit = opts.max_results.unwrap_or(num_items as u32) as usize;
-            return (0..num_items)
-                .take(limit)
-                .map(|i| KeySearchResult {
-                    index: i as u32,
-                    score: 1.0,
-                    key_scores: vec![1.0; num_keys],
-                })
-                .collect();
-        }
-        if query.is_empty() {
-            return Vec::new();
-        }
-        let max_results = opts.max_results;
-        let min_score = opts.min_score;
-        let case_matching = resolve_case_matching(opts.is_case_sensitive);
-        let threshold = min_score.unwrap_or(0.0);
-        if self.weights.iter().any(|w| !w.is_finite() || *w < 0.0) {
-            return Vec::new();
-        }
-        let mut matcher = self.matcher.borrow_mut();
-        let pattern = Pattern::parse(&query, case_matching, Normalization::Smart);
-        let max_score = compute_max_score(&query, &pattern, &mut matcher);
-        let query_mask = compute_query_mask(&query);
-        let active_keys: Vec<usize> = (0..num_keys).filter(|&k| self.weights[k] > 0.0).collect();
-        let active_total_weight: f64 = active_keys.iter().map(|&k| self.weights[k]).sum();
-        let mut per_key_scores: Vec<Vec<f64>> = vec![vec![0.0; num_items]; num_keys];
-        let threshold_weighted = threshold * self.total_weight;
-        let mut scored: Vec<(u32, f64)> = (0..num_items)
-            .filter_map(|i| {
-                let mut weighted_sum = 0.0;
-                let mut matched_any = false;
-                let mut remaining_weight = active_total_weight;
-                for &k in &active_keys {
-                    let w = self.weights[k];
-                    remaining_weight -= w;
-                    if query_mask != 0 && (self.key_char_masks[k][i] & query_mask) != query_mask {
-                        if threshold > 0.0 && weighted_sum + remaining_weight < threshold_weighted {
-                            return None;
-                        }
-                        continue;
-                    }
-                    let atoms = self.utf32_keys[k][i].slice(..);
-                    let score = match pattern.score(atoms, &mut matcher) {
-                        Some(raw) => ((raw as f64) / max_score).min(1.0),
-                        None => 0.0,
-                    };
-                    per_key_scores[k][i] = score;
-                    if score > 0.0 {
-                        weighted_sum += score * w;
-                        matched_any = true;
-                    }
-                    if threshold > 0.0 && weighted_sum + remaining_weight < threshold_weighted {
-                        return None;
-                    }
-                }
-                if !matched_any {
-                    return None;
-                }
-                let combined = weighted_sum / self.total_weight;
-                if combined >= threshold {
-                    Some((i as u32, combined))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        let cmp = |a: &(u32, f64), b: &(u32, f64)| {
-            let score_ord = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
-            if score_ord != std::cmp::Ordering::Equal {
-                return score_ord;
-            }
-            a.0.cmp(&b.0)
-        };
-        if let Some(max) = max_results {
-            let k = max as usize;
-            if scored.len() > k {
-                scored.select_nth_unstable_by(k, cmp);
-                scored.truncate(k);
-            }
-        }
-        scored.sort_unstable_by(cmp);
-        scored
-            .into_iter()
-            .map(|(index, score)| {
-                let key_scores: Vec<f64> = per_key_scores
-                    .iter()
-                    .map(|scores| scores[index as usize])
-                    .collect();
-                KeySearchResult {
-                    index,
-                    score,
-                    key_scores,
-                }
-            })
-            .collect()
+        let (key_texts, weights) =
+            deserialize_keyed(data, KEYED_INDEX_MAGIC).map_err(|e| JsValue::from_str(&e))?;
+        KeyedFuzzyIndexCore::new(key_texts, weights)
+            .map(|core| Self { core })
+            .map_err(|e| JsValue::from_str(&e))
     }
 }

--- a/crates/wasm/src/search/keys.rs
+++ b/crates/wasm/src/search/keys.rs
@@ -1,9 +1,8 @@
-use nucleo_matcher::pattern::{Normalization, Pattern};
-use nucleo_matcher::{Config, Matcher};
+use rapid_fuzzy_core::search::SearchKeysOptions;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-use super::{SearchOptions, compute_max_score, resolve_case_matching, to_js};
+use super::{SearchOptions, to_js};
 
 /// A single result from multi-key fuzzy search.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -12,6 +11,16 @@ pub struct KeySearchResult {
     pub index: u32,
     pub score: f64,
     pub key_scores: Vec<f64>,
+}
+
+impl From<rapid_fuzzy_core::search::KeySearchResult> for KeySearchResult {
+    fn from(r: rapid_fuzzy_core::search::KeySearchResult) -> Self {
+        Self {
+            index: r.index,
+            score: r.score,
+            key_scores: r.key_scores,
+        }
+    }
 }
 
 /// Perform fuzzy search across multiple text keys with weights.
@@ -32,136 +41,18 @@ pub fn search_keys(
         Ok(v) => v,
         Err(_) => return to_js::<Vec<KeySearchResult>>(&Vec::new()),
     };
-    let results = search_keys_impl(query, key_texts, weights, options);
-    to_js(&results)
-}
 
-pub(crate) fn search_keys_impl(
-    query: String,
-    key_texts: Vec<Vec<String>>,
-    weights: Vec<f64>,
-    options: Option<SearchOptions>,
-) -> Vec<KeySearchResult> {
-    let num_keys = key_texts.len();
-    if num_keys == 0 || weights.len() != num_keys {
-        return Vec::new();
-    }
-    let num_items = key_texts[0].len();
-    if num_items == 0 {
-        return Vec::new();
-    }
-    for texts in &key_texts {
-        if texts.len() != num_items {
-            return Vec::new();
-        }
-    }
-    let opts = options.unwrap_or_default();
-    let return_all_on_empty = opts.return_all_on_empty.unwrap_or(false);
-    if return_all_on_empty && query.trim().is_empty() {
-        let max_results = opts.max_results;
-        let limit = max_results.unwrap_or(num_items as u32) as usize;
-        return (0..num_items)
-            .take(limit)
-            .map(|i| KeySearchResult {
-                index: i as u32,
-                score: 1.0,
-                key_scores: vec![1.0; num_keys],
-            })
+    let core_opts = options.map(|opts| SearchKeysOptions {
+        max_results: opts.max_results,
+        min_score: opts.min_score,
+        is_case_sensitive: opts.is_case_sensitive,
+        return_all_on_empty: opts.return_all_on_empty,
+    });
+
+    let results: Vec<KeySearchResult> =
+        rapid_fuzzy_core::search::search_keys_impl(&query, &key_texts, &weights, core_opts)
+            .into_iter()
+            .map(KeySearchResult::from)
             .collect();
-    }
-    if query.is_empty() {
-        return Vec::new();
-    }
-    let max_results = opts.max_results;
-    let min_score = opts.min_score;
-    let case_matching = resolve_case_matching(opts.is_case_sensitive);
-    let threshold = min_score.unwrap_or(0.0);
-    if weights.iter().any(|w| !w.is_finite() || *w < 0.0) {
-        return Vec::new();
-    }
-    let total_weight: f64 = weights.iter().sum();
-    if total_weight <= 0.0 {
-        return Vec::new();
-    }
-    use nucleo_matcher::Utf32String;
-    let utf32_keys: Vec<Vec<Utf32String>> = key_texts
-        .iter()
-        .map(|texts| {
-            texts
-                .iter()
-                .map(|s| Utf32String::from(s.as_str()))
-                .collect()
-        })
-        .collect();
-    let mut matcher = Matcher::new(Config::DEFAULT);
-    let pattern = Pattern::parse(&query, case_matching, Normalization::Smart);
-    let max_score = compute_max_score(&query, &pattern, &mut matcher);
-    let mut per_key_scores: Vec<Vec<f64>> = Vec::with_capacity(num_keys);
-    let mut buf: Vec<u32> = Vec::new();
-    #[allow(clippy::needless_range_loop)]
-    for k in 0..num_keys {
-        let mut scores = Vec::with_capacity(num_items);
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..num_items {
-            let atoms = utf32_keys[k][i].slice(..);
-            let score = match pattern.score(atoms, &mut matcher) {
-                Some(raw) => ((raw as f64) / max_score).min(1.0),
-                None => 0.0,
-            };
-            scores.push(score);
-        }
-        per_key_scores.push(scores);
-        buf.clear();
-    }
-    let threshold_weighted = threshold * total_weight;
-    let mut scored: Vec<(u32, f64)> = (0..num_items)
-        .filter_map(|i| {
-            let mut weighted_sum = 0.0;
-            let mut matched_any = false;
-            for k in 0..num_keys {
-                let w = weights[k];
-                let s = per_key_scores[k][i];
-                if s > 0.0 {
-                    weighted_sum += s * w;
-                    matched_any = true;
-                }
-            }
-            if !matched_any {
-                return None;
-            }
-            let combined = weighted_sum / total_weight;
-            if combined >= threshold {
-                Some((i as u32, combined))
-            } else {
-                None
-            }
-        })
-        .collect();
-    let _ = threshold_weighted;
-    let cmp = |a: &(u32, f64), b: &(u32, f64)| {
-        let score_ord = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
-        if score_ord != std::cmp::Ordering::Equal {
-            return score_ord;
-        }
-        a.0.cmp(&b.0)
-    };
-    if let Some(max) = max_results {
-        let k = max as usize;
-        if scored.len() > k {
-            scored.select_nth_unstable_by(k, cmp);
-            scored.truncate(k);
-        }
-    }
-    scored.sort_unstable_by(cmp);
-    scored
-        .into_iter()
-        .map(|(index, score)| {
-            let key_scores: Vec<f64> = per_key_scores.iter().map(|s| s[index as usize]).collect();
-            KeySearchResult {
-                index,
-                score,
-                key_scores,
-            }
-        })
-        .collect()
+    to_js(&results)
 }

--- a/crates/wasm/src/search/mod.rs
+++ b/crates/wasm/src/search/mod.rs
@@ -94,11 +94,7 @@ pub(crate) fn to_js<T: Serialize>(value: &T) -> JsValue {
     serde_wasm_bindgen::to_value(value).unwrap_or(JsValue::NULL)
 }
 
-pub(crate) use rapid_fuzzy_core::search::{
-    BigramIndex, PrecomputedSearch, compute_char_mask, compute_max_score, compute_query_mask,
-    extract_query_bigrams, resolve_case_matching, search_over_precomputed,
-    search_over_precomputed_indices,
-};
+pub(crate) use rapid_fuzzy_core::search::resolve_case_matching;
 
 // ─── Standalone search functions ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Following #507 (distance extraction), extract shared search module logic from napi and wasm bindings to `crates/core-lib/src/search/`. Eliminates ~700 lines of duplicated code.

### New files in core-lib

- **`serialization.rs`** — Shared binary serialization/deserialization for FuzzyIndex and KeyedFuzzyIndex
- **`fuzzy_index.rs`** — `FuzzyIndexCore` struct with platform-independent state and methods
- **`keyed_index.rs`** — `KeyedFuzzyIndexCore` struct with multi-key state and methods
- **`keys.rs`** — `search_keys_impl` standalone function

### Binding changes

Both napi and wasm crates now wrap core-lib structs instead of duplicating logic. Binding-specific code (async task, JsValue conversion, Either handling) is preserved.

## Related issue

Closes #509

## Checklist

- [x] `cargo test` — 268 tests pass (unchanged)
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean
- [x] No functional changes — pure refactoring
- [x] No test code modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-key search support enabling fuzzy matching across multiple weighted text fields.
  * Added serialization capabilities for search indices, allowing indices to be persisted and restored.
  * Enhanced search with incremental caching for improved performance.

* **Refactor**
  * Consolidated and restructured search implementations into unified core modules for better maintainability and consistency across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->