### PR TITLE
fix(deps): bump transitive rand to 0.9.3 to clear advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,9 +820,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
## Summary

- \`cargo update -p rand --precise 0.9.3\` to clear the Dependabot low-severity alert (\`Rand is unsound with a custom logger using rand::rng()\`).
- \`rand\` is transitive, so Renovate does not propose it directly.

Closes #543

## Test plan

- [x] \`cargo build --workspace\` passes
- [x] \`cargo test --workspace\` passes
- [ ] CI green
- [ ] Dependabot alert auto-closes after merge