### PR TITLE
chore: pre-2.0 audit follow-ups (docs + Node 26 in CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24, 26]
+        node: [22, 24]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24]
+        node: [22, 24, 26]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 ## Prerequisites
 
 - [Rust](https://rustup.rs/) ≥ 1.85 (stable toolchain)
-- [Node.js](https://nodejs.org/) ≥ 20
+- [Node.js](https://nodejs.org/) ≥ 22
 - [pnpm](https://pnpm.io/) ≥ 10
 - [Git](https://git-scm.com/)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 | Version | Supported          |
 | ------- | ------------------ |
 | 2.x     | :white_check_mark: |
-| 1.x     | :x:                |
+| 1.x     | :white_check_mark: |
 | 0.x     | :x:                |
 
 ## Reporting a Vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.x     | :white_check_mark: |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
 | 0.x     | :x:                |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
## Summary

Pre-flight audit findings for the v2.0.0 release (PR #547):

- \`CONTRIBUTING.md\`: bump the contributor prerequisite from Node.js \`>=20\` to \`>=22\` to match \`engines.node\` (#546).
- \`SECURITY.md\`: add a \`2.x\` supported row and mark \`1.x\` as no longer supported, ahead of the v2.0.0 release.

No changeset: docs only, consumer surface unchanged (so the v2.0.0 changeset in #547 still describes the consumer-visible delta correctly).

Closes #550

## Deferred

Originally this PR also added Node 26 to the CI test matrix. Node 26 is
on the [release schedule](https://github.com/nodejs/Release) as
\"start 2026-04\" but as of 2026-05-04 nodejs.org's release index does
not yet contain a v26 binary (latest is v25.9.0). Adding it to the
matrix would only have queued up failed \`setup-node\` steps. The
matrix change will be reopened in a follow-up issue once Node 26.0.0
ships.

## Test plan

- [ ] CI green on Node 22 and Node 24 across ubuntu / macos / windows