### PR TITLE
fix(deps): pin fast-uri >=3.1.2 to resolve high-severity advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,8 @@
       "lefthook"
     ],
     "overrides": {
-      "axios": ">=1.15.0"
+      "axios": ">=1.15.0",
+      "fast-uri": ">=3.1.2"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   axios: '>=1.15.0'
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -1357,8 +1358,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@4.0.0:
+    resolution: {integrity: sha512-l90y339r2DkZs/ldcWQXcwTjkbp/NbuJDGYoQ3awBgaT3GXOFkm3OkVpz6Z86TywYcya0eVP2r1kTV90f3krGQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -3217,7 +3218,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 4.0.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3430,7 +3431,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@4.0.0: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves two high-severity Dependabot advisories for `fast-uri` (<= 3.1.1):
- Host confusion via percent-encoded authority delimiters (patched in 3.1.2)
- Path traversal via percent-encoded dot segments (patched in 3.1.1)

`fast-uri` is pulled in transitively via `ajv` → `@commitlint/config-validator` → `@commitlint/cli` (a devDependency), so it is **not part of the published package** and poses no runtime risk to consumers. Pinning the secure floor via a pnpm override clears the alerts and keeps the lockfile clean.

## Change
Adds `"fast-uri": ">=3.1.2"` to `pnpm.overrides` (same mechanism as the existing `axios` override). The resolver picks 4.0.0; the commitlint/ajv chain was verified to work with it.

## Verification
`pnpm install`, `pnpm run check / typecheck / test`, commit-msg hook (commitlint, which exercises the ajv → fast-uri path) — all pass locally.

Closes #611