### PR TITLE
chore(renovate): skip minimumReleaseAge for github-actions digest pins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
       "description": "Skip stability wait for github-actions digest pins (no releaseTimestamp)",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["digest"],
-      "minimumReleaseAge": "0"
+      "minimumReleaseAge": "0 days"
     },
     {
       "description": "Group Rust crate updates",

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,12 @@
       "automerge": true
     },
     {
+      "description": "Skip stability wait for github-actions digest pins (no releaseTimestamp)",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest"],
+      "minimumReleaseAge": "0"
+    },
+    {
       "description": "Group Rust crate updates",
       "matchManagers": ["cargo"],
       "groupName": "rust-dependencies"


### PR DESCRIPTION
## Summary

- Adds a narrow Renovate package rule that sets \`minimumReleaseAge: 0\` for digest-type updates under the github-actions manager.
- Versioned npm and cargo updates still honor the global 3-day grace period.
- Fixes the \`renovate/stability-days = pending\` deadlock that affected #514, #516, #523, and #535 (Renovate has no releaseTimestamp for floating-tag digest pins, so the timestamp-required check never resolves).

Closes #541

## Test plan

- [x] \`renovate.json\` parses as valid JSON
- [ ] After merge, next Renovate run shows \`renovate/stability-days\` resolved on github-actions digest PRs
- [ ] Versioned dep PRs still wait the full 3 days