### PR TITLE
feat(bindings): hamming TypedArray variants + enriched type docs

### DIFF
--- a/.changeset/hamming-typed-array-variants.md
+++ b/.changeset/hamming-typed-array-variants.md
@@ -1,0 +1,7 @@
+---
+'rapid-fuzzy': minor
+---
+
+Add `hammingManyU32` and `normalizedHammingManyF64` TypedArray variants, completing the `*Many` TypedArray family. Because `hammingMany`/`normalizedHammingMany` return `null` for length mismatches or candidates filtered by the threshold, the typed arrays use a documented sentinel for those slots: `0xffffffff` for `hammingManyU32` and `NaN` for `normalizedHammingManyF64`.
+
+Also enrich type documentation: field-level JSDoc on `KeyConfig` and `ObjectSearchResult` (and a clearer note on why `includePositions` has no effect for multi-key search), and document the `number` (maxResults shorthand) argument on `FuzzyIndex.search()` and `searchIndices()`.

--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -10,6 +10,7 @@ import {
   hamming,
   hammingBatch,
   hammingMany,
+  hammingManyU32,
   indel,
   indelBatch,
   indelMany,
@@ -29,6 +30,7 @@ import {
   normalizedHamming,
   normalizedHammingBatch,
   normalizedHammingMany,
+  normalizedHammingManyF64,
   normalizedIndel,
   normalizedIndelBatch,
   normalizedIndelMany,
@@ -131,6 +133,12 @@ describe('distance', () => {
       const score = sorensenDice('night', 'nacht');
       expect(score).toBeGreaterThan(0);
       expect(score).toBeLessThan(1);
+    });
+
+    it('distinguishes single characters by content (no bigrams)', () => {
+      // Single-char inputs have no bigrams; equal chars score 1.0, different chars 0.0.
+      expect(sorensenDice('a', 'a')).toBe(1.0);
+      expect(sorensenDice('a', 'b')).toBe(0.0);
     });
   });
 
@@ -967,6 +975,13 @@ describe('token-based matching', () => {
     it('should return 0.0 for one empty', () => {
       expect(tokenSortRatio('hello', '')).toBe(0.0);
     });
+
+    it('preserves duplicate tokens when sorting', () => {
+      // Duplicates are kept, so a reordering with the same multiset still scores 1.0,
+      // while dropping a duplicate lowers the score.
+      expect(tokenSortRatio('hello hello world', 'world hello hello')).toBe(1.0);
+      expect(tokenSortRatio('hello hello world', 'hello world')).toBeLessThan(1.0);
+    });
   });
 
   describe('tokenSortRatioBatch', () => {
@@ -1081,6 +1096,20 @@ describe('token-based matching', () => {
       const result = partialRatioMany('hello', ['hello world', 'xyz']);
       expect(result[0]).toBe(1.0);
       expect(result[1]).toBeLessThan(0.5);
+    });
+
+    it('with a threshold matches the per-candidate result, zeroing sub-threshold scores', () => {
+      const ref = 'hello world';
+      const cands = ['hello', 'world peace', 'helo wrld', 'xyz', 'lo wo'];
+      const minSimilarity = 0.5;
+      const got = partialRatioMany(ref, cands, minSimilarity);
+      const expected = cands.map((c) => {
+        const s = partialRatio(ref, c);
+        return s >= minSimilarity ? s : 0;
+      });
+      got.forEach((value, i) => {
+        expect(value).toBeCloseTo(expected[i] as number, 10);
+      });
     });
   });
 
