### PR TITLE
chore!: drop Node 20 support (EOL 2026-04-30)

### DIFF
--- a/.changeset/drop-node-20.md
+++ b/.changeset/drop-node-20.md
@@ -1,0 +1,8 @@
+---
+'rapid-fuzzy': major
+---
+
+Drop Node.js 20 support. The minimum required Node.js version is now 22.0.0.
+
+Node.js 20 reached End-of-Life on 2026-04-30. Consumers running on Node 20
+must upgrade to Node 22+ before pulling in this release.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [22, 24]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm version](https://img.shields.io/npm/v/rapid-fuzzy)](https://www.npmjs.com/package/rapid-fuzzy)
 [![npm downloads](https://img.shields.io/npm/dm/rapid-fuzzy)](https://www.npmjs.com/package/rapid-fuzzy)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen)](https://nodejs.org/)
 
 Blazing-fast fuzzy search for JavaScript — powered by Rust, works everywhere.
 
@@ -50,7 +50,7 @@ pnpm add rapid-fuzzy
 
 ### Runtime-specific notes
 
-- **Node.js** (>=20): Uses native bindings via napi-rs for best performance.
+- **Node.js** (>=22): Uses native bindings via napi-rs for best performance.
 - **Bun**: Uses native napi-rs bindings. WASM fallback also works — see [Bun section](#bun) below.
 - **Browser / CDN / Cloudflare Workers / Deno**: Falls back to the wasm-bindgen WASM build (~195 KB raw). No `SharedArrayBuffer` or COOP/COEP headers required.
 

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/derodero24/rapid-fuzzy",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/derodero24/rapid-fuzzy",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/derodero24/rapid-fuzzy",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/derodero24/rapid-fuzzy",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/derodero24/rapid-fuzzy",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/derodero24/rapid-fuzzy",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/derodero24/rapid-fuzzy",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/derodero24/rapid-fuzzy",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/derodero24/rapid-fuzzy",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     ]
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "pnpm@10.33.2",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump \`engines.node\` to \`>=22.0.0\` in root \`package.json\` and all 9 platform packages under \`npm/\`.
- Remove Node 20 from the CI test matrix (\`matrix.node\` \`[20, 22, 24]\` → \`[22, 24]\`).
- Update Node version badge and runtime note in \`README.md\`.
- Add a major Changeset entry.

Node.js 20 reached End-of-Life on 2026-04-30. Dropping it unblocks
follow-up work such as adopting \`pnpm/action-setup@v6\` (whose bootstrap
pnpm 11 requires Node ≥22.13, see closed #515).

Closes #542

## Test plan

- [ ] CI green on Node 22 and Node 24 across all OS
- [ ] Renovate can recreate the \`pnpm/action-setup\` v6 PR after this lands

## Breaking change

Consumers running on Node 20 must upgrade to Node 22+ before pulling in this release.