### PR TITLE
fix(deps): pin form-data and js-yaml to resolve security advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,10 @@
     ],
     "overrides": {
       "axios": ">=1.15.0",
-      "fast-uri": ">=3.1.2"
+      "fast-uri": ">=3.1.2",
+      "form-data": ">=4.0.6",
+      "js-yaml@3": ">=3.15.0 <4.0.0",
+      "js-yaml@4": ">=4.2.0"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 overrides:
   axios: '>=1.15.0'
   fast-uri: '>=3.1.2'
+  form-data: '>=4.0.6'
+  js-yaml@3: '>=3.15.0 <4.0.0'
+  js-yaml@4: '>=4.2.0'
 
 importers:
 
@@ -1408,8 +1411,8 @@ packages:
       debug:
         optional: true
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs-extra@7.0.1:
@@ -1585,12 +1588,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -2378,7 +2377,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -2417,7 +2416,7 @@ snapshots:
     dependencies:
       axios: 1.17.0
       find-up: 6.3.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       node-gyp-build: 4.8.4
       stack-trace: 1.0.0-pre2
     transitivePeerDependencies:
@@ -3266,7 +3265,7 @@ snapshots:
   axios@1.17.0:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -3347,7 +3346,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -3480,7 +3479,7 @@ snapshots:
 
   follow-redirects@1.16.0: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -3648,14 +3647,10 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.2.0:
     dependencies:
@@ -3919,7 +3914,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 


### PR DESCRIPTION
## Summary
GitHub Dependabot flags 3 open alerts, none caught by CI (\`cargo-deny\` only covers Rust):

- **form-data** (high): resolved at 4.0.5, vulnerable \`>=4.0.0, <4.0.6\` (CRLF injection via unescaped multipart field/filenames). Via \`@codspeed/core\`/\`axios\` (devDependencies).
- **js-yaml** (medium, x2 ranges): resolved at 3.14.2, vulnerable \`<3.15.0\` and \`>=4.0.0,<=4.1.1\` (quadratic-complexity DoS via repeated merge-key aliases). Via \`@manypkg/get-packages\` (changesets toolchain).

Neither ships in the published package (devDependency-only), but pinned the secure floor via \`pnpm.overrides\`, following the \`fast-uri\` precedent (#612).

The \`js-yaml\` override is split by requester range (\`js-yaml@3\` / \`js-yaml@4\`) rather than a single unbounded \`>=3.15.0\`, because \`read-yaml-file\` (a \`@manypkg/get-packages\` dependency) requires the v3 API — an unbounded range would let pnpm resolve it to 4.x and silently break it (v4 removed \`safeLoad\`/\`safeDump\`). Verified \`npx changeset status\` still works correctly post-override.

## Related issue
Closes #644

## Checklist
- [x] \`pnpm run check\`
- [x] \`pnpm run typecheck\`
- [x] \`pnpm test\`
- [x] \`pnpm run build\`
- [x] Verified axios/fast-uri overrides still intact
- [x] Verified changesets tooling (\`npx changeset status\`) still functions
- [ ] No changeset (devDependency-only pin, no published-code change — same as #612)