@@ -2019,5 +2048,53 @@ describe('TypedArray variants', () => {
     const arr = levenshteinManyU32('kitten', cands, 2);
     const plain = levenshteinMany('kitten', cands, 2);
     expect(Array.from(arr)).toEqual(plain);
+  });
+
+  describe('hamming variants (null -> sentinel)', () => {
+    // 'abd','xyz','abc' are same length as 'abc'; 'ab' and 'abcd' differ -> null.
+    const hammingCands = ['abd', 'ab', 'abcd', 'xyz', 'abc'];
+
+    it('hammingManyU32 maps null to the 0xffffffff sentinel and keeps real distances', () => {
+      const arr = hammingManyU32('abc', hammingCands);
+      expect(arr).toBeInstanceOf(Uint32Array);
+      const plain = hammingMany('abc', hammingCands);
+      const expected = plain.map((v) => (v == null ? 0xffffffff : v));
+      expect(Array.from(arr)).toEqual(expected);
+      // length mismatches become the sentinel
+      expect(arr[1]).toBe(0xffffffff);
+      expect(arr[2]).toBe(0xffffffff);
+    });
+
+    it('hammingManyU32 sentinels candidates filtered by maxDistance', () => {
+      const arr = hammingManyU32('abc', hammingCands, 1);
+      const plain = hammingMany('abc', hammingCands, 1);
+      const expected = plain.map((v) => (v == null ? 0xffffffff : v));
+      expect(Array.from(arr)).toEqual(expected);
+    });
+
+    it('normalizedHammingManyF64 maps null to NaN and keeps real similarities', () => {
+      const arr = normalizedHammingManyF64('abc', hammingCands);
+      expect(arr).toBeInstanceOf(Float64Array);
+      const plain = normalizedHammingMany('abc', hammingCands);
+      arr.forEach((value, i) => {
+        if (plain[i] == null) {
+          expect(Number.isNaN(value)).toBe(true);
+        } else {
+          expect(value).toBeCloseTo(plain[i] as number, 10);
+        }
+      });
+    });
+
+    it('normalizedHammingManyF64 sentinels candidates filtered by minSimilarity', () => {
+      const arr = normalizedHammingManyF64('abc', hammingCands, 0.9);
+      const plain = normalizedHammingMany('abc', hammingCands, 0.9);
+      arr.forEach((value, i) => {
+        if (plain[i] == null) {
+          expect(Number.isNaN(value)).toBe(true);
+        } else {
+          expect(value).toBeCloseTo(plain[i] as number, 10);
+        }
+      });
+    });
   });
 });

--- a/crates/core/src/search/index.rs
+++ b/crates/core/src/search/index.rs
@@ -68,6 +68,9 @@ impl FuzzyIndex {
     ///
     /// Returns matches sorted by score (best match first).
     /// Scores are normalized to a 0.0-1.0 range where 1.0 is a perfect match.
+    ///
+    /// The second argument accepts either a number (maxResults shorthand) or a
+    /// SearchOptions object.
     #[napi]
     pub fn search(
         &self,
@@ -128,6 +131,9 @@ impl FuzzyIndex {
     /// This is more efficient than `search()` when you maintain your own data
     /// array and only need the index to look up the original item. Avoids
     /// String cloning overhead for each result.
+    ///
+    /// The second argument accepts either a number (maxResults shorthand) or a
+    /// SearchOptions object.
     #[napi]
     pub fn search_indices(
         &self,

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,9 @@ export declare class FuzzyIndex {
    *
    * Returns matches sorted by score (best match first).
    * Scores are normalized to a 0.0-1.0 range where 1.0 is a perfect match.
+   *
+   * The second argument accepts either a number (maxResults shorthand) or a
+   * SearchOptions object.
    */
   search(query: string, options?: number | SearchOptions | undefined | null): Array<SearchResult>
   /**
@@ -42,6 +45,9 @@ export declare class FuzzyIndex {
    * This is more efficient than `search()` when you maintain your own data
    * array and only need the index to look up the original item. Avoids
    * String cloning overhead for each result.
+   *
+   * The second argument accepts either a number (maxResults shorthand) or a
+   * SearchOptions object.
    */
   searchIndices(query: string, options?: number | SearchOptions | undefined | null): Array<IndexSearchResult>
   /** Add a single item to the index. */
@@ -636,3 +642,16 @@ export declare function tokenSortRatioManyF64(reference: string, candidates: Arr
 export declare function tokenSetRatioManyF64(reference: string, candidates: Array<string>, minSimilarity?: number | undefined | null): Float64Array;
 export declare function partialRatioManyF64(reference: string, candidates: Array<string>, minSimilarity?: number | undefined | null): Float64Array;
 export declare function weightedRatioManyF64(reference: string, candidates: Array<string>, minSimilarity?: number | undefined | null): Float64Array;
+/**
+ * TypedArray variant of `hammingMany`. Slots that `hammingMany` returns as `null`
+ * (length mismatch, or filtered out by `maxDistance`) become the sentinel `0xffffffff`
+ * (4294967295), since a Uint32Array cannot hold `null`. Check for it with
+ * `value === 0xffffffff` before treating a slot as a real distance.
+ */
+export declare function hammingManyU32(reference: string, candidates: Array<string>, maxDistance?: number | undefined | null): Uint32Array;
+/**
+ * TypedArray variant of `normalizedHammingMany`. Slots that `normalizedHammingMany`
+ * returns as `null` (length mismatch, or filtered out by `minSimilarity`) become `NaN`,
+ * since a Float64Array cannot hold `null`. Check for it with `Number.isNaN(value)`.
+ */
+export declare function normalizedHammingManyF64(reference: string, candidates: Array<string>, minSimilarity?: number | undefined | null): Float64Array;

--- a/index.js
+++ b/index.js
@@ -652,3 +652,8 @@ module.exports.tokenSortRatioManyF64 = (r, c, s) => new Float64Array(nativeBindi
 module.exports.tokenSetRatioManyF64 = (r, c, s) => new Float64Array(nativeBinding.tokenSetRatioMany(r, c, s));
 module.exports.partialRatioManyF64 = (r, c, s) => new Float64Array(nativeBinding.partialRatioMany(r, c, s));
 module.exports.weightedRatioManyF64 = (r, c, s) => new Float64Array(nativeBinding.weightedRatioMany(r, c, s));
+// hamming variants return null for length mismatches or filtered candidates;
+// the TypedArray cannot hold null, so those slots use a sentinel:
+//   hammingManyU32 -> 0xffffffff (4294967295), normalizedHammingManyF64 -> NaN.
+module.exports.hammingManyU32 = (r, c, d) => Uint32Array.from(nativeBinding.hammingMany(r, c, d), (v) => (v == null ? 0xffffffff : v));
+module.exports.normalizedHammingManyF64 = (r, c, s) => Float64Array.from(nativeBinding.normalizedHammingMany(r, c, s), (v) => (v == null ? Number.NaN : v));

--- a/index.mjs
+++ b/index.mjs
@@ -66,6 +66,8 @@ export const {
   tokenSetRatioManyF64,
   partialRatioManyF64,
   weightedRatioManyF64,
+  hammingManyU32,
+  normalizedHammingManyF64,
 } = { ...binding, ...require('./highlight.js') };
 
 export const { searchObjects, FuzzyObjectIndex } = require('./objects.js');

--- a/objects.d.ts
+++ b/objects.d.ts
@@ -1,22 +1,38 @@
 import type { SearchOptions } from './index';
 
 export interface KeyConfig {
+  /**
+   * Object key to search. Supports dot-separated paths for nested values,
+   * e.g. `'address.city'`.
+   */
   name: string;
+  /** Relative weight of this key in the combined score. Defaults to `1.0`. */
   weight?: number;
 }
 
 /**
  * Options for searchObjects(). Extends SearchOptions with key configuration.
- * Note: `includePositions` has no effect for multi-key search.
+ *
+ * Note: `includePositions` has no effect for multi-key search — match positions
+ * are per-key and are not merged, so the `positions`/`matchType` fields from
+ * single-key {@link SearchOptions} are not populated. All other SearchOptions
+ * fields (maxResults, minScore, isCaseSensitive, returnAllOnEmpty) apply.
  */
 export interface ObjectSearchOptions extends SearchOptions {
   keys: Array<string | KeyConfig>;
 }
 
 export interface ObjectSearchResult<T> {
+  /** The matched object from the original input array. */
   item: T;
+  /** Index of the matched item in the original input array. */
   index: number;
+  /** Combined weighted score normalized to the 0.0–1.0 range. */
   score: number;
+  /**
+   * Per-key scores in the same order as the configured keys.
+   * A score of 0.0 means the item did not match on that key.
+   */
   keyScores: Array<number>;
 }
 

--- a/scripts/patch-binding.js
+++ b/scripts/patch-binding.js
@@ -43,6 +43,11 @@ patchFile(
     'module.exports.tokenSetRatioManyF64 = (r, c, s) => new Float64Array(nativeBinding.tokenSetRatioMany(r, c, s));',
     'module.exports.partialRatioManyF64 = (r, c, s) => new Float64Array(nativeBinding.partialRatioMany(r, c, s));',
     'module.exports.weightedRatioManyF64 = (r, c, s) => new Float64Array(nativeBinding.weightedRatioMany(r, c, s));',
+    '// hamming variants return null for length mismatches or filtered candidates;',
+    '// the TypedArray cannot hold null, so those slots use a sentinel:',
+    '//   hammingManyU32 -> 0xffffffff (4294967295), normalizedHammingManyF64 -> NaN.',
+    'module.exports.hammingManyU32 = (r, c, d) => Uint32Array.from(nativeBinding.hammingMany(r, c, d), (v) => (v == null ? 0xffffffff : v));',
+    'module.exports.normalizedHammingManyF64 = (r, c, s) => Float64Array.from(nativeBinding.normalizedHammingMany(r, c, s), (v) => (v == null ? Number.NaN : v));',
   ].join('\n'),
 );
 
@@ -64,6 +69,19 @@ patchFile(
     'export declare function tokenSetRatioManyF64(reference: string, candidates: Array<string>, minSimilarity?: number | undefined | null): Float64Array;',
     'export declare function partialRatioManyF64(reference: string, candidates: Array<string>, minSimilarity?: number | undefined | null): Float64Array;',
     'export declare function weightedRatioManyF64(reference: string, candidates: Array<string>, minSimilarity?: number | undefined | null): Float64Array;',
+    '/**',
+    ' * TypedArray variant of `hammingMany`. Slots that `hammingMany` returns as `null`',
+    ' * (length mismatch, or filtered out by `maxDistance`) become the sentinel `0xffffffff`',
+    ' * (4294967295), since a Uint32Array cannot hold `null`. Check for it with',
+    ' * `value === 0xffffffff` before treating a slot as a real distance.',
+    ' */',
+    'export declare function hammingManyU32(reference: string, candidates: Array<string>, maxDistance?: number | undefined | null): Uint32Array;',
+    '/**',
+    ' * TypedArray variant of `normalizedHammingMany`. Slots that `normalizedHammingMany`',
+    ' * returns as `null` (length mismatch, or filtered out by `minSimilarity`) become `NaN`,',
+    ' * since a Float64Array cannot hold `null`. Check for it with `Number.isNaN(value)`.',
+    ' */',
+    'export declare function normalizedHammingManyF64(reference: string, candidates: Array<string>, minSimilarity?: number | undefined | null): Float64Array;',
   ].join('\n'),
 );
 


### PR DESCRIPTION
## Summary

A small, focused release from an API/correctness/DX audit, limited to verified, backward-compatible improvements.

### hamming TypedArray variants (feat)
Adds `hammingManyU32` and `normalizedHammingManyF64`, completing the `*Many` TypedArray family (every other `*Many` distance/similarity function already had one). Because `hammingMany`/`normalizedHammingMany` return `null` for length mismatches or threshold-filtered candidates, the typed arrays use a documented sentinel for those slots:
- `hammingManyU32` → `0xffffffff` (4294967295)
- `normalizedHammingManyF64` → `NaN`

### Type documentation (docs)
- Field-level JSDoc on `KeyConfig` and `ObjectSearchResult`, plus a clearer note on why `includePositions` has no effect for multi-key search.
- Document the `number` (maxResults shorthand) argument on `FuzzyIndex.search()` and `searchIndices()` (the standalone `search()` already had it).

### Regression tests (test)
Guards for behaviors verified correct during the audit but previously untested: `partialRatioMany` threshold path, duplicate-token handling in `tokenSortRatio`, and single-character `sorensenDice`.

## Notes

The publint `pkg.browser` suggestion was evaluated and intentionally deferred — every way of applying it surfaced new type-resolution warnings or required a fragile duplicate `.cts` file, for a change publint itself marks "may be a breaking change". The current setup resolves correctly for both bundlers and Node.

## Verification

Local: `pnpm run check / typecheck / test` (394 passed), `pnpm run build` (native + wasm32-wasip1-threads), `cargo test / clippy`, `pnpm run publint`.

Closes #609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `hammingManyU32` and `normalizedHammingManyF64` functions that return typed arrays for hamming-based string similarity calculations.

* **Documentation**
  * Expanded documentation for search methods and configuration types to clarify parameter options and multi-key search behavior.

* **Tests**
  * Added test coverage for new hamming variants and string similarity edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->